### PR TITLE
Use the correct type to store size/offset.

### DIFF
--- a/include/zim/file_compound.h
+++ b/include/zim/file_compound.h
@@ -29,10 +29,10 @@ namespace zim {
 class FileReader;
 
 struct Range {
-  Range(const size_t point ) : min(point), max(point) {}
-  Range(const size_t min, const size_t max) : min(min), max(max) {}
-  const size_t min;
-  const size_t max;
+  Range(const offset_type point ) : min(point), max(point) {}
+  Range(const offset_type  min, const offset_type max) : min(min), max(max) {}
+  const offset_type min;
+  const offset_type max;
 };
 
 struct less_range : public std::binary_function< Range, Range, bool>
@@ -46,13 +46,13 @@ class FileCompound : public std::map<Range, FilePart*, less_range> {
   public:
     FileCompound(const std::string& filename);
 
-    size_t fsize() const { return _fsize; };
+    offset_type fsize() const { return _fsize; };
     time_t getMTime() const;
     bool fail() const { return empty(); };
     bool is_multiPart() const { return size() > 1; };
 
   private:
-    size_t _fsize;
+    offset_type _fsize;
     mutable time_t mtime;
 };
 

--- a/include/zim/file_part.h
+++ b/include/zim/file_part.h
@@ -22,6 +22,8 @@
 
 #include <string>
 
+#include <zim/zim.h>
+
 namespace zim {
 
 class FilePart {
@@ -31,14 +33,14 @@ class FilePart {
     const std::string& filename() const { return filename_; };
     const int fd() const { return fd_; };
 
-    std::size_t size() const { return size_; };
+    offset_type size() const { return size_; };
     bool fail() const { return size_ == 0; };
     bool good() const { return size_; };
 
   private:
     const std::string filename_;
     int fd_;
-    std::size_t size_;
+    offset_type size_;
 };
 
 };

--- a/include/zim/file_reader.h
+++ b/include/zim/file_reader.h
@@ -31,35 +31,35 @@ class FileCompound;
 class Reader {
   public:
     Reader() {};
-    virtual std::size_t size() const = 0;
+    virtual offset_type size() const = 0;
     virtual ~Reader() {};
 
-    virtual void read(char* dest, std::size_t offset, std::size_t size) const = 0;
+    virtual void read(char* dest, offset_type offset, offset_type size) const = 0;
     template<typename T>
-    T read(std::size_t offset) const {
+    T read(offset_type offset) const {
       assert(offset < size());
       assert(offset+sizeof(T) <= size());
       T ret;
       read(reinterpret_cast<char*>(&ret), offset, sizeof(T));
       return ret;
     }
-    virtual char read(std::size_t offset) const = 0;
+    virtual char read(offset_type offset) const = 0;
 
-    virtual std::shared_ptr<const Buffer> get_buffer(std::size_t offset, std::size_t size) const = 0;
-    std::shared_ptr<const Buffer> get_buffer(std::size_t offset) const {
+    virtual std::shared_ptr<const Buffer> get_buffer(offset_type offset, offset_type size) const = 0;
+    std::shared_ptr<const Buffer> get_buffer(offset_type offset) const {
       return get_buffer(offset, size()-offset);
     }
-    virtual std::unique_ptr<const Reader> sub_reader(std::size_t offset, std::size_t size) const = 0;
-    std::unique_ptr<const Reader> sub_reader(std::size_t offset) const {
+    virtual std::unique_ptr<const Reader> sub_reader(offset_type offset, offset_type size) const = 0;
+    std::unique_ptr<const Reader> sub_reader(offset_type offset) const {
       return sub_reader(offset, size()-offset);
     }
-    virtual std::size_t offset() const = 0;
+    virtual offset_type offset() const = 0;
 
-    std::unique_ptr<const Reader> sub_clusterReader(std::size_t offset, std::size_t size, CompressionType* comp) const;
+    std::unique_ptr<const Reader> sub_clusterReader(offset_type offset, offset_type size, CompressionType* comp) const;
 
   private:
-    std::shared_ptr<const Buffer> get_clusterBuffer(std::size_t offset, std::size_t size, CompressionType comp) const;
-    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(std::size_t offset, std::size_t size) const = 0;
+    std::shared_ptr<const Buffer> get_clusterBuffer(offset_type offset, offset_type size, CompressionType comp) const;
+    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(offset_type offset, offset_type size) const = 0;
 
 };
 
@@ -68,24 +68,24 @@ class FileReader : public Reader {
     FileReader(std::shared_ptr<const FileCompound> source);
     ~FileReader() {};
 
-    std::size_t size() const { return _size; };
-    std::size_t offset() const { return _offset; };
+    offset_type size() const { return _size; };
+    offset_type offset() const { return _offset; };
 
-    char read(std::size_t offset) const;
-    void read(char* dest, std::size_t offset, std::size_t size) const;
-    std::shared_ptr<const Buffer> get_buffer(std::size_t offset, std::size_t size) const;
+    char read(offset_type offset) const;
+    void read(char* dest, offset_type offset, offset_type size) const;
+    std::shared_ptr<const Buffer> get_buffer(offset_type offset, offset_type size) const;
 
-    std::unique_ptr<const Reader> sub_reader(std::size_t offest, std::size_t size) const;
+    std::unique_ptr<const Reader> sub_reader(offset_type offest, offset_type size) const;
 
   private:
-    FileReader(std::shared_ptr<const FileCompound> source, std::size_t offset);
-    FileReader(std::shared_ptr<const FileCompound> source, std::size_t offset, std::size_t size);
+    FileReader(std::shared_ptr<const FileCompound> source, offset_type offset);
+    FileReader(std::shared_ptr<const FileCompound> source, offset_type offset, offset_type size);
 
-    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(std::size_t offset, std::size_t size) const;
+    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(offset_type offset, offset_type size) const;
 
     std::shared_ptr<const FileCompound> source;
-    std::size_t _offset;
-    std::size_t _size;
+    offset_type _offset;
+    offset_type _size;
 };
 
 class BufferReader : public Reader {
@@ -94,16 +94,16 @@ class BufferReader : public Reader {
       : source(source) {}
     virtual ~BufferReader() {};
 
-    std::size_t size() const;
-    std::size_t offset() const;
+    offset_type size() const;
+    offset_type offset() const;
 
-    void read(char* dest, std::size_t offset, std::size_t size) const;
-    char read(std::size_t offset) const;
-    std::shared_ptr<const Buffer> get_buffer(std::size_t offset, std::size_t size) const;
-    std::unique_ptr<const Reader> sub_reader(std::size_t offset, std::size_t size) const;
+    void read(char* dest, offset_type offset, offset_type size) const;
+    char read(offset_type offset) const;
+    std::shared_ptr<const Buffer> get_buffer(offset_type offset, offset_type size) const;
+    std::unique_ptr<const Reader> sub_reader(offset_type offset, offset_type size) const;
 
   private:
-    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(std::size_t offset, std::size_t size) const 
+    virtual std::unique_ptr<const Reader> get_mmap_sub_reader(offset_type offset, offset_type size) const
       { return std::unique_ptr<Reader>(); }
     std::shared_ptr<const Buffer> source;
 };

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -31,16 +31,16 @@
 
 namespace zim {
 
-std::shared_ptr<const Buffer> Buffer::sub_buffer(std::size_t offset, std::size_t size) const
+std::shared_ptr<const Buffer> Buffer::sub_buffer(offset_type offset, offset_type size) const
 {
   return std::make_shared<SubBuffer>(shared_from_this(), offset, size);
 }
 
 #if !defined(_WIN32)
-MMapBuffer::MMapBuffer(int fd, std::size_t offset, std::size_t size):
+MMapBuffer::MMapBuffer(int fd, offset_type offset, offset_type size):
   Buffer(size)
 {
-  std::size_t pa_offset = offset & ~(sysconf(_SC_PAGE_SIZE) - 1);
+  offset_type pa_offset = offset & ~(sysconf(_SC_PAGE_SIZE) - 1);
   _offset = offset-pa_offset;
 #if defined(__APPLE__)
   #define MAP_FLAGS MAP_PRIVATE

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -64,7 +64,7 @@ namespace zim
     offsets.push_back(0);
     
     auto buffer = reader->get_buffer(0, offset);
-    std::size_t current = 4;
+    offset_type current = 4;
     while (--n_offset)
     {
       size_type new_offset = fromLittleEndian(buffer->as<size_type>(current));

--- a/src/dirent.cpp
+++ b/src/dirent.cpp
@@ -89,7 +89,7 @@ namespace zim
     size_type version = fromLittleEndian(buffer->as<size_type>(4));
     setVersion(version);
 
-    std::size_t current = 8;
+    offset_type current = 8;
 
     if (redirect)
     {
@@ -125,14 +125,14 @@ namespace zim
 
     log_debug("read url, title and parameters");
 
-    std::size_t url_size = strlen(buffer->data(current));
+    offset_type url_size = strlen(buffer->data(current));
     if (current + url_size >= buffer->size()) {
       throw(InvalidSize());
     }
     url = std::string(buffer->data(current), url_size);
     current += url_size + 1;
     
-    std::size_t title_size = strlen(buffer->data(current));
+    offset_type title_size = strlen(buffer->data(current));
     if (current + title_size >= buffer->size()) {
       throw(InvalidSize());
     }

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -64,7 +64,7 @@ namespace zim
     }
 
     // ptrOffsetBuffer
-    size_t size = header.getArticleCount() * 8;;
+    offset_type size = header.getArticleCount() * 8;;
     urlPtrOffsetBuffer = zimReader->get_buffer(header.getUrlPtrPos(), size);
 
     // Create titleIndexBuffer
@@ -82,9 +82,9 @@ namespace zim
     {
       offset_type lastOffset = getClusterOffset(getCountClusters() - 1);
       log_debug("last offset=" << lastOffset << " file size=" << zimFile->fsize());
-      if (lastOffset > static_cast<offset_type>(zimFile->fsize()))
+      if (lastOffset > zimFile->fsize())
       {
-        log_fatal("last offset (" << lastOffset << ") larger than file size (" << zimFile->fsize() << ')');
+        std::cerr << "last offset (" << lastOffset << ") larger than file size (" << zimFile->fsize() << ')' << std::endl;
         throw ZimFileFormatError("last cluster offset larger than file size; file corrupt");
       }
     }
@@ -92,11 +92,11 @@ namespace zim
     // read mime types
     size = header.getUrlPtrPos() - header.getMimeListPos();
     auto buffer = zimReader->get_buffer(header.getMimeListPos(), size);
-    size_t current = 0;
+    offset_type current = 0;
     while (current < size)
     {
-      size_t len = strlen(buffer->data(current));
- 
+      offset_type len = strlen(buffer->data(current));
+
       if (len == 0) {
         break;
       }
@@ -137,7 +137,7 @@ namespace zim
     // Most dirent will be "Article" entry (header's size == 16) without extra parameters.
     // Let's hope that url + title size will be < 256 and if not try again with a bigger size.
 
-    size_t bufferSize = 256;
+    offset_type bufferSize = 256;
     Dirent dirent;
     while (true) {
         bufferDirentZone.reserve(bufferSize);
@@ -192,7 +192,7 @@ namespace zim
     offset_type clusterOffset = getClusterOffset(idx);
     auto next_idx = idx + 1;
     offset_type nextClusterOffset = (next_idx < getCountClusters()) ? getClusterOffset(next_idx) : header.getChecksumPos();
-    size_t clusterSize = nextClusterOffset - clusterOffset;
+    offset_type clusterSize = nextClusterOffset - clusterOffset;
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
     CompressionType comp;
     std::shared_ptr<const Reader> reader = zimReader->sub_clusterReader(clusterOffset, clusterSize, &comp);
@@ -329,8 +329,8 @@ namespace zim
 
     Md5stream md5;
 
-    size_t checksumPos = header.getChecksumPos();
-    size_t currentPos = 0;
+    offset_type checksumPos = header.getChecksumPos();
+    offset_type currentPos = 0;
     for(auto part = zimFile->begin();
         part != zimFile->end();
         part++) {

--- a/src/writer/cluster.h
+++ b/src/writer/cluster.h
@@ -41,8 +41,8 @@ class Cluster {
 
     void setCompression(CompressionType c) { compression = c; }
     CompressionType getCompression() const { return compression; }
-    std::size_t count() const  { return offsets.size() - 1; }
-    std::size_t size() const   { return offsets.size() * sizeof(size_type) + _data.size(); }
+    offset_type count() const  { return offsets.size() - 1; }
+    offset_type size() const   { return offsets.size() * sizeof(size_type) + _data.size(); }
     void clear();
 
     size_type getBlobSize(unsigned n) const { return offsets[n+1] - offsets[n]; }


### PR DESCRIPTION
As a zim files may be larger than 4GB, we need 8 bytes len integer
to store size or offset in a zim file.

`std::size_t` is not the same depending if the architecture is
32 bits (4 bytes) or 64 bits (8 bytes).

On the other side, we are properly declaring `offset_type` in zim.h to
always be 8 bytes whatever the architecture is.

So, let's use `offset_type` instead of `std::size_t`.

Fixes kiwix/kiwix-tools#76