### PR TITLE
Do not fail if gtest is not found.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ else
     icu_dep = dependency('icu-i18n', required:false, static:static_linkage)
 endif
 
-gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_dep'])
+gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_dep'], required:false)
 
 inc = include_directories('include')
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -15,15 +15,17 @@ if lzma_dep.found()
 #    zimlibtest_sources += ['lzmastream.cpp']
 endif
 
-foreach test_name : tests
-    test_exe = executable(test_name, [test_name+'.cpp'],
-                          include_directories : [include_directory, src_directory],
-                          link_with : libzim,
-                          link_args: extra_link_args,
-                          dependencies : deps + [gtest_dep],
-                          build_rpath : '$ORIGIN')
-    test(test_name, test_exe, timeout : 60)
-endforeach
+if gtest_dep.found()
+    foreach test_name : tests
+        test_exe = executable(test_name, [test_name+'.cpp'],
+                              include_directories : [include_directory, src_directory],
+                              link_with : libzim,
+                              link_args: extra_link_args,
+                              dependencies : deps + [gtest_dep],
+                              build_rpath : '$ORIGIN')
+        test(test_name, test_exe, timeout : 60)
+    endforeach
+endif
 
 if get_option('default_library') != 'static'
     subdir('pytest')


### PR DESCRIPTION
gtest may not be available if it is not system installed and meson is
run with `--wrap-mode=nodownload`.

We must meson without download in flatpak because run the build in a
container without network access.