### PR TITLE
Add suggestion mode to the search.

### DIFF
--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -89,6 +89,7 @@ namespace zim
       const_iterator find(const std::string& url) const;
 
       const Search* search(const std::string& query, int start, int end) const;
+      const Search* suggestions(const std::string& query, int start, int end) const;
 
       bool good() const    { return impl.getPointer() != 0; }
       time_t getMTime() const   { return impl->getMTime(); }

--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -47,6 +47,7 @@ class Search
         Search& add_zimfile(const File* zimfile);
         Search& set_query(const std::string& query);
         Search& set_range(int start, int end);
+        Search& set_suggestion_mode(bool suggestion_mode);
 
         search_iterator begin() const;
         search_iterator end() const;
@@ -58,9 +59,11 @@ class Search
          std::vector<const File*> zimfiles;
 
          mutable std::map<std::string, int> valuesmap;
+         mutable std::string prefixes;
          std::string query;
          int range_start;
          int range_end;
+         bool suggestion_mode;
          mutable bool search_started;
          mutable bool has_database;
          mutable int estimated_matches_number;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -209,6 +209,14 @@ namespace zim
       return search;
   }
 
+  const Search* File::suggestions(const std::string& query, int start, int end) const {
+      Search* search = new Search(this);
+      search->set_query(query);
+      search->set_range(start, end);
+      search->set_suggestion_mode(true);
+      return search;
+  }
+
   offset_type File::getOffset(size_type clusterIdx, size_type blobIdx) const
   {
     Cluster cluster = getCluster(clusterIdx);


### PR DESCRIPTION
In suggestion mode, the flag FLAG_PARTIAL
(https://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html#ae96a58a8de9d219ca3214a5a66e0407eae0b632c2f797fc7ae53c444f104072c7)
will be added to the default flag for the queryparser.

If the embedded database has been indexed with a separated title namespace,
the search will be only in this namespace. Else the search is made in
all the database.