### PR TITLE
Do not close the databasefd in case of error.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,7 +277,6 @@ Search::iterator Search::begin() const {
                       << zimfile->getFilename() << std::endl;
             std::cerr << "dbOffest = " << dbOffset << std::endl;
             std::cerr << "error = " << e.get_msg() << std::endl;
-            close(databasefd);
             continue;
         }
 


### PR DESCRIPTION
XapianDatabase will always close the file descriptor, even in case of
error. Do not try to close it ourselves.

On windows, the `close` on a invalid file descriptor make the application
crash.