### PR TITLE
Compile using gcc-5 on native ubuntu.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,25 @@ language: cpp
 dist: trusty
 sudo: required
 cache: ccache
+before_install:
+- eval "${MATRIX_EVAL}"
+- ${CXX} --version
 install: travis/install_deps.sh
 script: travis/compile.sh
 env:
-- PLATFORM="native_static"
-- PLATFORM="native_dyn"
-- PLATFORM="win32_static"
-- PLATFORM="win32_dyn"
-- PLATFORM="android_arm"
-- PLATFORM="android_arm64"
+  global:
+    - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+  matrix:
+    - PLATFORM="native_static"
+    - PLATFORM="native_dyn"
+    - PLATFORM="win32_static"
+    - PLATFORM="win32_dyn"
+    - PLATFORM="android_arm"
+    - PLATFORM="android_arm64"
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-5


### PR DESCRIPTION
As dependencies prepared by kiwix-build are build using gcc-5
(kiwix/kiwix-build@7fc557dd448cef93ae8da357069845607011021c),
we need to also compile libzim using gcc-5.