### PR TITLE
meson: Use werror=true and declare a dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,15 +1,13 @@
 project('libzim', ['c', 'cpp'],
   version : '3.1.0',
   license : 'GPL2',
-  default_options : ['c_std=c11', 'cpp_std=c++11'])
+  default_options : ['c_std=c11', 'cpp_std=c++11', 'werror=true'])
 
 conf = configuration_data()
 conf.set('VERSION', '"@0@"'.format(meson.project_version()))
 conf.set('DIRENT_CACHE_SIZE', get_option('DIRENT_CACHE_SIZE'))
 conf.set('CLUSTER_CACHE_SIZE', get_option('CLUSTER_CACHE_SIZE'))
 conf.set('LZMA_MEMORY_SIZE', get_option('LZMA_MEMORY_SIZE'))
-
-add_global_arguments(['-Werror', '-Wall'], language:'cpp')
 
 zlib_dep = dependency('zlib', required:false)
 conf.set('ENABLE_ZLIB', zlib_dep.found())

--- a/src/meson.build
+++ b/src/meson.build
@@ -58,4 +58,5 @@ libzim = library('zim',
                  dependencies : deps,
                  version: meson.project_version(),
                  install : true)
-
+libzim_dep = declare_dependency(link_with: libzim,
+                                include_directories: include_directory)


### PR DESCRIPTION
Instead of manually adding -Wall -Werror, set werror=true which will set the same in a cross-platform way.

Also declare a dependency so libzim can be used as a subproject.