### PR TITLE
Fix compression

### DIFF
--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -171,13 +171,15 @@ CompStatus ZSTD_INFO::stream_run_encode(stream_t* stream, CompStep step) {
   stream->avail_out -= outBuf.pos;
   stream->total_out += outBuf.pos;
 
-  if (::ZSTD_isError(ret))
+  if (::ZSTD_isError(ret)) {
     return CompStatus::OTHER;
+  }
 
   if ( step == CompStep::STEP ) {
-    if ( stream->avail_in != 0)
+    if ( stream->avail_in != 0) {
       ASSERT(stream->avail_out, ==, 0u);
       return CompStatus::BUF_ERROR;
+    }
   } else if ( ret > 0 ) {
       return CompStatus::BUF_ERROR;
   }

--- a/src/compression.h
+++ b/src/compression.h
@@ -238,10 +238,15 @@ class Compressor
       stream.next_in = (unsigned char*)data;
       stream.avail_in = size;
       auto errcode = CompStatus::OTHER;
-      while (1) {
+      while (true) {
         errcode = INFO::stream_run_encode(&stream, step);
-        if (errcode == CompStatus::BUF_ERROR) {
-          if (stream.avail_out == 0 && stream.avail_in != 0) {
+        if (stream.avail_out == 0) {
+          if (errcode == CompStatus::OK) {
+            // lzma return a OK return status the first time it runs out of output memory.
+            // The BUF_ERROR is returned only the second time we call a lzma_code.
+            continue;
+          }
+          if (errcode == CompStatus::BUF_ERROR) {
             //Not enought output size
             ret_size *= 2;
             std::unique_ptr<char[]> new_ret_data(new char[ret_size]);
@@ -252,8 +257,10 @@ class Compressor
             continue;
           }
         }
-        if (errcode == CompStatus::STREAM_END || errcode == CompStatus::OK)
+        if (errcode == CompStatus::STREAM_END || errcode == CompStatus::OK) {
+          // Everything ok, quit the loop
           break;
+        }
         return RunnerStatus::ERROR;
       };
       return RunnerStatus::NEED_MORE;

--- a/src/compression.h
+++ b/src/compression.h
@@ -161,6 +161,7 @@ class Uncompressor
     }
 
     std::unique_ptr<char[]> get_data(zim::zsize_t* size) {
+      feed(nullptr, 0, CompStep::FINISH);
       size->v = stream.total_out;
       INFO::stream_end_decode(&stream);
       return std::move(ret_data);

--- a/test/compression.cpp
+++ b/test/compression.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <algorithm>
+#if defined(_MSC_VER)
+# include <BaseTsd.h>
+  typedef SSIZE_T ssize_t;
+#else
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <io.h>
+#include <fileapi.h>
+#undef min
+#undef max
+#endif
+
+#include "gtest/gtest.h"
+
+#include <zim/zim.h>
+
+#include "../src/compression.h"
+
+namespace
+{
+
+template<typename T>
+class CompressionTest : public testing::Test {
+  protected:
+    typedef zim::Compressor<T> CompressorT;
+    typedef zim::Uncompressor<T> DecompressorT;
+};
+
+using CompressionAlgo = ::testing::Types<LZMA_INFO, ZSTD_INFO>;
+
+TYPED_TEST_CASE(CompressionTest, CompressionAlgo);
+
+TYPED_TEST(CompressionTest, compress) {
+  std::string data;
+  data.reserve(100000);
+  for (int i=0; i<100000; i++) {
+    data.append(1, (char)(i%256));
+  }
+  data[99999] = 0;
+
+  auto initialSizes = std::vector<unsigned int>{32, 1024, 1024*1024};
+  auto chunkSizes = std::vector<unsigned long>{32, 512, 1024*1024};
+  for (auto initialSize: initialSizes) {
+    for (auto chunkSize: chunkSizes) {
+      typename TestFixture::CompressorT compressor(initialSize);
+      {
+        bool first=true;
+        unsigned long size = data.size();
+        size_t offset = 0;
+        while (size) {
+          if (first) {
+            compressor.init(const_cast<char*>(data.c_str()));
+            first = false;
+          }
+          auto adjustedChunkSize = std::min(size, chunkSize);
+          compressor.feed(data.c_str()+offset, adjustedChunkSize);
+          offset += adjustedChunkSize;
+          size -= adjustedChunkSize;
+        }
+      }
+
+      zim::zsize_t comp_size;
+      auto comp_data = compressor.get_data(&comp_size);
+
+      typename TestFixture::DecompressorT decompressor(initialSize);
+      {
+        bool first=true;
+        unsigned long size = comp_size.v;
+        size_t offset = 0;
+        while (size) {
+          if (first) {
+            decompressor.init(comp_data.get());
+            first = false;
+          }
+          auto adjustedChunkSize = std::min(size, chunkSize);
+          decompressor.feed(comp_data.get()+offset, adjustedChunkSize);
+          offset += adjustedChunkSize;
+          size -= adjustedChunkSize;
+        }
+      }
+
+      zim::zsize_t decomp_size;
+      auto decomp_data = decompressor.get_data(&decomp_size);
+
+      ASSERT_EQ(decomp_size.v, data.size());
+      ASSERT_EQ(data, std::string(decomp_data.get(), decomp_size.v));
+    }
+  }
+}
+
+
+}  // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -10,7 +10,8 @@ tests = [
     'uuid',
     'template',
     'iterator',
-    'find'
+    'find',
+    'compression'
 ]
 
 if gtest_dep.found() and not meson.is_cross_build()


### PR DESCRIPTION
Add test on the compression/decompression algorithm and fix few (important) issues.

One of the bug leads us to create invalid zim files (kiwix/kiwix-tools#389).
The problem appears when the compressed size was bigger that the initial allocated buffer (1024Kb).
This is especially triggered by the issue (openzim/mwoffliner#1183).