### PR TITLE
Fix for issue #398

### DIFF
--- a/test/zimfile.cpp
+++ b/test/zimfile.cpp
@@ -157,7 +157,6 @@ TEST(ZimFile, openRealZimFile)
   }
 }
 
-#if ! defined(__APPLE__)
 TEST(ZimFile, multipart)
 {
   const zim::File zimfile1("./data/wikibooks_be_all_nopic_2017-02.zim");
@@ -202,6 +201,5 @@ TEST(ZimFile, multipart)
     );
   }
 }
-#endif // ! defined(__APPLE__)
 
 } // unnamed namespace


### PR DESCRIPTION
Fixes #398.

Under MacOS the implementation of `std::map::equal_range()` makes assumptions about the properties of the key comparison function and abuses the `std::map` requirement that it must contain unique keys. As a result, when a map `m` is queried with an element `k` that is equivalent to more than one keys present in `m`, `m.equal_range(k).first` may be different from `m.lower_bound(k)` (the latter one returning the correct result).

This PR must be merged after #387 (by first rebasing the fix_for_issue398 branch onto master).