### PR TITLE
Support for Zstd compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ libraries need to be available:
 * [Z](https://zlib.net/) (package `zlib1g-dev` on Ubuntu)
 * [LZMA](https://tukaani.org/lzma/) (package `lzma-dev` on Ubuntu)
 * [ICU](http://site.icu-project.org/) (package `libicu-dev` on Ubuntu)
+* [Zstd](https://facebook.github.io/zstd/) (package `libzstd-dev` on Ubuntu)
 * [Xapian](https://xapian.org/) - optional (package `libxapian-dev` on Ubuntu)
 * [Google Test](https://github.com/google/googletest) - optional (package `googletest` on Ubuntu)
 

--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -35,7 +35,7 @@ namespace zim
 
   // The size of something (article, zim, cluster, blob, ...)
   typedef uint64_t size_type;
-  
+
   // An offset.
   typedef uint64_t offset_type;
 
@@ -45,7 +45,8 @@ namespace zim
     zimcompNone,
     zimcompZip,
     zimcompBzip2, // Not supported anymore in the libzim
-    zimcompLzma
+    zimcompLzma,
+    zimcompZstd
   };
 
   static const char MimeHtmlTemplate[] = "text/x-zim-htmltemplate";

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,9 @@ conf.set('ENABLE_ZLIB', zlib_dep.found())
 
 lzma_dep = dependency('liblzma', static:static_linkage)
 
+zstd_dep = dependency('libzstd', required:false, static:static_linkage)
+conf.set('ENABLE_ZSTD', zstd_dep.found())
+
 xapian_dep = dependency('xapian-core',
                         required:false,
                         static:static_linkage)
@@ -48,6 +51,9 @@ else
 endif
 if zlib_dep.found()
     pkg_requires += ['zlib']
+endif
+if zstd_dep.found()
+    pkg_requires += ['libzstd']
 endif
 if xapian_dep.found()
     pkg_requires += ['xapian-core']

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -50,7 +50,7 @@ namespace zim
     public:
       Cluster(std::shared_ptr<const Reader> reader, CompressionType comp, bool isExtended);
       CompressionType getCompression() const   { return compression; }
-      bool isCompressed() const                { return compression == zimcompZip || compression == zimcompBzip2 || compression == zimcompLzma; }
+      bool isCompressed() const                { return compression != zimcompDefault && compression != zimcompNone; }
 
       blob_index_t count() const               { return blob_index_t(offsets.size() - 1); }
       zsize_t size() const;

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -110,3 +110,7 @@ void ZIP_INFO::stream_end_encode(stream_t* stream) {
   ASSERT(ret, ==, Z_OK);
 }
 #endif // ENABLE_ZLIB
+
+#if defined(ENABLE_ZSTD)
+const std::string ZSTD_INFO::name = "zstd";
+#endif

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -113,52 +113,110 @@ void ZIP_INFO::stream_end_encode(stream_t* stream) {
 
 #if defined(ENABLE_ZSTD)
 const std::string ZSTD_INFO::name = "zstd";
+
+ZSTD_INFO::stream_t::stream_t()
+: next_in(nullptr),
+  avail_in(0),
+  next_out(nullptr),
+  avail_out(0),
+  total_out(0),
+  encoder_stream(nullptr),
+  decoder_stream(nullptr)
+{}
+
+ZSTD_INFO::stream_t::~stream_t()
+{
+  if ( encoder_stream )
+    ::ZSTD_freeCStream(encoder_stream);
+
+  if ( decoder_stream )
+    ::ZSTD_freeDStream(decoder_stream);
+}
+
 void ZSTD_INFO::init_stream_decoder(stream_t* stream, char* raw_data)
 {
-  *stream = LZMA_STREAM_INIT;
-  unsigned memsize = zim::envMemSize("ZIM_LZMA_MEMORY_SIZE", LZMA_MEMORY_SIZE * 1024 * 1024);
-  auto errcode = lzma_stream_decoder(stream, memsize, 0);
-  if (errcode != LZMA_OK) {
-    throw std::runtime_error("Impossible to allocated needed memory to uncompress lzma stream");
+  stream->decoder_stream = ::ZSTD_createDStream();
+  auto ret = ::ZSTD_initDStream(stream->decoder_stream);
+  if (::ZSTD_isError(ret)) {
+    throw std::runtime_error("Failed to initialize Zstd decompression");
   }
 }
 
 void ZSTD_INFO::init_stream_encoder(stream_t* stream, char* raw_data)
 {
-  *stream = LZMA_STREAM_INIT;
-  auto errcode = lzma_easy_encoder(stream, 9 | LZMA_PRESET_EXTREME, LZMA_CHECK_CRC32);
-  if (errcode != LZMA_OK) {
-    throw std::runtime_error("Cannot initialize lzma_easy_encoder");
+  stream->encoder_stream = ::ZSTD_createCStream();
+  auto ret = ::ZSTD_initCStream(stream->encoder_stream, ::ZSTD_maxCLevel());
+  if (::ZSTD_isError(ret)) {
+    throw std::runtime_error("Failed to initialize Zstd compression");
   }
 }
 
 CompStatus ZSTD_INFO::stream_run_encode(stream_t* stream, CompStep step) {
-  return stream_run(stream, step);
+  ::ZSTD_inBuffer inBuf;
+  inBuf.src = stream->next_in;
+  inBuf.size = stream->avail_in;
+  inBuf.pos = 0;
+
+  ::ZSTD_outBuffer outBuf;
+  outBuf.dst = stream->next_out;
+  outBuf.size = stream->avail_out;
+  outBuf.pos = 0;
+
+  auto ret = step == CompStep::STEP
+           ? ::ZSTD_compressStream(stream->encoder_stream, &outBuf, &inBuf)
+           : ::ZSTD_endStream(stream->encoder_stream, &outBuf);
+  stream->next_in += inBuf.pos;
+  stream->avail_in -= inBuf.pos;
+  stream->next_out += outBuf.pos;
+  stream->avail_out -= outBuf.pos;
+  stream->total_out += outBuf.pos;
+
+  if (::ZSTD_isError(ret))
+    return CompStatus::OTHER;
+
+  if ( step == CompStep::STEP ) {
+    if ( stream->avail_in != 0)
+      ASSERT(stream->avail_out, ==, 0u);
+      return CompStatus::BUF_ERROR;
+  } else if ( ret > 0 ) {
+      return CompStatus::BUF_ERROR;
+  }
+
+  return CompStatus::OK;
 }
 
-CompStatus ZSTD_INFO::stream_run_decode(stream_t* stream, CompStep step) {
-  return stream_run(stream, step);
-}
+CompStatus ZSTD_INFO::stream_run_decode(stream_t* stream, CompStep /*step*/) {
+  ::ZSTD_inBuffer inBuf;
+  inBuf.src = stream->next_in;
+  inBuf.size = stream->avail_in;
+  inBuf.pos = 0;
 
-CompStatus ZSTD_INFO::stream_run(stream_t* stream, CompStep step)
-{
-  auto errcode = lzma_code(stream, step==CompStep::STEP?LZMA_RUN:LZMA_FINISH);
-  if (errcode == LZMA_BUF_ERROR)
-    return CompStatus::BUF_ERROR;
-  if (errcode == LZMA_STREAM_END)
+  ::ZSTD_outBuffer outBuf;
+  outBuf.dst = stream->next_out;
+  outBuf.size = stream->avail_out;
+  outBuf.pos = 0;
+
+  auto ret = ::ZSTD_decompressStream(stream->decoder_stream, &outBuf, &inBuf);
+  stream->next_in += inBuf.pos;
+  stream->avail_in -= inBuf.pos;
+  stream->next_out += outBuf.pos;
+  stream->avail_out -= outBuf.pos;
+  stream->total_out += outBuf.pos;
+
+  if (::ZSTD_isError(ret))
+    return CompStatus::OTHER;
+
+  if (ret == 0)
     return CompStatus::STREAM_END;
-  if (errcode == LZMA_OK)
-    return CompStatus::OK;
-  return CompStatus::OTHER;
+
+  return CompStatus::BUF_ERROR;
 }
 
 void ZSTD_INFO::stream_end_decode(stream_t* stream)
 {
-  lzma_end(stream);
 }
 
 void ZSTD_INFO::stream_end_encode(stream_t* stream)
 {
-  lzma_end(stream);
 }
 #endif

--- a/src/compression.h
+++ b/src/compression.h
@@ -64,6 +64,14 @@ struct ZIP_INFO {
 };
 #endif
 
+#if defined(ENABLE_ZSTD)
+struct ZSTD_INFO : LZMA_INFO
+{
+  static const std::string name;
+};
+#endif
+
+
 namespace zim {
 
 template<typename INFO>

--- a/src/compression.h
+++ b/src/compression.h
@@ -65,10 +65,18 @@ struct ZIP_INFO {
 #endif
 
 #if defined(ENABLE_ZSTD)
-struct ZSTD_INFO : LZMA_INFO
-{
+struct ZSTD_INFO {
+  typedef lzma_stream stream_t;
   static const std::string name;
+  static void init_stream_decoder(stream_t* stream, char* raw_data);
+  static void init_stream_encoder(stream_t* stream, char* raw_data);
+  static CompStatus stream_run_encode(stream_t* stream, CompStep step);
+  static CompStatus stream_run_decode(stream_t* stream, CompStep step);
+  static CompStatus stream_run(stream_t* stream, CompStep step);
+  static void stream_end_encode(stream_t* stream);
+  static void stream_end_decode(stream_t* stream);
 };
+
 #endif
 
 

--- a/src/compression.h
+++ b/src/compression.h
@@ -14,6 +14,10 @@
 #include <zlib.h>
 #endif
 
+#if defined(ENABLE_ZSTD)
+#include <zstd.h>
+#endif
+
 
 #include "zim_types.h"
 
@@ -66,13 +70,29 @@ struct ZIP_INFO {
 
 #if defined(ENABLE_ZSTD)
 struct ZSTD_INFO {
-  typedef lzma_stream stream_t;
+  struct stream_t
+  {
+    const unsigned char* next_in;
+    size_t avail_in;
+    unsigned char* next_out;
+    size_t avail_out;
+    size_t total_out;
+
+    ::ZSTD_CStream* encoder_stream;
+    ::ZSTD_DStream* decoder_stream;
+
+    stream_t();
+    ~stream_t();
+  private:
+    stream_t(const stream_t& t) = delete;
+    void operator=(const stream_t& t) = delete;
+  };
+
   static const std::string name;
   static void init_stream_decoder(stream_t* stream, char* raw_data);
   static void init_stream_encoder(stream_t* stream, char* raw_data);
   static CompStatus stream_run_encode(stream_t* stream, CompStep step);
   static CompStatus stream_run_decode(stream_t* stream, CompStep step);
-  static CompStatus stream_run(stream_t* stream, CompStep step);
   static void stream_end_encode(stream_t* stream);
   static void stream_end_decode(stream_t* stream);
 };

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -9,6 +9,8 @@
 
 #mesondefine ENABLE_ZLIB
 
+#mesondefine ENABLE_ZSTD
+
 #mesondefine ENABLE_XAPIAN
 
 #mesondefine ENABLE_USE_MMAP

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,10 @@ if zlib_dep.found()
     deps += [zlib_dep]
 endif
 
+if zstd_dep.found()
+    deps += [zstd_dep]
+endif
+
 if xapian_dep.found()
     sources += xapian_sources
     sources += lib_resources

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -123,25 +123,36 @@ void Cluster::compress()
 #if !defined(ENABLE_ZLIB)
     case zim::zimcompZip:
 #endif
+#if !defined(ENABLE_ZSTD)
+    case zim::zimcompZstd:
+#endif
       {
         throw std::runtime_error("Compression method not enabled in this library");
         break;
       }
 
     case zim::zimcompLzma:
+      {
+        _compress<LZMA_INFO>();
+        break;
+      }
+
 #if defined(ENABLE_ZLIB)
     case zim::zimcompZip:
-#endif
       {
-        if (comp == zim::zimcompLzma) {
-          _compress<LZMA_INFO>();
-          break;
-        };
-#if defined(ENABLE_ZLIB)
         _compress<ZIP_INFO>();
         break;
-#endif
       }
+#endif
+
+#if defined(ENABLE_ZSTD)
+    case zim::zimcompZstd:
+      {
+        _compress<ZSTD_INFO>();
+        break;
+      }
+#endif
+
     default:
       throw std::runtime_error("We cannot compress an uncompressed cluster");
   };
@@ -202,6 +213,7 @@ void Cluster::write(int out_fd) const
     case zim::zimcompZip:
     case zim::zimcompBzip2:
     case zim::zimcompLzma:
+    case zim::zimcompZstd:
       {
         log_debug("compress data");
         _write(out_fd, compressed_data.data(), compressed_data.size());


### PR DESCRIPTION
Fix for #84.

These changes introduce zstd as an optional dependency for libzim. **The default compression method stays the same (lzma) regardless of whether libzim was compiled with zstd enabled**.

The implementation is based on most basic stream-based Zstd compression API. The compression level is set to the highest value without any means of controlling it from outside.

A new unit test `ClusterTest.read_write_clusterZstd` was created as a clone of `ClusterTest.read_write_clusterLzma`.

As additional testing zim-tools was built with the default compression method set to zstd. The file `wikipedia_en_climate_change_nopic_2020-01.zim` (31MB) found under `tests/data` was successfully recreated with slight (470KB) reduction in size. The runtime of recreation with zstd compression is slower than with the original zimrecreate (19 seconds vs 15 seconds).

zimbench demonstrates 6x improvement in decompression speed for linear access and ~4x improvement for random access:

$ zimbench **orig**/wikipedia_en_climate_change_nopic_2020-01.zim
linear: size=47265248 t=5.423s 184.4 articles/s
random: size=30113230 t=0.154s 6493.51 articles/s

$ zimbench **zstd**/wikipedia_en_climate_change_nopic_2020-01.zim
linear: size=47287455 t=0.893s 1119.82 articles/s
random: size=35435635 t=0.038s 26315.8 articles/s

kiwix/kiwix-build#423 is a prerequisite for this PR. The CI builds of kiwix/kiwix-build#423 have produced artifacts that enabled a [clean CI build of this branch](https://github.com/openzim/libzim/runs/548283975).