### PR TITLE
Correctly open file in windows.

### DIFF
--- a/src/file_part.cpp
+++ b/src/file_part.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "file_part.h"
+#include "tools.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -35,11 +36,7 @@ FilePart::FilePart(const std::string& filename)
   : filename_(filename),
     size_(0)
 {
-#ifdef _WIN32
-  fd_ = _open(filename.c_str(), O_RDONLY|O_BINARY);
-#else
-  fd_ = open(filename.c_str(), O_RDONLY);
-#endif
+  fd_ = openFile(filename);
   struct stat sb;
   if ( fd_ >= 0 ) {
     fstat(fd_, &sb);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -21,12 +21,12 @@
 #include <zim/file.h>
 #include "search_internal.h"
 #include "levenshtein.h"
+#include "tools.h"
 
 #include <sstream>
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #if !defined(_WIN32)
 # include <unistd.h>
 #else
@@ -262,11 +262,7 @@ Search::iterator Search::begin() const {
         if (dbOffset == 0) {
             continue;
         }
-#ifdef _WIN32
-        int databasefd = _open(zimfile->getFilename().c_str(), O_RDONLY|O_BINARY);
-#else
-        int databasefd = open(zimfile->getFilename().c_str(), O_RDONLY);
-#endif
+        int databasefd = openFile(zimfile->getFilename());
         if (databasefd == -1) {
             std::cerr << "Impossible to open " << zimfile->getFilename() << std::endl;
             std::cerr << strerror(errno) << std::endl;

--- a/src/tools.h
+++ b/src/tools.h
@@ -27,6 +27,15 @@ namespace zim {
 
   std::string removeAccents(const std::string& text);
 
+  /**
+   * Open a file in BINARY and READONLY mode and return
+   * the corresponding fd.
+   *
+   * @param filepath An utf8 encoded path.
+   * @return the file descriptor of the open file.
+   * @error If the file cannot be opened, return -1 and set errno.
+   */
+  int  openFile(const std::string& filepath);
   bool makeDirectory(const std::string& path);
   void remove_all(const std::string& path);
   void move(const std::string& old_path,


### PR DESCRIPTION
All our strings are (and must) be utf8 encoded.

We just need to convert the filepath to utf-16 (wchar_t) right before
opening the file using `_wopen`.

Client code must pass utf8 encoded string to libzim.
See http://utf8everywhere.org/

As opening a file is now a bit more complex that just run `open` and we
need to open a file at sereval place, create the tool functon `openFile`
to open file correctly.

Fix #74 