### PR TITLE
Do not assume there is a checksum in zim when reading cluster.

### DIFF
--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -325,7 +325,11 @@ namespace zim
 
     offset_type clusterOffset = getClusterOffset(idx);
     auto next_idx = idx + 1;
-    offset_type nextClusterOffset = (next_idx < getCountClusters()) ? getClusterOffset(next_idx) : header.getChecksumPos();
+    offset_type nextClusterOffset = (next_idx < getCountClusters())
+                                        ? getClusterOffset(next_idx)
+                                        : (header.hasChecksum())
+                                            ? header.getChecksumPos()
+                                            : zimFile->fsize();
     offset_type clusterSize = nextClusterOffset - clusterOffset;
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
     CompressionType comp;


### PR DESCRIPTION
If there is no checksum in the zim file, the end of the last cluster
is the end of the file, not the checksumPos.

Fix kiwix/kiwix-tools#150