### PR TITLE
Use friend struct instead of friend class.

### DIFF
--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -32,7 +32,7 @@ class File;
 class Search
 {
     friend class search_iterator;
-    friend class search_iterator::InternalData;
+    friend struct search_iterator::InternalData;
     public:
         typedef search_iterator iterator;
 


### PR DESCRIPTION
`search_iterator::InternalData` is declared as a `struct`, so we must use
`friend struct`.

Fix #95.