### PR TITLE
Improve ordering of suggestions search results.

### DIFF
--- a/src/levenshtein.cpp
+++ b/src/levenshtein.cpp
@@ -1,0 +1,33 @@
+
+#include "levenshtein.h"
+#include <numeric>
+#include <algorithm>
+
+int levenshtein_distance(const std::string &s1, const std::string &s2)
+{
+  int s1len = s1.size();
+  int s2len = s2.size();
+	
+  auto column_start = (decltype(s1len))1;
+
+  auto column = new decltype(s1len)[s1len + 1];
+  std::iota(column + column_start - 1, column + s1len + 1, column_start - 1);
+	
+  for (auto x = column_start; x <= s2len; x++) {
+    column[0] = x;
+    auto last_diagonal = x - column_start;
+    for (auto y = column_start; y <= s1len; y++) {
+      auto old_diagonal = column[y];
+      auto possibilities = {
+        column[y] + 1,
+        column[y - 1] + 1,
+        last_diagonal + (s1[y - 1] == s2[x - 1]? 0 : 1)
+      };
+      column[y] = std::min(possibilities);
+      last_diagonal = old_diagonal;
+    }
+  }
+  auto result = column[s1len];
+  delete[] column;
+  return result;
+}

--- a/src/levenshtein.h
+++ b/src/levenshtein.h
@@ -1,0 +1,9 @@
+
+#ifndef LEVENSHTEIN_H
+#define LEVENSHTEIN_H
+
+#include <string>
+
+int levenshtein_distance(const std::string &s1, const std::string &s2);
+
+#endif // LEVENSHTEIN_H

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ common_sources = [
     'search_iterator.cpp',
     'template.cpp',
     'uuid.cpp',
+    'levenshtein.cpp',
     'writer/zimcreatorimpl.cpp',
     'writer/lzmastream.cpp',
     'writer/cluster.cpp',


### PR DESCRIPTION
By default xapian sort search result using relevance using the BM25
algorithm.

This alogrithm calculate the relevance using a "complex" calculation based
on the number of terms in each document, the number of terms in the
query, the number of documents, ...

This works pretty well with full documents but when we search in the
title namespace, this is not relevant at all.
Most titles are pretty short and the query is most of the time one term
only. In this case, all title are very close in number of term and all
contain only one term matching the query. Relevances are very closed and
most of the time irrelevant.

This commit sort the document using the Levenshtein distance of the
document titles to the query string. The search results are pretty more
relevant this way !

The levensthtein distance calculation algorithm is taken from wikibook
(https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++).

This should improve https://github.com/kiwix/kiwix-android/issues/316, https://github.com/kiwix/kiwix-tools/issues/124, https://github.com/kiwix/kiwix-lib/issues/29 and https://github.com/kiwix/kiwix-lib/issues/23 (but probably not totally fix them...)