### PR TITLE
Search should return absolute url.

### DIFF
--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -111,7 +111,12 @@ std::string search_iterator::get_url() const {
     if ( ! internal ) {
         return "";
     }
-    return internal->get_document().get_data();
+    auto url = internal->get_document().get_data();
+    if (url[0] == '/') {
+        return url;
+    } else {
+        return "/" + url;
+    }
 #else
     return "";
 #endif


### PR DESCRIPTION
If the url stored in the embedded index database is not absolute,
make it so.

Fix kiwix/kiwix-lib#110