### PR TITLE
Added a unit-test checking correct handling of multipart ZIM files

### DIFF
--- a/test/zimfile.cpp
+++ b/test/zimfile.cpp
@@ -157,6 +157,7 @@ TEST(ZimFile, openRealZimFile)
   }
 }
 
+#if ! defined(__APPLE__)
 TEST(ZimFile, multipart)
 {
   const zim::File zimfile1("./data/wikibooks_be_all_nopic_2017-02.zim");
@@ -201,5 +202,6 @@ TEST(ZimFile, multipart)
     );
   }
 }
+#endif // ! defined(__APPLE__)
 
 } // unnamed namespace

--- a/test/zimfile.cpp
+++ b/test/zimfile.cpp
@@ -157,4 +157,45 @@ TEST(ZimFile, openRealZimFile)
   }
 }
 
+TEST(ZimFile, multipart)
+{
+  const zim::File zimfile1("./data/wikibooks_be_all_nopic_2017-02.zim");
+  const zim::File zimfile2("./data/wikibooks_be_all_nopic_2017-02_splitted.zim");
+  ASSERT_FALSE(zimfile1.is_multiPart());
+  ASSERT_TRUE (zimfile2.is_multiPart());
+
+  EXPECT_EQ(zimfile1.getFilesize(), zimfile2.getFilesize());
+  EXPECT_EQ(zimfile1.getCountClusters(), zimfile2.getCountClusters());
+  EXPECT_EQ(zimfile1.getNamespaces(), zimfile2.getNamespaces());
+
+  ASSERT_EQ(zimfile1.getCountArticles(), zimfile2.getCountArticles());
+
+  ASSERT_EQ(118, zimfile1.getCountArticles()); // ==> below loop is not a noop
+  for ( zim::article_index_type i = 0; i < zimfile1.getCountArticles(); ++i ) {
+    const zim::Article article1 = zimfile1.getArticle(i);
+    const zim::Article article2 = zimfile2.getArticle(i);
+    ASSERT_EQ(i, article1.getIndex());
+    ASSERT_EQ(i, article2.getIndex());
+    ASSERT_EQ(article1.getParameter(), article2.getParameter());
+    ASSERT_EQ(article1.getTitle(), article2.getTitle());
+    ASSERT_EQ(article1.getUrl(), article2.getUrl());
+    ASSERT_EQ(article1.getLongUrl(), article2.getLongUrl());
+    ASSERT_EQ(article1.getLibraryMimeType(), article2.getLibraryMimeType());
+    ASSERT_EQ(article1.isRedirect(), article2.isRedirect());
+    ASSERT_EQ(article1.isLinktarget(), article2.isLinktarget());
+    ASSERT_EQ(article1.isDeleted(), article2.isDeleted());
+    ASSERT_EQ(article1.getNamespace(), article2.getNamespace());
+    ASSERT_EQ(article1.getArticleSize(), article2.getArticleSize());
+    ASSERT_EQ(article1.getData(), article2.getData());
+    ASSERT_EQ(article1.getClusterNumber(), article2.getClusterNumber());
+    ASSERT_EQ(article1.getOffset(), article2.getOffset());
+    ASSERT_EQ(zimfile1.getArticleByTitle(i).getIndex(),
+              zimfile2.getArticleByTitle(i).getIndex()
+    );
+    ASSERT_EQ(zimfile1.getArticleByClusterOrder(i).getIndex(),
+              zimfile2.getArticleByClusterOrder(i).getIndex()
+    );
+  }
+}
+
 } // unnamed namespace

--- a/test/zimfile.cpp
+++ b/test/zimfile.cpp
@@ -172,10 +172,12 @@ TEST(ZimFile, multipart)
 
   ASSERT_EQ(118, zimfile1.getCountArticles()); // ==> below loop is not a noop
   for ( zim::article_index_type i = 0; i < zimfile1.getCountArticles(); ++i ) {
-    const zim::Article article1 = zimfile1.getArticle(i);
-    const zim::Article article2 = zimfile2.getArticle(i);
+    zim::Article article1 = zimfile1.getArticle(i);
+    zim::Article article2 = zimfile2.getArticle(i);
     ASSERT_EQ(i, article1.getIndex());
     ASSERT_EQ(i, article2.getIndex());
+    ASSERT_EQ(article1.getClusterNumber(), article2.getClusterNumber());
+    ASSERT_EQ(article1.getOffset(), article2.getOffset());
     ASSERT_EQ(article1.getParameter(), article2.getParameter());
     ASSERT_EQ(article1.getTitle(), article2.getTitle());
     ASSERT_EQ(article1.getUrl(), article2.getUrl());
@@ -187,8 +189,10 @@ TEST(ZimFile, multipart)
     ASSERT_EQ(article1.getNamespace(), article2.getNamespace());
     ASSERT_EQ(article1.getArticleSize(), article2.getArticleSize());
     ASSERT_EQ(article1.getData(), article2.getData());
-    ASSERT_EQ(article1.getClusterNumber(), article2.getClusterNumber());
-    ASSERT_EQ(article1.getOffset(), article2.getOffset());
+    if ( !article1.isRedirect() && ! article1.isLinktarget() && !article1.isLinktarget() ) {
+      ASSERT_EQ(article1.getPage(true, 5), article2.getPage(true, 5));
+      ASSERT_EQ(article1.getPage(false, 5), article2.getPage(false, 5));
+    }
     ASSERT_EQ(zimfile1.getArticleByTitle(i).getIndex(),
               zimfile2.getArticleByTitle(i).getIndex()
     );


### PR DESCRIPTION
Besides checking that multi-part ZIM files are handled correctly, the new unit-test also significantly increase the coverage of libzim. Actually, that's the main reason why I added it: while working on optimization of caching in libzim I found out that libzim's own unit-tests don't cover relevant code (`zim::FileImpl::getCluster()`), so I had to test those changes via kiwix-lib. However, though the new unit-test exercises `zim::FileImpl::getCluster()`, a separate unit-test focusing on cache access patterns is still needed (this one was simply a low-hanging fruit).

Regarding `Article::getPage()`, it turned out that data needed for meaningful operation of `Article::getPage()` misses from the test ZIM files, so I wonder if it makes sense to keep my second commit (a separate unit test for `Article::getPage()` should be created anyway, but that's not a priority for me now).