### PR TITLE
Use the correct type for our test vector.

### DIFF
--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -29,7 +29,7 @@ namespace
 
 TEST(ClusterIteratorTest, getArticleByClusterOrder)
 {
-    std::vector<int> expected = {
+    std::vector<zim::article_index_type> expected = {
 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,


### PR DESCRIPTION
`Article::getIndex()` return a `zim::article_index_type`, who is an
unsigned int.
Let's use the right type to avoid warning (and error with -Werror) when
comparing values.