### PR TITLE
Better implementation of the creation of the cluster ordered list.

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -59,7 +59,7 @@ namespace zim
   {
     // read first offset, which specifies, how many offsets we need to read
     OFFSET_TYPE offset;
-    offset = reader->read<OFFSET_TYPE>(offset_t(0));
+    offset = reader->read_uint<OFFSET_TYPE>(offset_t(0));
 
     size_t n_offset = offset / sizeof(OFFSET_TYPE);
     offset_t data_address(offset);
@@ -126,9 +126,9 @@ namespace zim
   template<typename OFFSET_TYPE>
   zsize_t _read_size(const Reader* reader, offset_t offset)
   {
-    OFFSET_TYPE blob_offset = reader->read<OFFSET_TYPE>(offset);
+    OFFSET_TYPE blob_offset = reader->read_uint<OFFSET_TYPE>(offset);
     auto off = offset+offset_t(blob_offset-sizeof(OFFSET_TYPE));
-    auto s = reader->read<OFFSET_TYPE>(off);
+    auto s = reader->read_uint<OFFSET_TYPE>(off);
     return zsize_t(s);
   }
 

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -39,7 +39,7 @@ class Reader {
 
     virtual void read(char* dest, offset_t offset, zsize_t size) const = 0;
     template<typename T>
-    T read(offset_t offset) const {
+    T read_uint(offset_t offset) const {
       ASSERT(offset.v, <, size().v);
       ASSERT(offset.v+sizeof(T), <=, size().v);
       char tmp_buf[sizeof(T)];

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -269,7 +269,17 @@ namespace zim
 
           for(zim::article_index_type i = 0; i < nb_articles; i++)
           {
-              articleListByCluster.push_back(std::make_pair(this->getDirent(article_index_t(i))->getClusterNumber().v, i));
+              // This is the offset of the dirent in the zimFile
+              auto indexOffset = getOffset(urlPtrOffsetReader.get(), i);
+              // Get the mimeType of the dirent (offset 0) to know the type of the dirent
+              uint16_t mimeType = zimReader->read_uint<uint16_t>(indexOffset);
+              if (mimeType==Dirent::redirectMimeType || mimeType==Dirent::linktargetMimeType || mimeType == Dirent::deletedMimeType) {
+                articleListByCluster.push_back(std::make_pair(0, i));
+              } else {
+                // If it is a classic article, get the clusterNumber (at offset 8)
+                auto clusterNumber = zimReader->read_uint<zim::cluster_index_type>(indexOffset+offset_t(8));
+                articleListByCluster.push_back(std::make_pair(clusterNumber, i));
+              }
           }
           std::sort(articleListByCluster.begin(), articleListByCluster.end());
       });

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -364,7 +364,7 @@ namespace zim
     if (idx >= getCountArticles())
       throw ZimFileFormatError("article index out of range");
 
-    article_index_t ret(titleIndexReader->read<article_index_type>(
+    article_index_t ret(titleIndexReader->read_uint<article_index_type>(
                             offset_t(sizeof(article_index_t)*idx.v)));
 
     return ret;
@@ -401,7 +401,7 @@ namespace zim
 
   offset_t FileImpl::getOffset(const Reader* reader, size_t idx)
   {
-    offset_t offset(reader->read<offset_type>(offset_t(sizeof(offset_type)*idx)));
+    offset_t offset(reader->read_uint<offset_type>(offset_t(sizeof(offset_type)*idx)));
     return offset;
   }
 


### PR DESCRIPTION
Using the `getDirent` is too complex for our use case here where we just
want the cluster number.

Directly reading the two integers we need should be pretty more efficient.

Fix #344