### PR TITLE
Correctly stem term for the research for "old" zims.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -197,6 +197,17 @@ Search::iterator Search::begin() const {
         if ( first ) {
             this->valuesmap = read_valuesmap(database.get_metadata("valuesmap"));
             language = database.get_metadata("language");
+            if (language.empty() ) {
+              // Database created before 2017/03 has no language metadata.
+              // However, term were stemmed anyway and we need to stem our
+              // search query the same the database was created.
+              // So we need a language, let's use the one of the zim.
+              // If zimfile has no language metadata, we can't do lot more here :/
+              auto article = zimfile->getArticle('M', "Language");
+              if ( article.good() ) {
+                language = article.getData();
+              }
+            }
             stopwords = database.get_metadata("stopwords");
             this->prefixes = database.get_metadata("prefixes");
         } else {


### PR DESCRIPTION
Zim files created before 2017-03 doesn't have a language metadata in the
database.

But the database was created stemming the content. So we need to stem
our request also.

For example, "Maladie" will be indexed using the stemmed term "malad".
If we don't stem our request, xapian will not found the "maladie" term
in the database, and will return no result.
If we stem our request, we search for "malad" and everything works.

So we need a language. zim file itself store a language metadata, so
let's use it if the database has no metadata.