### PR TITLE
Do not search in embedded data base if zim is multipart.

### DIFF
--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -98,6 +98,8 @@ namespace zim
 
       std::string getChecksum()   { return impl->getChecksum(); }
       bool verify()               { return impl->verify(); }
+
+      bool is_multiPart() const   { return impl->is_multiPart(); }
   };
 
   std::string urldecode(const std::string& url);

--- a/include/zim/fileimpl.h
+++ b/include/zim/fileimpl.h
@@ -83,6 +83,7 @@ namespace zim
 
       std::string getChecksum();
       bool verify();
+      bool is_multiPart() const;
   };
 
 }

--- a/include/zim/fstream.h
+++ b/include/zim/fstream.h
@@ -77,6 +77,7 @@ namespace zim
       { buffer.resize(s); setg(0, 0, 0);}
       zim::offset_type fsize() const;
       time_t getMTime() const;
+      bool is_multiPart() const { return files.size() > 1; }
   };
 
   class ifstream : public std::istream
@@ -95,6 +96,7 @@ namespace zim
       void setBufsize(unsigned s) { myStreambuf.setBufsize(s); }
       zim::offset_type fsize() const  { return myStreambuf.fsize(); }
       time_t getMTime() const     { return myStreambuf.getMTime(); }
+      bool is_multiPart() const { return myStreambuf.is_multiPart(); }
   };
 
 }

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -347,4 +347,8 @@ namespace zim
     return true;
   }
 
+  bool FileImpl::is_multiPart() const {
+    return zimFile.is_multiPart();
+  }
+
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,11 +186,17 @@ Search::iterator Search::begin() const {
     for(it=zimfiles.begin(); it!=zimfiles.end(); it++)
     {
         const File* zimfile = *it;
+        if (zimfile->is_multiPart()) {
+            continue;
+        }
         zim::Article xapianArticle = zimfile->getArticle('Z', "/fulltextIndex/xapian");
         if (!xapianArticle.good()) {
             continue;
         }
         zim::offset_type dbOffset = xapianArticle.getOffset();
+        if (dbOffset == 0) {
+            continue;
+        }
         int databasefd = open(zimfile->getFilename().c_str(), O_RDONLY);
         lseek(databasefd, dbOffset, SEEK_SET);
         Xapian::Database database(databasefd);


### PR DESCRIPTION
We cannot search in multipart zim. So do not search.

Fixes kiwix/kiwix-tools#65
The search will not working, but kiwix-serve will not crash.