### PR TITLE
Increase the test timeout a little bit, to help slow architectures

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -23,7 +23,7 @@ if gtest_dep.found() and not meson.is_cross_build()
                               link_args: extra_link_args,
                               dependencies : deps + [gtest_dep],
                               build_rpath : '$ORIGIN')
-        test(test_name, test_exe, timeout : 60)
+        test(test_name, test_exe, timeout : 90)
     endforeach
 endif
 


### PR DESCRIPTION
On some of the slower (emulated) qemu architectures, such as riscv64,
it's taking around 80 seconds to run the tests, causing build failures.

Bumping the timeout to 90 seconds should resolve the issue.

Originally reported downstream at <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964196>.