### PR TITLE
Provide parse_html definition from HtmlParser in MyHtmlParser.

### DIFF
--- a/src/xapian/myhtmlparse.h
+++ b/src/xapian/myhtmlparse.h
@@ -42,6 +42,7 @@ class MyHtmlParser : public HtmlParser {
 	void process_text(const string &text);
 	void opening_tag(const string &tag);
 	void closing_tag(const string &tag);
+	using HtmlParser::parse_html;
 	void parse_html(const string &text, const string &charset_,
 			bool charset_from_meta_);
 	MyHtmlParser() :


### PR DESCRIPTION
Recent versions of llvm are now compiled with '-Woverloaded-virtual`
option. (http://llvm.1065342.n5.nabble.com/Woverloaded-virtual-td5478.html)

This option raise a warning if a virtual method is overloaded in a chill
class. The compiler raise a warning because of the potential mistake of
overloading the method instead of overwriting it.

Fix #95

By explicitly bringing the definition of `parse_html` in `MyHtmlParser`,
we avoid the warning.