### PR TITLE
Fix compilation of createZimExample.

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,2 +1,5 @@
 
-executable('createZimExample', 'createZimExample.cpp', link_with: libzim, include_directories: include_directory)
+executable('createZimExample', 'createZimExample.cpp',
+           link_with: libzim,
+           include_directories: include_directory,
+           dependencies: [xapian_dep, icu_dep, zlib_dep, lzma_dep, bzip2_dep])


### PR DESCRIPTION
There were some missing dependencies to the createZimExample compilation.