### PR TITLE
Allow blob to be assigned with operator=

### DIFF
--- a/include/zim/blob.h
+++ b/include/zim/blob.h
@@ -30,8 +30,8 @@ namespace zim
   class Buffer;
   class Blob
   {
-      const char* const _data;
-      const unsigned _size;
+      const char* _data;
+      unsigned _size;
       std::shared_ptr<const Buffer> _buffer;
 
     public:


### PR DESCRIPTION
If we want to initialize a `Blob` with a `operator=`, the members of the
`Blob` must not be `const`.

This is not a change in the api as `_data` and `_size` are private.