### PR TITLE
Enclose the HtmlParser in a namespace to avoid conflict.

### DIFF
--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -152,7 +152,7 @@ std::string search_iterator::get_snippet() const {
     /* Get the content of the article to generate a snippet.
        We parse it and use the html dump to avoid remove html tags in the
        content and be able to nicely cut the text at random place. */
-    MyHtmlParser htmlParser;
+    zim::MyHtmlParser htmlParser;
     std::string content = article.getData();
     try {
         htmlParser.parse_html(content, "UTF-8", true);

--- a/src/xapian/htmlparse.cc
+++ b/src/xapian/htmlparse.cc
@@ -45,7 +45,7 @@ lowercase_string(string &str)
     }
 }
 
-map<string, unsigned int> HtmlParser::named_ents;
+map<string, unsigned int> zim::HtmlParser::named_ents;
 
 inline static bool
 p_notdigit(char c)
@@ -91,7 +91,7 @@ p_whitespaceeqgt(char c)
 }
 
 bool
-HtmlParser::get_parameter(const string & param, string & value)
+zim::HtmlParser::get_parameter(const string & param, string & value)
 {
     map<string, string>::const_iterator i = parameters.find(param);
     if (i == parameters.end()) return false;
@@ -99,7 +99,7 @@ HtmlParser::get_parameter(const string & param, string & value)
     return true;
 }
 
-HtmlParser::HtmlParser()
+zim::HtmlParser::HtmlParser()
 {
     static const struct ent { const char *n; unsigned int v; } ents[] = {
 #include "namedentities.h"
@@ -115,7 +115,7 @@ HtmlParser::HtmlParser()
 }
 
 void
-HtmlParser::decode_entities(string &s)
+zim::HtmlParser::decode_entities(string &s)
 {
     // We need a const_iterator version of s.end() - otherwise the
     // find() and find_if() templates don't work...
@@ -164,7 +164,7 @@ HtmlParser::decode_entities(string &s)
 }
 
 void
-HtmlParser::parse_html(const string &body)
+zim::HtmlParser::parse_html(const string &body)
 {
     in_script = false;
 

--- a/src/xapian/htmlparse.h
+++ b/src/xapian/htmlparse.h
@@ -28,6 +28,8 @@
 using std::string;
 using std::map;
 
+namespace zim {
+
 class HtmlParser {
 	map<string, string> parameters;
     protected:
@@ -44,6 +46,8 @@ class HtmlParser {
 	virtual void parse_html(const string &text);
 	HtmlParser();
 	virtual ~HtmlParser() { }
+};
+
 };
 
 #endif // OMEGA_INCLUDED_HTMLPARSE_H

--- a/src/xapian/myhtmlparse.cc
+++ b/src/xapian/myhtmlparse.cc
@@ -37,7 +37,7 @@ lowercase_string(string &str)
 }
 
 void
-MyHtmlParser::parse_html(const string &text, const string &charset_,
+zim::MyHtmlParser::parse_html(const string &text, const string &charset_,
 			 bool charset_from_meta_)
 {
     charset = charset_;
@@ -46,7 +46,7 @@ MyHtmlParser::parse_html(const string &text, const string &charset_,
 }
 
 void
-MyHtmlParser::process_text(const string &text)
+zim::MyHtmlParser::process_text(const string &text)
 {
     if (!text.empty() && !in_script_tag && !in_style_tag) {
 	string::size_type b = text.find_first_not_of(WHITESPACE);
@@ -66,7 +66,7 @@ MyHtmlParser::process_text(const string &text)
 }
 
 void
-MyHtmlParser::opening_tag(const string &tag)
+zim::MyHtmlParser::opening_tag(const string &tag)
 {
     if (tag.empty()) return;
     switch (tag[0]) {
@@ -226,7 +226,7 @@ MyHtmlParser::opening_tag(const string &tag)
 }
 
 void
-MyHtmlParser::closing_tag(const string &tag)
+zim::MyHtmlParser::closing_tag(const string &tag)
 {
     if (tag.empty()) return;
     switch (tag[0]) {

--- a/src/xapian/myhtmlparse.h
+++ b/src/xapian/myhtmlparse.h
@@ -29,6 +29,8 @@
 // \xa0?
 #define WHITESPACE " \t\n\r"
 
+namespace zim {
+
 class MyHtmlParser : public HtmlParser {
     public:
 	bool in_script_tag;
@@ -60,6 +62,8 @@ class MyHtmlParser : public HtmlParser {
 	    keywords.resize(0);
 	    dump.resize(0);
 	}
+};
+
 };
 
 #endif // OMEGA_INCLUDED_MYHTMLPARSE_H


### PR DESCRIPTION
Even if the HtmlParser is fully private, it use a static variable.
If the code of the HtmlParser is also used in another project, the
two static variables will conflict.
By using a namespace we avoid the potential conflict.

Fixes #18