### PR TITLE
Cast the value to OFFSET_TYPE.

### DIFF
--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -79,7 +79,7 @@ void Cluster::write_impl(std::ostream& out) const
     offset_t o = (*it);
     o.v += a;
     char out_buf[sizeof(OFFSET_TYPE)];
-    toLittleEndian(o.v, out_buf);
+    toLittleEndian(static_cast<OFFSET_TYPE>(o.v), out_buf);
     out.write(out_buf, sizeof(OFFSET_TYPE));
   }
 


### PR DESCRIPTION
`toLittleEndian` will use the type of the first argument (`o.v`) to
know the size of value and so, how many bytes to write.

But offset_t is always a 64bits integer and OFFSET_TYPE may be a 64bits or
a 32bits integer.

So `toLittleEndian` may write out of buffer.