### PR TITLE
Compression type can be passed to zim::writer::Creator

### DIFF
--- a/examples/createZimExample.cpp
+++ b/examples/createZimExample.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
 {
   unsigned max = 16;
   try {
-    zim::writer::Creator c;
+    zim::writer::Creator c(false, zim::zimcompZstd);
     c.startZimCreation("foo.zim");
     for (unsigned n = 0; n < max; ++n)
     {

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -33,7 +33,7 @@ namespace zim
     class Creator
     {
       public:
-        Creator(bool verbose = false);
+        Creator(bool verbose = false, CompressionType c = zimcompLzma);
         virtual ~Creator();
 
         zim::size_type getMinChunkSize() const { return minChunkSize; }
@@ -55,6 +55,7 @@ namespace zim
       private:
         std::unique_ptr<CreatorData> data;
         bool verbose;
+        const CompressionType compression;
         bool withIndex = false;
         size_t minChunkSize = 1024-64;
         std::string indexingLanguage;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -74,15 +74,16 @@ namespace zim
 {
   namespace writer
   {
-    Creator::Creator(bool verbose)
+    Creator::Creator(bool verbose, CompressionType c)
       : verbose(verbose)
+      , compression(c)
     {}
 
     Creator::~Creator() = default;
 
     void Creator::startZimCreation(const std::string& fname)
     {
-      data = std::unique_ptr<CreatorData>(new CreatorData(fname, verbose, withIndex, indexingLanguage));
+      data = std::unique_ptr<CreatorData>(new CreatorData(fname, verbose, withIndex, indexingLanguage, compression));
       data->setMinChunkSize(minChunkSize);
 
       for(unsigned i=0; i<nbWorkerThreads; i++)
@@ -360,8 +361,10 @@ namespace zim
     CreatorData::CreatorData(const std::string& fname,
                                    bool verbose,
                                    bool withIndex,
-                                   std::string language)
-      : withIndex(withIndex),
+                                   std::string language,
+                                   CompressionType c)
+      : compression(c),
+        withIndex(withIndex),
         indexingLanguage(language),
 #if defined(ENABLE_XAPIAN)
         titleIndexer(language, IndexingMode::TITLE, true),
@@ -370,12 +373,12 @@ namespace zim
         nbArticles(0),
         nbRedirectArticles(0),
         nbCompArticles(0),
-	nbUnCompArticles(0),
-	nbFileArticles(0),
-	nbIndexArticles(0),
-	nbClusters(0),
-	nbCompClusters(0),
-	nbUnCompClusters(0),
+        nbUnCompArticles(0),
+        nbFileArticles(0),
+        nbIndexArticles(0),
+        nbClusters(0),
+        nbCompClusters(0),
+        nbUnCompClusters(0),
         start_time(time(NULL))
     {
       basename =  (fname.size() > 4 && fname.compare(fname.size() - 4, 4, ".zim") == 0)

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -69,7 +69,8 @@ namespace zim
         typedef std::vector<pthread_t> ThreadList;
 
         CreatorData(const std::string& fname, bool verbose,
-                       bool withIndex, std::string language);
+                       bool withIndex, std::string language,
+                       CompressionType compression);
         virtual ~CreatorData();
 
         void addDirent(Dirent* dirent, const Article* article);
@@ -102,7 +103,7 @@ namespace zim
         TaskQueue taskList;
         ThreadList workerThreads;
         pthread_t  writerThread;
-        CompressionType compression = zimcompLzma;
+        const CompressionType compression;
         std::string basename;
         bool isEmpty = true;
         bool isExtended = false;


### PR DESCRIPTION
Will fix #360

The default compression type is still LZMA. Client code can create ZIM files with a different compression type by passing an extra argument to the `zim::writer::Creator` constructor.

An alternative was to make libzim pick up the compression type from an environment variable, in which case no changes would need to be made in client code and all tools would automatically benefit from this enhancement. However in a slack discussion with @kelson the choice wad made in favour of hard control over the compression method via the libzim API.