### PR TITLE
Fix find function.

### DIFF
--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -74,6 +74,7 @@ namespace zim
 
       const_iterator begin() const;
       const_iterator beginByTitle() const;
+      const_iterator beginByUrl() const;
       const_iterator end() const;
       const_iterator findByTitle(char ns, const std::string& title) const;
       const_iterator find(char ns, const std::string& url) const;

--- a/include/zim/fileiterator.h
+++ b/include/zim/fileiterator.h
@@ -43,7 +43,7 @@ namespace zim
       bool is_end() const  { return file == 0 || idx >= file->getCountArticles(); }
 
     public:
-      explicit const_iterator(const File* file_ = 0, article_index_type idx_ = 0, Mode mode_ = ClusterIterator)
+      explicit const_iterator(const File* file_, article_index_type idx_, Mode mode_)
         : file(file_),
           idx(idx_),
           mode(mode_)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -159,24 +159,27 @@ namespace zim
   }
 
   File::const_iterator File::begin() const
-  { return const_iterator(this, 0); }
+  { return const_iterator(this, 0, const_iterator::ClusterIterator); }
 
   File::const_iterator File::beginByTitle() const
   { return const_iterator(this, 0, const_iterator::ArticleIterator); }
 
+  File::const_iterator File::beginByUrl() const
+  { return const_iterator(this, 0, const_iterator::UrlIterator); }
+
   File::const_iterator File::end() const
-  { return const_iterator(this, getCountArticles()); }
+  { return const_iterator(this, getCountArticles(), const_iterator::UrlIterator); }
 
   File::const_iterator File::find(char ns, const std::string& url) const
   {
     std::pair<bool, article_index_t> r = impl->findx(ns, url);
-    return File::const_iterator(this, article_index_type(r.second));
+    return File::const_iterator(this, article_index_type(r.second), const_iterator::UrlIterator);
   }
 
   File::const_iterator File::find(const std::string& url) const
   {
     std::pair<bool, article_index_t> r = impl->findx(url);
-    return File::const_iterator(this, article_index_type(r.second));
+    return File::const_iterator(this, article_index_type(r.second), const_iterator::UrlIterator);
   }
 
   File::const_iterator File::findByTitle(char ns, const std::string& title) const


### PR DESCRIPTION
Commit fc8949b change the default order of `const_iterator`.
It breaks the `File::find` function as the find function find by url
and create a iterator using the default order.
As the order change, the iterator is broken.

This commit remove the default value of the `const_iterator`, so creating
a iterator need an explicit order.

The `File::begin` create the iterator using the "default" `ClusterIterator`
order.

This also add a method `File::beginByUrl` to allow user code to access
an iterator by url.

Fix kiwix/kiwix-lib#339