### PR TITLE
Fix RPATH of libzim.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -58,6 +58,8 @@ libzim = library('zim',
                  include_directories : inc,
                  dependencies : deps,
                  version: meson.project_version(),
-                 install : true)
+                 install : true,
+                 build_rpath : join_paths(get_option('prefix'), get_option('libdir')),
+                 install_rpath: '$ORIGIN')
 libzim_dep = declare_dependency(link_with: libzim,
                                 include_directories: include_directory)

--- a/test/meson.build
+++ b/test/meson.build
@@ -15,7 +15,8 @@ foreach test_name : tests
     test_exe = executable(test_name, [test_name+'.cpp'],
                           include_directories : include_directory,
                           link_with : libzim,
-                          dependencies : deps + [gtest_dep])
+                          dependencies : deps + [gtest_dep],
+                          build_rpath : '$ORIGIN')
     test(test_name, test_exe)
 endforeach
 


### PR DESCRIPTION
We need a RPATH to allow binaries and libraries to find other libraries.
We need this because :
- We are not installing libraries in the default (system) directories and
- We cannot change the LD_LIBRARY_PATH in macos.