### PR TITLE
Update meson.build, increase test timeout

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -23,7 +23,7 @@ if gtest_dep.found() and not meson.is_cross_build()
                               link_args: extra_link_args,
                               dependencies : deps + [gtest_dep],
                               build_rpath : '$ORIGIN')
-        test(test_name, test_exe, timeout : 60)
+        test(test_name, test_exe, timeout : 120)
     endforeach
 endif
 


### PR DESCRIPTION
This allows slow architectures such as emulated riscv64 in Ubuntu to successfully finish the build process.
https://launchpad.net/ubuntu/+source/zimlib/6.1.3-4ubuntu2

also, please have a look at:
https://bugs.debian.org/964196
containing more details on the issue