### PR TITLE
Add newline to end of "Try to open..." message

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -262,7 +262,7 @@ Search::iterator Search::begin() const {
         if (dbOffset == 0) {
             continue;
         }
-        std::cerr << "Try to open " << zimfile->getFilename() << " at offset " << dbOffset;
+        std::cerr << "Try to open " << zimfile->getFilename() << " at offset " << dbOffset << std::endl;
         DEFAULTFS::FD databasefd;
         try {
             databasefd = DEFAULTFS::openFile(zimfile->getFilename());


### PR DESCRIPTION
Otherwise there's no separation and it all gets jumbled
together.