### PR TITLE
PPA: Drop eoan and sync with proper Debian package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,9 +7,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [debian-unstable, debian-bullseye, debian-buster, ubuntu-groovy, ubuntu-focal, ubuntu-eoan]
+        distro: [debian-unstable, debian-bullseye, debian-buster, ubuntu-groovy, ubuntu-focal]
     steps:
       - uses: actions/checkout@v2
+
+      # Determine which PPA we should upload to
+      - name: PPA
+        id: ppa
+        run: |
+          if [[ $REF == refs/tags* ]]
+          then
+            echo "::set-output name=ppa::kiwixteam/release"
+          else
+            echo "::set-output name=ppa::kiwixteam/dev"
+          fi
+        env:
+          REF: ${{ github.ref }}
 
       - uses: legoktm/gh-action-auto-dch@master
         with:
@@ -44,6 +57,7 @@ jobs:
         id: build-ubuntu-groovy
         with:
           args: --no-sign
+          ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: legoktm/gh-action-build-deb@ubuntu-focal
         if: matrix.distro == 'ubuntu-focal'
@@ -51,13 +65,7 @@ jobs:
         id: build-ubuntu-focal
         with:
           args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@ubuntu-eoan
-        if: matrix.distro == 'ubuntu-eoan'
-        name: Build package for ubuntu-eoan
-        id: build-ubuntu-eoan
-        with:
-          args: --no-sign
+          ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: zimlib
 Section: libs
 Priority: optional
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
  liblzma-dev,
  zlib1g-dev,
  libicu-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export SKIP_BIG_MEMORY_TEST=1
 %:
 	dh $@ --buildsystem=meson
+
+# Increase test timeout
+override_dh_auto_test:
+	dh_auto_test -- -t 3


### PR DESCRIPTION
Two commits:

PPA: Stop building for Ubuntu eoan, its EOL

Launchpad no longer accepts uploads for eoan.

While we're at it, restore the PPA as a build dependency for the package. I
had earlier removed it on the basis that zimlib didn't depend on any local
packages, but if we need to backport any extra dependencies (like I want to
for a newer debhelper), then we need to rely on the PPA. Also it's easier to
keep all the CI definitions the same anyways.

----
 debian: Sync with proper Debian package

* Switch to debhelper 13
* Bump build timeout via `meson test` (this will fix the few remaining timeouts I see on launchpad builds which is using some really resource limited/slow amd64 builders...)