### PR TITLE
Revert "[API change] Dropped zim::File::getOffset()"

### DIFF
--- a/include/zim/file.h
+++ b/include/zim/file.h
@@ -61,6 +61,7 @@ namespace zim
       offset_type getClusterOffset(cluster_index_type idx) const;
 
       Blob getBlob(cluster_index_type clusterIdx, blob_index_type blobIdx) const;
+      offset_type getOffset(cluster_index_type clusterIdx, blob_index_type blobIdx) const;
 
       article_index_type getNamespaceBeginOffset(char ch) const;
       article_index_type getNamespaceEndOffset(char ch) const;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -203,6 +203,13 @@ namespace zim
       return search;
   }
 
+  offset_type File::getOffset(cluster_index_type clusterIdx, blob_index_type blobIdx) const
+  {
+    return offset_type(impl->getBlobOffset(
+                           cluster_index_t(clusterIdx),
+                           blob_index_t(blobIdx)));
+  }
+
   time_t File::getMTime() const
   {
     return impl->getMTime();


### PR DESCRIPTION
This reverts commit 3dac58aeb929b39fe5800b9b9869f31fbf758196, addressing one of the screwups described in https://github.com/openzim/libzim/pull/393#issuecomment-677670354