### PR TITLE
Do not fail if cluster are not written sequentially.

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -123,4 +123,21 @@ namespace zim
       return zsize_t(offsets.size() * sizeof(uint32_t) + reader->size().v);
   }
 
+  template<typename OFFSET_TYPE>
+  zsize_t _read_size(const Reader* reader, offset_t offset)
+  {
+    OFFSET_TYPE blob_offset = reader->read<OFFSET_TYPE>(offset);
+    auto off = offset+offset_t(blob_offset-sizeof(OFFSET_TYPE));
+    auto s = reader->read<OFFSET_TYPE>(off);
+    return zsize_t(s);
+  }
+
+  zsize_t Cluster::read_size(const Reader* reader, bool isExtended, offset_t offset)
+  {
+    if (isExtended)
+      return _read_size<uint64_t>(reader, offset);
+    else
+      return _read_size<uint32_t>(reader, offset);
+  }
+
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -23,6 +23,7 @@
 #include <zim/zim.h>
 #include "buffer.h"
 #include "zim_types.h"
+#include "file_reader.h"
 #include <iosfwd>
 #include <vector>
 #include <memory>
@@ -62,6 +63,7 @@ namespace zim
       void clear();
 
       void init_from_buffer(Buffer& buffer);
+      static zsize_t read_size(const Reader* reader, bool isExtended, offset_t offset);
   };
 
 }

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -59,14 +59,13 @@ class Reader {
     virtual offset_t offset() const = 0;
 
     std::unique_ptr<const Reader> sub_clusterReader(offset_t offset,
-                                                    zsize_t size,
                                                     CompressionType* comp,
                                                     bool* extented) const;
 
     bool can_read(offset_t offset, zsize_t size);
 
   private:
-    std::shared_ptr<const Buffer> get_clusterBuffer(offset_t offset, zsize_t size, CompressionType comp) const;
+    std::shared_ptr<const Buffer> get_clusterBuffer(offset_t offset, CompressionType comp) const;
 };
 
 class FileReader : public Reader {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -365,17 +365,10 @@ namespace zim
     }
 
     offset_t clusterOffset(getClusterOffset(idx));
-    cluster_index_t next_idx(idx.v + 1);
-    offset_t nextClusterOffset( (next_idx < getCountClusters())
-                                        ? getClusterOffset(next_idx).v
-                                        : (header.hasChecksum())
-                                            ? header.getChecksumPos()
-                                            : zimFile->fsize().v );
-    zsize_t clusterSize(nextClusterOffset.v - clusterOffset.v);
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
     CompressionType comp;
     bool extended;
-    std::shared_ptr<const Reader> reader = zimReader->sub_clusterReader(clusterOffset, clusterSize, &comp, &extended);
+    std::shared_ptr<const Reader> reader = zimReader->sub_clusterReader(clusterOffset, &comp, &extended);
     cluster = std::shared_ptr<Cluster>(new Cluster(reader, comp, extended));
 
     log_debug("put cluster " << idx << " into cluster cache; hits " << clusterCache.getHits() << " misses " << clusterCache.getMisses() << " ratio " << clusterCache.hitRatio() * 100 << "% fillfactor " << clusterCache.fillfactor());

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -146,7 +146,7 @@ TEST(ClusterTest, read_write_clusterZ)
   zim::CompressionType comp;
   bool extended;
   std::shared_ptr<const zim::Reader> clusterReader
-      = reader->sub_clusterReader(zim::offset_t(0), zim::zsize_t(size), &comp, &extended);
+      = reader->sub_clusterReader(zim::offset_t(0), &comp, &extended);
   ASSERT_EQ(comp, zim::zimcompZip);
   ASSERT_EQ(extended, false);
   zim::Cluster cluster2(clusterReader, comp, extended);
@@ -191,7 +191,7 @@ TEST(ClusterTest, read_write_clusterLzma)
   zim::CompressionType comp;
   bool extended;
   std::shared_ptr<const zim::Reader> clusterReader
-      = reader->sub_clusterReader(zim::offset_t(0), zim::zsize_t(size), &comp, &extended);
+      = reader->sub_clusterReader(zim::offset_t(0), &comp, &extended);
   ASSERT_EQ(comp, zim::zimcompLzma);
   ASSERT_EQ(extended, false);
   zim::Cluster cluster2(clusterReader, comp, extended);
@@ -295,7 +295,7 @@ TEST(CluterTest, read_write_extended_cluster)
   zim::CompressionType comp;
   bool extended;
   std::shared_ptr<const zim::Reader> clusterReader
-      = reader->sub_clusterReader(zim::offset_t(0), zim::zsize_t(size), &comp, &extended);
+      = reader->sub_clusterReader(zim::offset_t(0), &comp, &extended);
   ASSERT_EQ(extended, true);
   zim::Cluster cluster2(clusterReader, comp, extended);
   ASSERT_EQ(cluster2.count().v, 4U);
@@ -378,7 +378,7 @@ TEST(CluterTest, read_extended_cluster)
   zim::CompressionType comp;
   bool extended;
   std::shared_ptr<const zim::Reader> clusterReader
-      = reader->sub_clusterReader(zim::offset_t(0), reader->size(), &comp, &extended);
+      = reader->sub_clusterReader(zim::offset_t(0), &comp, &extended);
   ASSERT_EQ(extended, true);
   zim::Cluster cluster2(clusterReader, comp, extended);
   ASSERT_EQ(cluster2.count().v, 4U);


### PR DESCRIPTION
We were assuming that cluster were written sequentially. But even if
it is what is made by libzim (reference implementation), this is not in
the spec and other may not write them sequentially.

So we have to detect the size of the cluster differently:
- For uncompressed cluster, we have to read the cluster header.
  As this is not compressed, the size of the cluster in the header is the
  same of the (zim) buffer containing the cluster.
- For compressed cluster, we cannot use the cluster header because
  1. It is compressed
  2. The size in the header is the uncompressed size, not the size of
     the compressed header.
  In fact, there is no way to know the size of the compressed buffer
  without decompressing the data until we reach the end of the
  compression stream. So we have to decompress the data, chunk by chunk
  until we decompress all the cluster.

Fix #196