### PR TITLE
Correctly wait for the threads' termination before finishing zim creation.

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -89,7 +89,7 @@ namespace zim
       {
         pthread_t thread;
         pthread_create(&thread, NULL, taskRunner, this->data.get());
-        pthread_detach(thread);
+        data->runningWriters.push_back(thread);
       }
 
       pthread_create(&data->writerThread, NULL, clusterWriter, this->data.get());
@@ -197,6 +197,10 @@ namespace zim
       // Quit all compressiont Threads
       for (auto i=0U; i< compressionThreads; i++) {
         data->taskList.pushToQueue(nullptr);
+      }
+
+      for(auto& thread: data->runningWriters) {
+        pthread_join(thread, nullptr);
       }
 
       // Be sure that all cluster are closed

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -66,6 +66,7 @@ namespace zim
         typedef std::vector<Cluster*> ClusterList;
         typedef Queue<Cluster*> ClusterQueue;
         typedef Queue<Task*> TaskQueue;
+        typedef std::vector<pthread_t> ThreadList;
 
         CreatorData(const std::string& fname, bool verbose,
                        bool withIndex, std::string language);
@@ -99,6 +100,7 @@ namespace zim
         ClusterList clustersList;
         ClusterQueue clusterToWrite;
         TaskQueue taskList;
+        ThreadList runningWriters;
         pthread_t  writerThread;
         CompressionType compression = zimcompLzma;
         std::string basename;


### PR DESCRIPTION
We were doing the following in `Creator::finishZimCreation`:
- Wait for workers to finish their tasks
- Send a nullptr per worker as new tasks in the task queue
- [When a worker get a null tasks from the task queue,
   it quit its infinit loop (and so the thread ends).]
- We finish the zim creation and delete the creatorData (and so the
  task queue also).

What may happen is that the last steps of zim creation are really quick
and we delete the creatorData before all worker threads get the
null task from the queue. In this case, worker try to use the task queue
but it is deleted => SIGSEV.

By adding a `thread_join` we ensure that threads have totally end.
(Checking that all tasks have been made is not enough).