### PR TITLE
Do not use this_thread::sleep.

### DIFF
--- a/src/writer/queue.h
+++ b/src/writer/queue.h
@@ -24,8 +24,7 @@
 
 #include <pthread.h>
 #include <queue>
-#include <chrono>
-#include <thread>
+#include <time.h>
 
 template<typename T>
 class Queue {
@@ -56,15 +55,15 @@ bool Queue<T>::isEmpty() {
 
 template<typename T>
 void Queue<T>::pushToQueue(const T &element) {
-    unsigned int wait = 0;
+    struct timespec wait = {0, 0};
     unsigned int queueSize = 0;
 
     do {
-        std::this_thread::sleep_for(std::chrono::microseconds(wait));
+        nanosleep(&wait, nullptr);
         pthread_mutex_lock(&m_queueMutex);
         queueSize = m_realQueue.size();
         pthread_mutex_unlock(&m_queueMutex);
-        wait += 10;
+        wait.tv_nsec += 10000;
     } while (queueSize > MAX_QUEUE_SIZE);
 
     pthread_mutex_lock(&m_queueMutex);

--- a/test/uuid.cpp
+++ b/test/uuid.cpp
@@ -23,8 +23,7 @@
 
 #include "gtest/gtest.h"
 
-#include <thread>
-#include <chrono>
+#include <time.h>
 
 namespace
 {
@@ -91,7 +90,8 @@ TEST(UuidTest, generate)
   // same during generating uuid1 and uuid2 leading to test
   // failure. To bring the time difference between 2 sleep for a
   // second. Thanks to Pino Toscano.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  struct timespec wait = {1, 0};
+  nanosleep(&wait, nullptr);
 
   uuid2 = zim::Uuid::generate();
   ASSERT_TRUE(uuid1 != uuid2);


### PR DESCRIPTION
Mingw doesn't implement it. So, we should not use it.
I suppose that it was working before because mingw package for debian trusty
simply no provides a "thread" header.
We may face to include the native "thread" header.

Has sleep was only use for creator and test and we never try to launch
zimwriterfs on windows, we never face the problem.