### PR TITLE
Fix check of maximum offset for mmap.

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -52,7 +52,7 @@ MMapBuffer::MMapBuffer(int fd, offset_t offset, zsize_t size):
   #define MAP_FLAGS MAP_PRIVATE|MAP_POPULATE
 #endif
 #if !MMAP_SUPPORT_64
-  if(pa_offset.v >= UINT32_MAX) {
+  if(pa_offset.v >= INT32_MAX) {
     throw MMapException();
   }
 #endif


### PR DESCRIPTION
off_t is a signed int. So max is INT32_MAX, not UINT32_MAX.