### PR TITLE
Ensure mimetype is not null.

### DIFF
--- a/src/writer/zimcreator.cpp
+++ b/src/writer/zimcreator.cpp
@@ -496,7 +496,12 @@ namespace zim
       }
       else
       {
-        dirent.setMimeType(getMimeTypeIdx(article->getMimeType()));
+        auto mimetype = article->getMimeType();
+        if (mimetype.empty()) {
+          std::cerr << "Warning, " << article->getUrl() << " have empty mimetype." << std::endl;
+          mimetype = "application/octet-stream";
+        }
+        dirent.setMimeType(getMimeTypeIdx(mimetype));
         log_debug("is article; mimetype " << dirent.getMimeType());
       }
       return dirent;


### PR DESCRIPTION
mimetype should never be null.

In normal case, caller code should ensure that `article->getMimeType()`
doesn't return a empty mimetype.
But it is better to not trust user code.

See openzim/zimwriterfs#48