### PR TITLE
Improvement of concurrent access to cluster cache

### DIFF
--- a/src/concurrent_cache.h
+++ b/src/concurrent_cache.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_CONCURRENT_CACHE_H
+#define ZIM_CONCURRENT_CACHE_H
+
+#include "lrucache.h"
+
+#include <future>
+#include <pthread.h>
+
+namespace zim
+{
+
+/**
+   ConcurrentCache implements a concurrent thread-safe cache
+
+   Compared to zim::lru_cache, each access operation is slightly more expensive.
+   However, different slots of the cache can be safely accessed concurrently
+   with minimal blocking. Concurrent access to the same element is also
+   safe, and, in case of a cache miss, will block until that element becomes
+   available.
+ */
+template <typename Key, typename Value>
+class ConcurrentCache
+{
+private: // types
+  typedef std::shared_future<Value> ValuePlaceholder;
+  typedef lru_cache<Key, ValuePlaceholder> Impl;
+
+public: // types
+  explicit ConcurrentCache(size_t maxEntries)
+    : impl_(maxEntries)
+    , lock_(PTHREAD_MUTEX_INITIALIZER)
+  {}
+
+  // Gets the entry corresponding to the given key. If the entry is not in the
+  // cache, it is obtained by calling f() (without any arguments) and the
+  // result is put into the cache.
+  //
+  // The cache as a whole is locked only for the duration of accessing
+  // the respective slot. If, in the case of the a cache miss, the generation
+  // of the missing element takes a long time, only attempts to access that
+  // element will block - the rest of the cache remains open to concurrent
+  // access.
+  template<class F>
+  Value getOrPut(const Key& key, F f)
+  {
+    std::promise<Value> valuePromise;
+    pthread_mutex_lock(&lock_);
+    const auto x = impl_.getOrPut(key, valuePromise.get_future().share());
+    pthread_mutex_unlock(&lock_);
+    if ( x.miss() ) {
+      valuePromise.set_value(f());
+    }
+
+    return x.value().get();
+  }
+
+private: // data
+  Impl impl_;
+  pthread_mutex_t lock_;
+};
+
+} // namespace zim
+
+#endif // ZIM_CONCURRENT_CACHE_H
+

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <future>
 #include <pthread.h>
 #include <zim/zim.h>
 #include <zim/fileheader.h>
@@ -54,7 +55,9 @@ namespace zim
       lru_cache<article_index_t, std::shared_ptr<const Dirent>> direntCache;
       pthread_mutex_t direntCacheLock;
 
-      lru_cache<cluster_index_t, std::shared_ptr<const Cluster>> clusterCache;
+      typedef std::shared_ptr<const Cluster> ClusterHandle;
+      typedef std::shared_future<ClusterHandle> ClusterFuture;
+      lru_cache<cluster_index_t, ClusterFuture> clusterCache;
       pthread_mutex_t clusterCacheLock;
 
       bool cacheUncompressedCluster;
@@ -113,7 +116,7 @@ namespace zim
       bool is_multiPart() const;
 
   private:
-      std::shared_ptr<const Cluster> readCluster(cluster_index_t idx);
+      ClusterHandle readCluster(cluster_index_t idx);
   };
 
 }

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -24,12 +24,12 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include <future>
 #include <pthread.h>
 #include <zim/zim.h>
 #include <zim/fileheader.h>
 #include <mutex>
 #include "lrucache.h"
+#include "concurrent_cache.h"
 #include "_dirent.h"
 #include "cluster.h"
 #include "buffer.h"
@@ -56,9 +56,7 @@ namespace zim
       pthread_mutex_t direntCacheLock;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
-      typedef std::shared_future<ClusterHandle> ClusterFuture;
-      lru_cache<cluster_index_t, ClusterFuture> clusterCache;
-      pthread_mutex_t clusterCacheLock;
+      ConcurrentCache<cluster_index_t, ClusterHandle> clusterCache;
 
       bool cacheUncompressedCluster;
       typedef std::map<char, article_index_t> NamespaceCache;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -54,7 +54,7 @@ namespace zim
       lru_cache<article_index_t, std::shared_ptr<const Dirent>> direntCache;
       pthread_mutex_t direntCacheLock;
 
-      lru_cache<cluster_index_t, std::shared_ptr<Cluster>> clusterCache;
+      lru_cache<cluster_index_t, std::shared_ptr<const Cluster>> clusterCache;
       pthread_mutex_t clusterCacheLock;
 
       bool cacheUncompressedCluster;
@@ -111,6 +111,9 @@ namespace zim
       std::string getChecksum();
       bool verify();
       bool is_multiPart() const;
+
+  private:
+      std::shared_ptr<const Cluster> readCluster(cluster_index_t idx);
   };
 
 }

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -34,34 +34,43 @@
  */
 
 #ifndef _LRUCACHE_HPP_INCLUDED_
-#define	_LRUCACHE_HPP_INCLUDED_
+#define _LRUCACHE_HPP_INCLUDED_
 
 #include <map>
 #include <list>
 #include <cstddef>
 #include <stdexcept>
+#include <cassert>
 
 namespace zim {
 
 template<typename key_t, typename value_t>
 class lru_cache {
 public: // types
-	typedef typename std::pair<key_t, value_t> key_value_pair_t;
-	typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
+  typedef typename std::pair<key_t, value_t> key_value_pair_t;
+  typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
+
+  enum AccessStatus {
+    HIT, // key was found in the cache
+    PUT, // key was not in the cache but was created by the getOrPut() access
+    MISS // key was not in the cache; get() access failed
+  };
 
   class AccessResult
   {
-    const bool hit_;
+    const AccessStatus status_;
     const value_t val_;
   public:
-    explicit AccessResult(const value_t& val) : hit_(true), val_(val) {}
-    AccessResult() : hit_(false), val_() {}
+    AccessResult(const value_t& val, AccessStatus status)
+      : status_(status), val_(val)
+    {}
+    AccessResult() : status_(MISS), val_() {}
 
-    bool hit() const { return hit_; }
+    bool hit() const { return status_ == HIT; }
     bool miss() const { return !hit(); }
     const value_t& value() const
     {
-      if ( miss() )
+      if ( status_ == MISS )
         throw std::range_error("There is no such key in cache");
       return val_;
     }
@@ -70,51 +79,71 @@ public: // types
   };
 
 public: // functions
-	explicit lru_cache(size_t max_size) :
-		_max_size(max_size) {
-	}
+  explicit lru_cache(size_t max_size) :
+    _max_size(max_size) {
+  }
 
-	void put(const key_t& key, const value_t& value) {
-		auto it = _cache_items_map.find(key);
-		if (it != _cache_items_map.end()) {
-			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
-      it->second->second = value;
-		} else {
-      _cache_items_list.push_front(key_value_pair_t(key, value));
-		  _cache_items_map[key] = _cache_items_list.begin();
-      if (_cache_items_map.size() > _max_size) {
-        auto last = _cache_items_list.end();
-        last--;
-        _cache_items_map.erase(last->first);
-        _cache_items_list.pop_back();
-      }
+  // If 'key' is present in the cache, returns the associated value,
+  // otherwise puts the given value into the cache (and returns it with
+  // a status of a cache miss).
+  AccessResult getOrPut(const key_t& key, const value_t& value) {
+    auto it = _cache_items_map.find(key);
+    if (it != _cache_items_map.end()) {
+      _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+      return AccessResult(it->second->second, HIT);
+    } else {
+      putMissing(key, value);
+      return AccessResult(value, PUT);
     }
-	}
+  }
 
-	AccessResult get(const key_t& key) {
-		auto it = _cache_items_map.find(key);
-		if (it == _cache_items_map.end()) {
-			return AccessResult();
-		} else {
-			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
-			return AccessResult(it->second->second);
-		}
-	}
+  void put(const key_t& key, const value_t& value) {
+    auto it = _cache_items_map.find(key);
+    if (it != _cache_items_map.end()) {
+      _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+      it->second->second = value;
+    } else {
+      putMissing(key, value);
+    }
+  }
 
-	bool exists(const key_t& key) const {
-		return _cache_items_map.find(key) != _cache_items_map.end();
-	}
+  AccessResult get(const key_t& key) {
+    auto it = _cache_items_map.find(key);
+    if (it == _cache_items_map.end()) {
+      return AccessResult();
+    } else {
+      _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+      return AccessResult(it->second->second, HIT);
+    }
+  }
 
-	size_t size() const {
-		return _cache_items_map.size();
-	}
+  bool exists(const key_t& key) const {
+    return _cache_items_map.find(key) != _cache_items_map.end();
+  }
+
+  size_t size() const {
+    return _cache_items_map.size();
+  }
+
+private: // functions
+  void putMissing(const key_t& key, const value_t& value) {
+    assert(_cache_items_map.find(key) == _cache_items_map.end());
+    _cache_items_list.push_front(key_value_pair_t(key, value));
+    _cache_items_map[key] = _cache_items_list.begin();
+    if (_cache_items_map.size() > _max_size) {
+      auto last = _cache_items_list.end();
+      last--;
+      _cache_items_map.erase(last->first);
+      _cache_items_list.pop_back();
+    }
+  }
 
 private: // data
-	std::list<key_value_pair_t> _cache_items_list;
-	std::map<key_t, list_iterator_t> _cache_items_map;
-	size_t _max_size;
+  std::list<key_value_pair_t> _cache_items_list;
+  std::map<key_t, list_iterator_t> _cache_items_map;
+  size_t _max_size;
 };
 
 } // namespace zim
 
-#endif	/* _LRUCACHE_HPP_INCLUDED_ */
+#endif  /* _LRUCACHE_HPP_INCLUDED_ */

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -131,9 +131,7 @@ private: // functions
     _cache_items_list.push_front(key_value_pair_t(key, value));
     _cache_items_map[key] = _cache_items_list.begin();
     if (_cache_items_map.size() > _max_size) {
-      auto last = _cache_items_list.end();
-      last--;
-      _cache_items_map.erase(last->first);
+      _cache_items_map.erase(_cache_items_list.back().first);
       _cache_items_list.pop_back();
     }
   }


### PR DESCRIPTION
This PR addresses #379 only with respect to the cluster cache.

The fix eliminates the possibility of the same cache entry being generated simultaneously from parallel threads (resulting in waste of CPU time and memory). It comes at the cost of slightly more expensive cache hits (a `std::shared_future` object, which is roughly equivalent to a shared pointer is created for every cache access). This is unavoidable if we want the cache access to be absolutely safe.

I wonder if the same approach should be applied to the dirent cache.