### PR TITLE
Fix windows compilation.

### DIFF
--- a/include/zim/article.h
+++ b/include/zim/article.h
@@ -26,6 +26,10 @@
 #include <limits>
 #include <iosfwd>
 
+#ifdef max
+#undef max
+#endif
+
 namespace zim
 {
   class Cluster;

--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -28,8 +28,6 @@
 #include "blob.h"
 #include "fileheader.h"
 
-class ZimDumper;
-
 namespace zim
 {
   class Search;
@@ -38,7 +36,6 @@ namespace zim
 
   class File
   {
-    friend class ::ZimDumper;
     std::shared_ptr<FileImpl> impl;
 
     public:


### PR DESCRIPTION
- Windows header define the max macro :/
- cl complains about the not defined ZimDumper. And we don't need it.