### PR TITLE
Use 'meson test' command instead of deprecated 'mesontest'.

### DIFF
--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -40,5 +40,5 @@ if [[ "$TEST" == "1" ]]
 then
     export LD_LIBRARY_PATH=${INSTALL_DIR}/lib:${INSTALL_DIR}/lib64:${INSTALL_DIR}/lib/x86_64-linux-gnu
     echo $LD_LIBRARY_PATH
-    mesontest --verbose
+    meson test --verbose
 fi


### PR DESCRIPTION
`mesontest` command is deprecated since meson `0.42.0` and it is broken
with last release (`0.44.0`). (mesonbuild/meson#2761)