### PR TITLE
Do not update python3 on macos CI.

### DIFF
--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -10,7 +10,7 @@ cd $HOME
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]
 then
   brew update
-  brew upgrade python3
+#  brew upgrade python3
   pip3 install meson==0.49.2 pytest
 
   wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip


### PR DESCRIPTION
Update python3 (from 3.6 to 3.7) take on looot of time on the CI
(~half an hour).
Python 3.6 is enough so, do not update it.