### PR TITLE
Correctly sort titles' array.

### DIFF
--- a/src/writer/zimcreator.cpp
+++ b/src/writer/zimcreator.cpp
@@ -621,6 +621,8 @@ namespace zim
 
     void ZimCreatorData::createTitleIndex()
     {
+      // Sort works on dirents sorted by url.
+      std::sort(dirents.begin(), dirents.end(), compareUrl);
       titleIdx.resize(0);
       titleIdx.reserve(dirents.size());
       for (auto dirent: dirents)


### PR DESCRIPTION
`CompareTitle` will use the index to get the correct dirent in `dirents`.
As the indexes in `titleIdx` are "url indexes", the `dirents` must be
sort by url before sorting `titleIdx`.

The last time `dirents` was sorted was by aid in `resolveRedirectIndexes`,
so, `CompareTitle` were comparing title of wrong dirents.

Fix openzim/zimwriterfs#55