### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ openZIM project at https://openzim.org/.
 
 [![latest release](https://img.shields.io/github/v/tag/openzim/libzim?label=latest%20release&sort=semver)](https://download.openzim.org/release/libzim/)
 [![Build Status](https://github.com/openzim/libzim/workflows/CI/badge.svg?query=branch%3Amaster)](https://github.com/openzim/libzim/actions?query=branch%3Amaster)
+[![Doc Status](https://readthedocs.org/projects/libzim/badge/?style=flat)](https://libzim.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/openzim/libzim/branch/master/graph/badge.svg)](https://codecov.io/gh/openzim/libzim)
 [![CodeFactor](https://www.codefactor.io/repository/github/openzim/libzim/badge)](https://www.codefactor.io/repository/github/openzim/libzim)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
@@ -42,6 +43,11 @@ libraries need to be available:
 * [Xapian](https://xapian.org/) - optional (package `libxapian-dev` on Ubuntu)
 * [UUID](http://e2fsprogs.sourceforge.net/) (package `uuid-dev` on Ubuntu)
 * [Google Test](https://github.com/google/googletest) - optional (package `googletest` on Ubuntu)
+
+To build the documentations you need the packages :
+
+* [Doxygen](https://www.doxygen.nl)
+* Python packages [Sphinx](https://www.sphinx-doc.org), [breathe](https://breathe.readthedocs.io) and [exhale](https://exhale.readthedocs.io).
 
 These dependencies may or may not be packaged by your operating
 system. They may also be packaged but only in an older version. The
@@ -80,6 +86,12 @@ By default, it will compile dynamic linked libraries. All binary files
 will be created in the `build` directory created automatically by
 Meson. If you want statically linked libraries, you can add
 `--default-library=static` option to the Meson command.
+
+If you want to build the documentation, we need to pass the `-Ddoc=true` option and run the `doc` target:
+```bash
+meson . build -Ddoc=true
+ninja -C build doc
+```
 
 Depending of you system, `ninja` may be called `ninja-build`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'libzim'
+copyright = '2020, libzim-team'
+author = 'libzim-team'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'breathe',
+    'exhale'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+breathe_projects = {
+    "libzim": "./xml"
+}
+breathe_default_project = 'libzim'
+
+exhale_args = {
+    "containmentFolder":   "./api",
+    "rootFileName":        "ref_api.rst",
+    "rootFileTitle":       "Reference API",
+    "doxygenStripFromPath":"..",
+    "treeViewIsBootstrap": True,
+    "createTreeView" : True,
+    "exhaleExecutesDoxygen": True,
+    "exhaleDoxygenStdin":    "INPUT = ../include"
+}
+
+primary_domain = 'cpp'
+
+highlight_language = 'cpp'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -23,6 +23,8 @@ author = 'libzim-team'
 
 
 # -- General configuration ---------------------------------------------------
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -41,7 +43,8 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
-html_theme = 'sphinx_rtd_theme'
+if not on_rtd:
+    html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. libzim documentation master file, created by
+   sphinx-quickstart on Fri Jul 24 15:40:50 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to libzim's documentation!
+==================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api/ref_api

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,7 @@
+
+sphinx = find_program('sphinx-build')
+
+sphinx_target = run_target('doc',
+    command: [sphinx, '-bhtml',
+              meson.current_source_dir(),
+              meson.current_build_dir()])

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,5 +1,5 @@
 
-sphinx = find_program('sphinx-build')
+sphinx = find_program('sphinx-build', native:true)
 
 sphinx_target = run_target('doc',
     command: [sphinx, '-bhtml',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+breathe
+exhale

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ subdir('static')
 subdir('src')
 subdir('examples')
 subdir('test')
+subdir('docs')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(libraries : libzim,

--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,9 @@ subdir('static')
 subdir('src')
 subdir('examples')
 subdir('test')
-subdir('docs')
+if get_option('doc')
+  subdir('docs')
+endif
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(libraries : libzim,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,5 @@ Header index are used to access articles, having them in memory can improve acce
 If false, we directly read the index in the file at each article access.''')
 option('static-linkage', type : 'boolean', value : false,
   description : 'Link statically with the dependencies.')
+option('doc', type : 'boolean', value : false,
+  description : 'Build the documentations.')


### PR DESCRIPTION
Will be merged in libzim_next branch.

The documentation isn't build by default (when running manually)
The readthedocs' CI build the documentation for us.
The libzim doc is available at https://libzim.readthedocs.io. The default doc is the `docs` branch (this one) but will be change once this is merged.