### PR TITLE
PPA: Set fail-fast: false

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,7 @@ jobs:
   build-deb:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         distro: [debian-unstable, debian-bullseye, debian-buster, ubuntu-groovy, ubuntu-focal, ubuntu-eoan]
     steps:


### PR DESCRIPTION
Occasionally some distros will fail to build, e.g. right
now unstable and groovy are broken because of 
<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=965033>.

Setting fail-fast: false will allow those that do work to
continue to build so a failure in one place doesn't
affect everything else.