### PR TITLE
Codecov should ignore 'test' and 'examples' directories

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,7 @@ coverage:
     project:
       default:
         threshold: 1%
+
+ignore:
+  - "test"
+  - "examples"


### PR DESCRIPTION
Fixing #260