### PR TITLE
Removed Rpath from compiled binaries

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -71,8 +71,6 @@ libzim = library('zim',
                  link_args : extra_link_args,
                  cpp_args : extra_cpp_args,
                  version: meson.project_version(),
-                 install : true,
-                 build_rpath : join_paths(get_option('prefix'), get_option('libdir')),
-                 install_rpath: '$ORIGIN')
+                 install : true)
 libzim_dep = declare_dependency(link_with: libzim,
                                 include_directories: include_directory)


### PR DESCRIPTION
Rpath is not needed to run installed binaries. Most of GNU/Linux
distributions strictly forbid it.

See also:
 * https://lintian.debian.org/tags/binary-or-shlib-defines-rpath.html
 * https://wiki.debian.org/RpathIssue
 * https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath
