### PR TITLE
Return a unique_ptr instead of a raw pointer when creating a search.

### DIFF
--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -81,8 +81,8 @@ namespace zim
       const_iterator find(char ns, const std::string& url) const;
       const_iterator find(const std::string& url) const;
 
-      const Search* search(const std::string& query, int start, int end) const;
-      const Search* suggestions(const std::string& query, int start, int end) const;
+      std::unique_ptr<Search> search(const std::string& query, int start, int end) const;
+      std::unique_ptr<Search> suggestions(const std::string& query, int start, int end) const;
 
       time_t getMTime() const;
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -176,15 +176,15 @@ namespace zim
     return File::const_iterator(this, article_index_type(r.second), const_iterator::ArticleIterator);
   }
 
-  const Search* File::search(const std::string& query, int start, int end) const {
-      Search* search = new Search(this);
+  std::unique_ptr<Search> File::search(const std::string& query, int start, int end) const {
+      auto search = std::unique_ptr<Search>(new Search(this));
       search->set_query(query);
       search->set_range(start, end);
       return search;
   }
 
-  const Search* File::suggestions(const std::string& query, int start, int end) const {
-      Search* search = new Search(this);
+  std::unique_ptr<Search> File::suggestions(const std::string& query, int start, int end) const {
+      auto search = std::unique_ptr<Search>(new Search(this));
       search->set_query(query);
       search->set_range(start, end);
       search->set_suggestion_mode(true);


### PR DESCRIPTION
This will avoid memory leak when client forget to delete the Search object.