### PR TITLE
Revert Do not use this_thread::sleep.

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -43,6 +43,13 @@
 # define SEPARATOR "/"
 #endif
 
+#ifdef __MINGW32__
+# include <time.h>
+#else
+# include <thread>
+# include <chrono>
+#endif
+
 
 std::string zim::removeAccents(const std::string& text)
 {
@@ -55,4 +62,16 @@ std::string zim::removeAccents(const std::string& text)
   std::string unaccentedText;
   ustring.toUTF8String(unaccentedText);
   return unaccentedText;
+}
+
+
+void zim::microsleep(int microseconds) {
+#ifdef __MINGW32__
+   struct timespec wait = {0, 0};
+   wait.tv_sec = microseconds / 1000000;
+   wait.tv_nsec = (microseconds - wait.tv_sec*10000) * 1000;
+   nanosleep(&wait, nullptr);
+#else
+   std::this_thread::sleep_for(std::chrono::microseconds(microseconds));
+#endif
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -26,7 +26,7 @@
 namespace zim {
 
   std::string removeAccents(const std::string& text);
-
+  void microsleep(int microseconds);
 }
 
 #endif  // OPENZIM_LIBZIM_TOOLS_H

--- a/src/writer/queue.h
+++ b/src/writer/queue.h
@@ -24,7 +24,7 @@
 
 #include <pthread.h>
 #include <queue>
-#include <time.h>
+#include "../tools.h"
 
 template<typename T>
 class Queue {
@@ -55,15 +55,15 @@ bool Queue<T>::isEmpty() {
 
 template<typename T>
 void Queue<T>::pushToQueue(const T &element) {
-    struct timespec wait = {0, 0};
+    unsigned int wait = 0;
     unsigned int queueSize = 0;
 
     do {
-        nanosleep(&wait, nullptr);
+        zim::microsleep(wait);
         pthread_mutex_lock(&m_queueMutex);
         queueSize = m_realQueue.size();
         pthread_mutex_unlock(&m_queueMutex);
-        wait.tv_nsec += 10000;
+        wait += 10;
     } while (queueSize > MAX_QUEUE_SIZE);
 
     pthread_mutex_lock(&m_queueMutex);

--- a/test/uuid.cpp
+++ b/test/uuid.cpp
@@ -22,8 +22,11 @@
 #include <sstream>
 
 #include "gtest/gtest.h"
-
-#include <time.h>
+#ifdef _WIN32
+# include <synchapi.h>
+#else
+# include <unistd.h>
+#endif
 
 namespace
 {
@@ -90,8 +93,11 @@ TEST(UuidTest, generate)
   // same during generating uuid1 and uuid2 leading to test
   // failure. To bring the time difference between 2 sleep for a
   // second. Thanks to Pino Toscano.
-  struct timespec wait = {1, 0};
-  nanosleep(&wait, nullptr);
+#ifdef _WIN32
+  Sleep(1000);
+#else
+  sleep(1);
+#endif
 
   uuid2 = zim::Uuid::generate();
   ASSERT_TRUE(uuid1 != uuid2);


### PR DESCRIPTION
On mingw32 `this_thread::sleep` is not implemented but `microsleep` is
not implemented on windows :/

We have to use a intermediate tool function to sleep.