### PR TITLE
Better management of temporary files in unit-tests

### DIFF
--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -32,7 +32,6 @@
 #endif
 
 #ifdef _WIN32
-#include <codecvt>
 #include <windows.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -56,50 +55,12 @@
 #include "../src/endian_tools.h"
 #include "../src/config.h"
 
+#include "tempfile.h"
+
 namespace
 {
 
-class TempFile
-{
-  int fd_;
-#ifndef _WIN32
-  std::string path_;
-#endif
-public:
-  explicit TempFile(const char* name)
-  {
-#ifdef _WIN32
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8ToUtf16;
-    wchar_t cbase[MAX_PATH];
-    wchar_t ctmp[MAX_PATH];
-    const std::wstring wname = utf8ToUtf16.from_bytes(name);
-    GetTempPathW(MAX_PATH-(wname.size()+2), cbase);
-    // This create a file for us, ensure it is unique.
-    // So we need to delete it and create the directory using the same name.
-    GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
-    auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
-#else
-    const char* const TMPDIR = std::getenv("TMPDIR");
-    const std::string tmpdir(TMPDIR ? TMPDIR : "/tmp");
-    path_ = tmpdir + "/" + name + "_XXXXXX";
-    auto tmp_fd = mkstemp(&path_[0]);
-#endif
-    fd_ = tmp_fd;
-  }
-
-  TempFile(const TempFile& ) = delete;
-  void operator=(const TempFile& ) = delete;
-
-  ~TempFile()
-  {
-    close(fd_);
-#ifndef _WIN32
-    unlink(path_.c_str());
-#endif
-  }
-
-  int fd() const { return fd_; }
-};
+using zim::unittests::TempFile;
 
 std::shared_ptr<zim::Buffer> write_to_buffer(zim::writer::Cluster& cluster)
 {

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -66,19 +66,19 @@ public:
   TempFile()
   {
 #ifdef _WIN32
-  wchar_t cbase[MAX_PATH];
-  wchar_t ctmp[MAX_PATH];
-  GetTempPathW(MAX_PATH-14, cbase);
-  // This create a file for us, ensure it is unique.
-  // So we need to delete it and create the directory using the same name.
-  GetTempFileNameW(cbase, L"test_cluster", 0, ctmp);
-  auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
+    wchar_t cbase[MAX_PATH];
+    wchar_t ctmp[MAX_PATH];
+    GetTempPathW(MAX_PATH-14, cbase);
+    // This create a file for us, ensure it is unique.
+    // So we need to delete it and create the directory using the same name.
+    GetTempFileNameW(cbase, L"test_cluster", 0, ctmp);
+    auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
 #else
-  char tmpl[] = "/tmp/test_cluster_XXXXXX";
-  auto tmp_fd = mkstemp(tmpl);
-  path_ = tmpl;
+    char tmpl[] = "/tmp/test_cluster_XXXXXX";
+    auto tmp_fd = mkstemp(tmpl);
+    path_ = tmpl;
 #endif
-  fd_ = tmp_fd;
+    fd_ = tmp_fd;
   }
 
   TempFile(const TempFile& ) = delete;

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #ifdef _WIN32
+#include <codecvt>
 #include <windows.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -61,22 +62,25 @@ namespace
 class TempFile
 {
   int fd_;
+#ifndef _WIN32
   std::string path_;
+#endif
 public:
-  TempFile()
+  explicit TempFile(const char* name)
   {
 #ifdef _WIN32
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8ToUtf16;
     wchar_t cbase[MAX_PATH];
     wchar_t ctmp[MAX_PATH];
-    GetTempPathW(MAX_PATH-14, cbase);
+    const std::wstring wname = utf8ToUtf16.from_bytes(name);
+    GetTempPathW(MAX_PATH-(wname.size()+2), cbase);
     // This create a file for us, ensure it is unique.
     // So we need to delete it and create the directory using the same name.
-    GetTempFileNameW(cbase, L"test_cluster", 0, ctmp);
+    GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
     auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
 #else
-    char tmpl[] = "/tmp/test_cluster_XXXXXX";
-    auto tmp_fd = mkstemp(tmpl);
-    path_ = tmpl;
+    path_ = std::string("/tmp/") + name + "_XXXXXX";
+    auto tmp_fd = mkstemp(&path_[0]);
 #endif
     fd_ = tmp_fd;
   }
@@ -97,7 +101,7 @@ public:
 
 std::shared_ptr<zim::Buffer> write_to_buffer(zim::writer::Cluster& cluster)
 {
-  TempFile tmpFile;
+  const TempFile tmpFile("test_cluster");
   cluster.close();
   const auto tmp_fd = tmpFile.fd();
   cluster.write(tmp_fd);

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -79,7 +79,9 @@ public:
     GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
     auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
 #else
-    path_ = std::string("/tmp/") + name + "_XXXXXX";
+    const char* const TMPDIR = std::getenv("TMPDIR");
+    const std::string tmpdir(TMPDIR ? TMPDIR : "/tmp");
+    path_ = tmpdir + "/" + name + "_XXXXXX";
     auto tmp_fd = mkstemp(&path_[0]);
 #endif
     fd_ = tmp_fd;

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,7 +16,7 @@ tests = [
 
 if gtest_dep.found() and not meson.is_cross_build()
     foreach test_name : tests
-        test_exe = executable(test_name, [test_name+'.cpp'],
+        test_exe = executable(test_name, [test_name+'.cpp', 'tempfile.cpp'],
                               implicit_include_directories: false,
                               include_directories : [include_directory, src_directory],
                               link_with : libzim,

--- a/test/tempfile.cpp
+++ b/test/tempfile.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "tempfile.h"
+
+#include <string>
+
+#ifdef _WIN32
+#include <codecvt>
+#include <windows.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <io.h>
+#include <fileapi.h>
+#undef min
+#undef max
+#else
+#include <unistd.h>
+#endif
+
+namespace zim
+{
+
+namespace unittests
+{
+
+TempFile::TempFile(const char* name)
+{
+#ifdef _WIN32
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8ToUtf16;
+  wchar_t cbase[MAX_PATH];
+  wchar_t ctmp[MAX_PATH];
+  const std::wstring wname = utf8ToUtf16.from_bytes(name);
+  GetTempPathW(MAX_PATH-(wname.size()+2), cbase);
+  // This create a file for us, ensure it is unique.
+  // So we need to delete it and create the directory using the same name.
+  GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
+  auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
+#else
+  const char* const TMPDIR = std::getenv("TMPDIR");
+  const std::string tmpdir(TMPDIR ? TMPDIR : "/tmp");
+  path_ = tmpdir + "/" + name + "_XXXXXX";
+  auto tmp_fd = mkstemp(&path_[0]);
+#endif
+  fd_ = tmp_fd;
+}
+
+TempFile::~TempFile()
+{
+  close(fd_);
+#ifndef _WIN32
+  unlink(path_.c_str());
+#endif
+}
+
+} // namespace unittests
+
+} // namespace zim

--- a/test/tempfile.h
+++ b/test/tempfile.h
@@ -1,0 +1,72 @@
+#ifndef ZIM_TEST_TEMPFILE_H
+#define ZIM_TEST_TEMPFILE_H
+
+#include <string>
+
+#ifdef _WIN32
+#include <codecvt>
+#include <windows.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <io.h>
+#include <fileapi.h>
+#undef min
+#undef max
+#else
+#include <unistd.h>
+#endif
+
+namespace zim
+{
+
+namespace unittests
+{
+
+class TempFile
+{
+  int fd_;
+#ifndef _WIN32
+  std::string path_;
+#endif
+public:
+  explicit TempFile(const char* name)
+  {
+#ifdef _WIN32
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8ToUtf16;
+    wchar_t cbase[MAX_PATH];
+    wchar_t ctmp[MAX_PATH];
+    const std::wstring wname = utf8ToUtf16.from_bytes(name);
+    GetTempPathW(MAX_PATH-(wname.size()+2), cbase);
+    // This create a file for us, ensure it is unique.
+    // So we need to delete it and create the directory using the same name.
+    GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
+    auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
+#else
+    const char* const TMPDIR = std::getenv("TMPDIR");
+    const std::string tmpdir(TMPDIR ? TMPDIR : "/tmp");
+    path_ = tmpdir + "/" + name + "_XXXXXX";
+    auto tmp_fd = mkstemp(&path_[0]);
+#endif
+    fd_ = tmp_fd;
+  }
+
+  TempFile(const TempFile& ) = delete;
+  void operator=(const TempFile& ) = delete;
+
+  ~TempFile()
+  {
+    close(fd_);
+#ifndef _WIN32
+    unlink(path_.c_str());
+#endif
+  }
+
+  int fd() const { return fd_; }
+};
+
+} // namespace unittests
+
+} // namespace zim
+
+#endif // ZIM_TEST_TEMPFILE_H

--- a/test/tempfile.h
+++ b/test/tempfile.h
@@ -1,21 +1,26 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
 #ifndef ZIM_TEST_TEMPFILE_H
 #define ZIM_TEST_TEMPFILE_H
 
 #include <string>
-
-#ifdef _WIN32
-#include <codecvt>
-#include <windows.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <io.h>
-#include <fileapi.h>
-#undef min
-#undef max
-#else
-#include <unistd.h>
-#endif
 
 namespace zim
 {
@@ -30,37 +35,12 @@ class TempFile
   std::string path_;
 #endif
 public:
-  explicit TempFile(const char* name)
-  {
-#ifdef _WIN32
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> utf8ToUtf16;
-    wchar_t cbase[MAX_PATH];
-    wchar_t ctmp[MAX_PATH];
-    const std::wstring wname = utf8ToUtf16.from_bytes(name);
-    GetTempPathW(MAX_PATH-(wname.size()+2), cbase);
-    // This create a file for us, ensure it is unique.
-    // So we need to delete it and create the directory using the same name.
-    GetTempFileNameW(cbase, wname.c_str(), 0, ctmp);
-    auto tmp_fd = _wopen(ctmp, _O_CREAT | _O_TEMPORARY | _O_SHORT_LIVED | _O_RDWR | _O_TRUNC);
-#else
-    const char* const TMPDIR = std::getenv("TMPDIR");
-    const std::string tmpdir(TMPDIR ? TMPDIR : "/tmp");
-    path_ = tmpdir + "/" + name + "_XXXXXX";
-    auto tmp_fd = mkstemp(&path_[0]);
-#endif
-    fd_ = tmp_fd;
-  }
+  explicit TempFile(const char* name);
 
   TempFile(const TempFile& ) = delete;
   void operator=(const TempFile& ) = delete;
 
-  ~TempFile()
-  {
-    close(fd_);
-#ifndef _WIN32
-    unlink(path_.c_str());
-#endif
-  }
+  ~TempFile();
 
   int fd() const { return fd_; }
 };


### PR DESCRIPTION
1. In `cluster`, `dirent` and `header` unit-tests there was some duplication of code related to temporary files. That duplication was eliminated with the introduction of `test/tempfile.h`. This change also fixes a potential leak of temporary files when an exception is thrown during the execution of the unit-test.

2. Besides, under POSIX-like OS-es creation of temporary files now respects the value of the `TMPDIR` environment variable (if the latter is not set, `/tmp` is assumed). This change enables to run unit-tests in a `tmpfs` filesystem (e.g. `/run/user/USERID`) which reduces the wear of SSD storage on modern hardware during a quick-paced edit-save-build-and-test development mode.

It should be slightly more convenient to review this PR commit-by-commit.