### PR TITLE
Support for meson versions before 0.47

### DIFF
--- a/test/data/meson.build
+++ b/test/data/meson.build
@@ -7,5 +7,21 @@ data_files = [
 ]
 
 foreach file : data_files
-  configure_file(input : file, output : file, copy: true)
+  # configure_file(input : file, output : file, copy: true)
+  #
+  # Above (commented) command doesn't work with Meson versions below 0.47
+  # (in which the 'copy' keyword was first introduced). We want to keep
+  # compatibility with Ubuntu 18.04 Bionic (which has Meson version 0.45)
+  # until its EOL.
+  #
+  # Below is a python based workaround.
+  configure_file(input : file,
+                 output : file,
+                 command: [
+                   find_program('python3'),
+                    '-c',
+                    'import sys; import shutil; shutil.copy(sys.argv[1], sys.argv[2])',
+                    '@INPUT@',
+                    '@OUTPUT@'
+                 ])
 endforeach


### PR DESCRIPTION
Will fix #388 

The `copy` keyword argument of `configure_file()` first appears in meson 0.47. Now performing file copy via python.