### PR TITLE
Fix the path of the temporary index during writing.

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -405,10 +405,10 @@ int mode =  _S_IREAD | _S_IWRITE;
       uncompCluster = new Cluster(zimcompNone);
 
 #if defined(ENABLE_XAPIAN)
-      titleIndexer.indexingPrelude(tmpfname+"_title.idx");
+      titleIndexer.indexingPrelude(basename+"_title.idx");
       if (withIndex) {
           indexer = new XapianIndexer(indexingLanguage, IndexingMode::FULL, true);
-          indexer->indexingPrelude(tmpfname+".idx");
+          indexer->indexingPrelude(basename+".idx");
       }
 #endif
     }

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -109,7 +109,6 @@ namespace zim
         zsize_t clustersSize;
         Cluster *compCluster = nullptr;
         Cluster *uncompCluster = nullptr;
-        std::string tmpfname;
         int out_fd;
 
         bool withIndex;


### PR DESCRIPTION
`tmpfname` is unused and not initialized.
Index path name must be based on `basename`, not `tmpfname`.

Fix #https://github.com/openzim/mwoffliner/pull/1097#issuecomment-625232734