### PR TITLE
Define _LARGEFILE64_SOURCE only if not on windows.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,9 @@ project('libzim', ['c', 'cpp'],
   license : 'GPL2',
   default_options : ['c_std=c11', 'cpp_std=c++11', 'werror=true'])
 
-add_project_arguments('-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64', language: 'cpp')
+if build_machine.system() != 'windows'
+  add_project_arguments('-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64', language: 'cpp')
+endif
 
 sizeof_off_t = meson.get_compiler('cpp').sizeof('off_t')
 


### PR DESCRIPTION
zlib try to include "unistd.h" if _LARGEFILE64_SOURCE is defined.
If we are compiling on windows platform, "unistd.h" is not present and
compilation fails.