### PR TITLE
Print better assert message and the callstack on assert failing.

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -23,11 +23,11 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
-#include <cassert>
 #include <iostream>
 
 #include <zim/zim.h>
 #include "endian_tools.h"
+#include "debug.h"
 
 namespace zim {
 
@@ -47,8 +47,8 @@ class Buffer : public std::enable_shared_from_this<Buffer> {
 
     template<typename T>
     T as(offset_type offset) const {
-      assert(offset < size_);
-      assert(offset+sizeof(T) <= size_);
+      ASSERT(offset, <, size_);
+      ASSERT(offset+sizeof(T), <=, size_);
       return fromLittleEndian<T>(data(offset));
     }
 
@@ -72,7 +72,7 @@ class MemoryBuffer : public Buffer {
     }
 
     const char* data(offset_type offset) const {
-        assert(offset <= size_);
+        ASSERT(offset, <=, size_);
         return _data + offset;
     }
   private:
@@ -104,11 +104,11 @@ class SubBuffer : public Buffer {
       : Buffer(size),
         _data(src, src->data(offset))
     {
-      assert((offset+size <= src->size()));
+      ASSERT(offset+size, <=, src->size());
     }
 
   const char* data(offset_type offset) const {
-        assert(offset <= size_);
+        ASSERT(offset, <=, size_);
         return _data.get() + offset;
     }
 

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -45,7 +45,7 @@ namespace zim
     startOffset = read_header();
     reader = reader->sub_reader(startOffset);
     auto d1 = reader->offset();
-    assert((d+startOffset)==d1);
+    ASSERT(d+startOffset, ==, d1);
   }
 
   /* This return the number of char read */
@@ -68,15 +68,15 @@ namespace zim
     while (--n_offset)
     {
       size_type new_offset = buffer->as<size_type>(current);
-      assert(new_offset >= offset);
-      assert(offset >= data_address);
-      assert(offset <= reader->size());
+      ASSERT(new_offset, >=, offset);
+      ASSERT(offset, >=, data_address);
+      ASSERT(offset, <=, reader->size());
       
       offset = new_offset;
       offsets.push_back(offset - data_address);
       current += sizeof(size_type);
     }
-    assert(offset==reader->size());
+    ASSERT(offset, ==, reader->size());
     return data_address;
   }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef DEBUG_H_
+#define DEBUG_H_
+
+#if defined (NDEBUG)
+# define ASSERT(left, operator, right) (void(0))
+#else
+
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__ANDROID__)
+#include <execinfo.h>
+#endif
+
+template<typename T, typename U>
+void _on_assert_fail(const char* vara, const char* op, const char* varb,
+                     T a, U b, const char* file, int line)  {
+  std::cerr << "\nAssertion failed at "<< file << ":" << line << "\n " <<
+      vara << "[" << a << "] " << op << " " << varb << "[" << b << "]" <<
+      std::endl;
+
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__ANDROID__)
+  void *callstack[64];
+  size_t size;
+  size = backtrace(callstack, 64);
+  char** strings = backtrace_symbols(callstack, size);
+  for (size_t i=0; i<size; i++) {
+    std::cerr << strings[i] << std::endl;
+  }
+  free(strings);
+#endif
+  exit(1);
+}
+
+# define ASSERT(left, operator, right) do { auto _left = left; auto _right = right; if (!((_left) operator (_right))) _on_assert_fail(#left, #operator, #right, _left, _right, __FILE__, __LINE__);  } while(0)
+
+#endif
+
+#endif

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -21,9 +21,9 @@
 #define ZIM_FILE_READER_H_
 
 #include <memory>
-#include <cassert>
 
 #include "endian_tools.h"
+#include "debug.h"
 
 namespace zim {
 
@@ -39,8 +39,8 @@ class Reader {
     virtual void read(char* dest, offset_type offset, offset_type size) const = 0;
     template<typename T>
     T read(offset_type offset) const {
-      assert(offset < size());
-      assert(offset+sizeof(T) <= size());
+      ASSERT(offset, <, size());
+      ASSERT(offset+sizeof(T), <=, size());
       char tmp_buf[sizeof(T)];
       read(tmp_buf, offset, sizeof(T));
       return fromLittleEndian<T>(tmp_buf);


### PR DESCRIPTION
`execinfo` is not available with mingw and apple platform
(https://www.gnu.org/software/gnulib/manual/html_node/execinfo_002eh.html),
so print the callstack only on linux.