### PR TITLE
Partial/incremental decompression of clusters

### DIFF
--- a/src/bufdatastream.h
+++ b/src/bufdatastream.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_BUFDATASTREAM_H
+#define ZIM_BUFDATASTREAM_H
+
+#include "idatastream.h"
+#include "debug.h"
+
+#include <string.h>
+
+namespace zim
+{
+
+class BufDataStream : public IDataStream
+{
+public: // functions
+  explicit BufDataStream(const char* data, size_t size)
+    : data_(data)
+    , size_(size)
+  {}
+
+protected:
+  void readImpl(void* buf, size_t nbytes) override;
+  Blob readBlobImpl(size_t size) override;
+
+
+private: // data
+  const char* data_;
+  size_t size_;
+};
+
+} // namespace zim
+
+#endif // ZIM_BUFDATASTREAM_H

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -28,6 +28,7 @@
 #include <iosfwd>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 #include "zim_types.h"
 #include "zim/error.h"
@@ -110,13 +111,15 @@ namespace zim
       template<typename OFFSET_TYPE>
       void readHeader(IDataStream& ds);
 
-      void readBlobs(IDataStream& ds);
+      void ensureBlobIsDecompressed(blob_index_t i) const;
 
     private: // data
       const std::unique_ptr<IDataStream> ds_;
       const CompressionType compression_;
       std::vector<size_t> blobSizes_;
-      std::vector<IDataStream::Blob> blobs_;
+
+      mutable std::mutex blobAccessMutex_;
+      mutable std::vector<IDataStream::Blob> blobs_;
   };
 
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -113,6 +113,7 @@ namespace zim
       void readBlobs(IDataStream& ds);
 
     private: // data
+      const std::unique_ptr<IDataStream> ds_;
       const CompressionType compression_;
       std::vector<size_t> blobSizes_;
       std::vector<IDataStream::Blob> blobs_;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -40,7 +40,6 @@ namespace zim
       typedef std::vector<offset_t> Offsets;
 
     public:
-      const CompressionType compression;
       const bool isExtended;
 
     private:
@@ -60,19 +59,33 @@ namespace zim
       offset_t read_header();
 
     public:
-      Cluster(std::shared_ptr<const Reader> reader, CompressionType comp, bool isExtended);
-      CompressionType getCompression() const   { return compression; }
-      bool isCompressed() const                { return compression != zimcompDefault && compression != zimcompNone; }
+      Cluster(std::shared_ptr<const Reader> reader, bool isExtended);
+      virtual ~Cluster() {}
+
+      virtual bool isCompressed() const                { return false; }
+      virtual CompressionType getCompression() const   { return zimcompNone; }
 
       blob_index_t count() const               { return blob_index_t(offsets.size() - 1); }
 
       zsize_t getBlobSize(blob_index_t n) const;
-
-      offset_t getBlobOffset(blob_index_t n) const { return startOffset + offsets[blob_index_type(n)]; }
+      virtual offset_t getBlobOffset(blob_index_t n) const { return startOffset + offsets[blob_index_type(n)]; }
       Blob getBlob(blob_index_t n) const;
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 
       static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
+  };
+
+  class CompressedCluster : public Cluster
+  {
+    public:
+      CompressedCluster(std::shared_ptr<const Reader> reader, CompressionType comp, bool isExtended);
+
+      virtual bool isCompressed() const override;
+      virtual CompressionType getCompression() const override;
+      virtual offset_t getBlobOffset(blob_index_t n) const override;
+
+    private:
+      const CompressionType compression_;
   };
 
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -23,7 +23,8 @@
 #include <zim/zim.h>
 #include "buffer.h"
 #include "zim_types.h"
-#include "file_reader.h"
+#include "reader.h"
+#include "idatastream.h"
 #include <iosfwd>
 #include <vector>
 #include <memory>
@@ -42,7 +43,7 @@ namespace zim
     public:
       const bool isExtended;
 
-    private:
+    protected:
       std::shared_ptr<const Reader> reader;
 
       // offset of the first blob of this cluster relative to the beginning
@@ -69,23 +70,29 @@ namespace zim
 
       zsize_t getBlobSize(blob_index_t n) const;
       virtual offset_t getBlobOffset(blob_index_t n) const { return startOffset + offsets[blob_index_type(n)]; }
-      Blob getBlob(blob_index_t n) const;
-      Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
+      virtual Blob getBlob(blob_index_t n) const;
+      virtual Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 
       static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
   };
 
   class CompressedCluster : public Cluster
   {
-    public:
+    public: // functions
       CompressedCluster(std::shared_ptr<const Reader> reader, CompressionType comp, bool isExtended);
 
-      virtual bool isCompressed() const override;
-      virtual CompressionType getCompression() const override;
-      virtual offset_t getBlobOffset(blob_index_t n) const override;
+      bool isCompressed() const override;
+      CompressionType getCompression() const override;
+      offset_t getBlobOffset(blob_index_t n) const override;
+      Blob getBlob(blob_index_t n) const override;
+      Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const override;
 
-    private:
+    private: // functions
+      void readBlobs();
+
+    private: // data
       const CompressionType compression_;
+      std::vector<IDataStream::Blob> blobs_;
   };
 
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -43,9 +43,10 @@ namespace zim
     public:
       const bool isExtended;
 
-    protected:
+    private:
       std::shared_ptr<const Reader> reader;
 
+    protected:
       // offset of the first blob of this cluster relative to the beginning
       // of the (uncompressed) cluster data
       offset_t startOffset;
@@ -56,8 +57,12 @@ namespace zim
       // 0) and the end of the last blob are also included.
       Offsets offsets;
 
+    private:
       template<typename OFFSET_TYPE>
       offset_t read_header();
+
+    protected:
+      Cluster(bool isExtended) : isExtended(isExtended) {}
 
     public:
       Cluster(std::shared_ptr<const Reader> reader, bool isExtended);
@@ -88,7 +93,10 @@ namespace zim
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const override;
 
     private: // functions
-      void readBlobs();
+      template<typename OFFSET_TYPE>
+      void readHeader(IDataStream& ds);
+
+      void readBlobs(IDataStream& ds);
 
     private: // data
       const CompressionType compression_;

--- a/src/decodeddatastream.h
+++ b/src/decodeddatastream.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_DECODECDATASTREAM_H
+#define ZIM_DECODECDATASTREAM_H
+
+#include "compression.h"
+#include "idatastream.h"
+
+namespace zim
+{
+
+template<typename Decoder>
+class DecodedDataStream : public IDataStream
+{
+private: // constants
+  enum { CHUNK_SIZE = 1024 };
+
+public: // functions
+  DecodedDataStream(std::unique_ptr<IDataStream> inputData, size_t inputSize)
+    : encodedDataStream_(std::move(inputData))
+    , inputBytesLeft_(inputSize)
+    , encodedDataChunk_()
+  {
+    Decoder::init_stream_decoder(&decoderState_, nullptr);
+    readNextChunk();
+  }
+
+  ~DecodedDataStream()
+  {
+    Decoder::stream_end_decode(&decoderState_);
+  }
+
+private: // functions
+  void readNextChunk()
+  {
+    const size_t n = std::min(size_t(CHUNK_SIZE), inputBytesLeft_);
+    encodedDataChunk_ = encodedDataStream_->readBlob(n);
+    inputBytesLeft_ -= n;
+    // XXX: ugly C-style cast (casting away constness) on the next line
+    decoderState_.next_in  = (unsigned char*)encodedDataChunk_.data();
+    decoderState_.avail_in = encodedDataChunk_.size();
+  }
+
+  CompStatus decodeMoreBytes()
+  {
+    CompStep step = CompStep::STEP;
+    if ( decoderState_.avail_in == 0 )
+    {
+      if ( inputBytesLeft_ == 0 )
+        step = CompStep::FINISH;
+      else
+        readNextChunk();
+    }
+
+    return Decoder::stream_run_decode(&decoderState_, step);
+  }
+
+  void readImpl(void* buf, size_t nbytes) override
+  {
+    decoderState_.next_out = (unsigned char*)buf;
+    decoderState_.avail_out = nbytes;
+    while ( decoderState_.avail_out != 0 )
+    {
+      decodeMoreBytes();
+    }
+  }
+
+private: // types
+  typedef typename Decoder::stream_t DecoderState;
+
+private: // data
+  std::unique_ptr<IDataStream> encodedDataStream_;
+  size_t inputBytesLeft_; // count of bytes left in the input stream
+  DecoderState decoderState_;
+  IDataStream::Blob encodedDataChunk_;
+};
+
+} // namespace zim
+
+#endif // ZIM_DECODECDATASTREAM_H

--- a/src/idatastream.cpp
+++ b/src/idatastream.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "idatastream.h"
+
+namespace zim
+{
+
+IDataStream::Blob
+IDataStream::readBlobImpl(size_t size)
+{
+  std::shared_ptr<char> buf(new char[size], std::default_delete<char[]>());
+  readImpl(buf.get(), size);
+  return Blob(buf, size);
+}
+
+} // namespace zim

--- a/src/idatastream.h
+++ b/src/idatastream.h
@@ -48,7 +48,7 @@ class IDataStream
 public: // types
   class Blob
   {
-  private: // types
+  public: // types
     typedef std::shared_ptr<const char> DataPtr;
 
   public: // functions

--- a/src/idatastream.h
+++ b/src/idatastream.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_IDATASTREAM_H
+#define ZIM_IDATASTREAM_H
+
+#include <exception>
+#include <memory>
+
+#include "endian_tools.h"
+
+namespace zim
+{
+
+// IDataStream is a simple interface for sequential iteration over a stream
+// of values of built-in/primitive types and/or opaque binary objects (blobs).
+// An example usage:
+//
+//   void foo(IDataStream& s)
+//   {
+//     const uint32_t n = s.read<uint32_t>();
+//     for(uint32_t i=0; i < n; ++i)
+//     {
+//        const uint16_t blobSize = s.read<uint16_t>();
+//        IDataStream::Blob blob = s.readBlob(blobSize);
+//        bar(blob, blobSize);
+//     }
+//   }
+//
+class IDataStream
+{
+public: // types
+  class Blob
+  {
+  private: // types
+    typedef std::shared_ptr<const char> DataPtr;
+
+  public: // functions
+    Blob(const DataPtr& data, size_t size) : data_(data) , size_(size) {}
+
+    const char* data() const { return data_.get(); }
+    size_t size() const { return size_; }
+
+  private: // data
+    DataPtr data_;
+    size_t size_;
+  };
+
+public: // functions
+  virtual ~IDataStream() {}
+
+  // Reads a value of the said type from the stream
+  //
+  // For best portability this function should be used with types of known
+  // bit-width (int32_t, uint16_t, etc) rather than builtin types with
+  // unknown bit-width (int, unsigned, etc).
+  template<typename T> T read();
+
+  // Reads a blob of the specified size from the stream
+  Blob readBlob(size_t size);
+
+private: // virtual methods
+  // Reads exactly 'nbytes' bytes into the provided buffer 'buf'
+  // (which must be at least that big). Throws an exception if
+  // more bytes are requested than can be retrieved.
+  virtual void readImpl(void* buf, size_t nbytes) = 0;
+
+  // By default a blob is returned as an independent object owning
+  // its own buffer. However, the function readBlobImpl() can be
+  // overriden so that it returns a blob referring to arbitrary
+  // pre-existing memory.
+  virtual Blob readBlobImpl(size_t size);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Implementation of IDataStream
+////////////////////////////////////////////////////////////////////////////////
+
+// XXX: Assuming that opaque binary data retrieved via 'readImpl()'
+// XXX: is encoded in little-endian form.
+template<typename T>
+inline T
+IDataStream::read()
+{
+  const size_t N = sizeof(T);
+  char buf[N];
+  readImpl(&buf, N);
+  return fromLittleEndian<T>(buf); // XXX: This handles only integral types
+}
+
+inline
+IDataStream::Blob
+IDataStream::readBlob(size_t size)
+{
+  return readBlobImpl(size);
+}
+
+} // namespace zim
+
+#endif // ZIM_IDATASTREAM_H

--- a/src/idatastream.h
+++ b/src/idatastream.h
@@ -52,6 +52,7 @@ public: // types
     typedef std::shared_ptr<const char> DataPtr;
 
   public: // functions
+    Blob() : data_(), size_(0) {}
     Blob(const DataPtr& data, size_t size) : data_(data) , size_(size) {}
 
     const char* data() const { return data_.get(); }

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ common_sources = [
     'levenshtein.cpp',
     'tools.cpp',
     'compression.cpp',
+    'idatastream.cpp',
     'writer/creator.cpp',
     'writer/article.cpp',
     'writer/cluster.cpp',

--- a/src/readerdatastreamwrapper.h
+++ b/src/readerdatastreamwrapper.h
@@ -30,20 +30,20 @@ namespace zim
 class ReaderDataStreamWrapper : public IDataStream
 {
 public: // functions
-  explicit ReaderDataStreamWrapper(const zim::Reader* reader)
-    : reader_(*reader)
+  explicit ReaderDataStreamWrapper(std::shared_ptr<const zim::Reader> reader)
+    : reader_(reader)
     , readerPos_(0)
   {}
 
   void readImpl(void* buf, size_t nbytes) override
   {
-    ASSERT(readerPos_.v + nbytes, <=, reader_.size().v);
-    reader_.read(static_cast<char*>(buf), readerPos_, zsize_t(nbytes));
+    ASSERT(readerPos_.v + nbytes, <=, reader_->size().v);
+    reader_->read(static_cast<char*>(buf), readerPos_, zsize_t(nbytes));
     readerPos_ += nbytes;
   }
 
 private: // data
-  const Reader& reader_;
+  std::shared_ptr<const Reader> reader_;
   offset_t readerPos_;
 };
 

--- a/src/readerdatastreamwrapper.h
+++ b/src/readerdatastreamwrapper.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_READERDATASTREAMWRAPPER_H
+#define ZIM_READERDATASTREAMWRAPPER_H
+
+#include "idatastream.h"
+#include "reader.h"
+#include "debug.h"
+
+namespace zim
+{
+
+class ReaderDataStreamWrapper : public IDataStream
+{
+public: // functions
+  explicit ReaderDataStreamWrapper(const zim::Reader* reader)
+    : reader_(*reader)
+    , readerPos_(0)
+  {}
+
+  void readImpl(void* buf, size_t nbytes) override
+  {
+    ASSERT(readerPos_.v + nbytes, <=, reader_.size().v);
+    reader_.read(static_cast<char*>(buf), readerPos_, zsize_t(nbytes));
+    readerPos_ += nbytes;
+  }
+
+private: // data
+  const Reader& reader_;
+  offset_t readerPos_;
+};
+
+} // namespace zim
+
+#endif // ZIM_READERDATASTREAMWRAPPER_H

--- a/test/decodeddatastream.cpp
+++ b/test/decodeddatastream.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "decodeddatastream.h"
+#include "bufdatastream.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+template<class CompressionInfo>
+std::string
+compress(const std::string& data)
+{
+  zim::Compressor<CompressionInfo> compressor(data.size());
+  compressor.init(const_cast<char*>(data.c_str()));
+  compressor.feed(data.c_str(), data.size());
+  zim::zsize_t comp_size;
+  const auto comp_data = compressor.get_data(&comp_size);
+  return std::string(comp_data.get(), comp_size.v);
+}
+
+std::string operator*(const std::string& s, unsigned N)
+{
+  std::string result;
+  for (unsigned i=0; i<N; i++)
+    result += s;
+  return result;
+}
+
+std::string toString(const zim::IDataStream::Blob& blob)
+{
+  return std::string(blob.data(), blob.size());
+}
+
+template<typename T>
+class DecodedDataStreamTest : public testing::Test {
+  protected:
+    typedef T CompressionInfo;
+};
+
+using CompressionTypes = ::testing::Types<
+  LZMA_INFO,
+  ZSTD_INFO
+#if defined(ENABLE_ZLIB)
+  ,ZIP_INFO
+#endif
+>;
+
+TYPED_TEST_CASE(DecodedDataStreamTest, CompressionTypes);
+
+TYPED_TEST(DecodedDataStreamTest, justCompressedData) {
+  typedef typename TestFixture::CompressionInfo CompressionInfo;
+
+  const int N = 10;
+  const std::string s("DecodedDataStream should work correctly");
+  const std::string compData = compress<CompressionInfo>(s*N);
+
+  std::unique_ptr<zim::IDataStream> bds(new zim::BufDataStream(compData.data(), compData.size()));
+  zim::DecodedDataStream<CompressionInfo> dds(std::move(bds), compData.size());
+  for (int i=0; i<N; i++)
+  {
+    ASSERT_EQ(s, toString(dds.readBlob(s.size()))) << "i: " << i;
+  }
+}
+
+TYPED_TEST(DecodedDataStreamTest, compressedDataFollowedByGarbage) {
+  typedef typename TestFixture::CompressionInfo CompressionInfo;
+
+  const int N = 10;
+  const std::string s("DecodedDataStream should work correctly");
+  const std::string compData = compress<CompressionInfo>(s*N);
+  const std::string inputData = compData + std::string(10, '\0');
+
+  std::unique_ptr<zim::IDataStream> bds(new zim::BufDataStream(inputData.data(), inputData.size()));
+  zim::DecodedDataStream<CompressionInfo> dds(std::move(bds), inputData.size());
+  for (int i=0; i<N; i++)
+  {
+    ASSERT_EQ(s, toString(dds.readBlob(s.size()))) << "i: " << i;
+  }
+}
+
+} // unnamed namespace

--- a/test/decodeddatastream.cpp
+++ b/test/decodeddatastream.cpp
@@ -45,6 +45,38 @@ std::string operator*(const std::string& s, unsigned N)
   return result;
 }
 
+std::string
+mutate(std::string str, size_t i)
+{
+  const size_t n = str.size();
+  if ( i >= n )
+    str = mutate(str, i/n);
+
+  str[i%n] = '!';
+
+  return str;
+}
+
+std::string
+largeNotEasilyCompressibleString()
+{
+  const int N = 5000;
+  const std::string s("DecodedDataStream should work correctly");
+  std::string text;
+  for (size_t i=0; i<N; i++)
+    text += mutate(s, i);
+
+  return text;
+}
+
+std::unique_ptr<zim::IDataStream>
+makeBufDataStream(const std::string* s)
+{
+  const char* const data = s->data();
+  const size_t size = s->size();
+  return std::unique_ptr<zim::IDataStream>(new zim::BufDataStream(data, size));
+}
+
 std::string toString(const zim::IDataStream::Blob& blob)
 {
   return std::string(blob.data(), blob.size());
@@ -66,14 +98,15 @@ using CompressionTypes = ::testing::Types<
 
 TYPED_TEST_CASE(DecodedDataStreamTest, CompressionTypes);
 
-TYPED_TEST(DecodedDataStreamTest, justCompressedData) {
+TYPED_TEST(DecodedDataStreamTest, smallCompressedData)
+{
   typedef typename TestFixture::CompressionInfo CompressionInfo;
 
   const int N = 10;
   const std::string s("DecodedDataStream should work correctly");
   const std::string compData = compress<CompressionInfo>(s*N);
 
-  std::unique_ptr<zim::IDataStream> bds(new zim::BufDataStream(compData.data(), compData.size()));
+  std::unique_ptr<zim::IDataStream> bds(makeBufDataStream(&compData));
   zim::DecodedDataStream<CompressionInfo> dds(std::move(bds), compData.size());
   for (int i=0; i<N; i++)
   {
@@ -81,7 +114,21 @@ TYPED_TEST(DecodedDataStreamTest, justCompressedData) {
   }
 }
 
-TYPED_TEST(DecodedDataStreamTest, compressedDataFollowedByGarbage) {
+TYPED_TEST(DecodedDataStreamTest, largeCompressedData)
+{
+  typedef typename TestFixture::CompressionInfo CompressionInfo;
+
+  const std::string text = largeNotEasilyCompressibleString();
+  const std::string compData = compress<CompressionInfo>(text);
+  ASSERT_GT(compData.size(), 2 * 1024); // 1024 is DecodedDataStream::CHUNK_SIZE
+
+  std::unique_ptr<zim::IDataStream> bds(makeBufDataStream(&compData));
+  zim::DecodedDataStream<CompressionInfo> dds(std::move(bds), compData.size());
+  ASSERT_EQ(text, toString(dds.readBlob(text.size())));
+}
+
+TYPED_TEST(DecodedDataStreamTest, compressedDataFollowedByGarbage)
+{
   typedef typename TestFixture::CompressionInfo CompressionInfo;
 
   const int N = 10;
@@ -89,7 +136,7 @@ TYPED_TEST(DecodedDataStreamTest, compressedDataFollowedByGarbage) {
   const std::string compData = compress<CompressionInfo>(s*N);
   const std::string inputData = compData + std::string(10, '\0');
 
-  std::unique_ptr<zim::IDataStream> bds(new zim::BufDataStream(inputData.data(), inputData.size()));
+  std::unique_ptr<zim::IDataStream> bds(makeBufDataStream(&inputData));
   zim::DecodedDataStream<CompressionInfo> dds(std::move(bds), inputData.size());
   for (int i=0; i<N; i++)
   {

--- a/test/idatastream.cpp
+++ b/test/idatastream.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "idatastream.h"
+#include "bufdatastream.h"
+#include "endian_tools.h"
 
 #include "gtest/gtest.h"
 
@@ -25,6 +27,10 @@ namespace
 {
 
 using zim::IDataStream;
+
+////////////////////////////////////////////////////////////////////////////////
+// IDataStream
+////////////////////////////////////////////////////////////////////////////////
 
 // Implement the IDataStream interface in the simplest way
 class InfiniteZeroStream : public IDataStream
@@ -53,6 +59,37 @@ TEST(IDataStream, readBlob)
   IDataStream& ids = izs;
   const IDataStream::Blob blob = ids.readBlob(N);
   EXPECT_EQ(0, memcmp(blob.data(), zerobuf, N));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BufDataStream
+////////////////////////////////////////////////////////////////////////////////
+
+std::string toString(const IDataStream::Blob& blob)
+{
+  return std::string(blob.data(), blob.size());
+}
+
+TEST(BufDataStream, shouldJustWork)
+{
+  char data[] = "abcdefghijklmnopqrstuvwxyz";
+  zim::toLittleEndian(uint32_t(1234), data);
+  zim::toLittleEndian(int64_t(-987654321), data+18);
+
+  zim::BufDataStream bds(data, sizeof(data));
+  IDataStream& ids = bds;
+
+  ASSERT_EQ(1234,         ids.read<uint32_t>());
+
+  const auto blob1 = ids.readBlob(4);
+  ASSERT_EQ("efgh", toString(blob1));
+  ASSERT_EQ(data + 4, blob1.data());
+
+  const auto blob2 = ids.readBlob(10);
+  ASSERT_EQ("ijklmnopqr", toString(blob2));
+  ASSERT_EQ(data + 8, blob2.data());
+
+  ASSERT_EQ(-987654321,   ids.read<int64_t>());
 }
 
 } // unnamed namespace

--- a/test/idatastream.cpp
+++ b/test/idatastream.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "idatastream.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+using zim::IDataStream;
+
+// Implement the IDataStream interface in the simplest way
+class InfiniteZeroStream : public IDataStream
+{
+  void readImpl(void* buf, size_t nbytes) { memset(buf, 0, nbytes); }
+};
+
+// ... and test that it compiles and works as intended
+
+TEST(IDataStream, read)
+{
+  InfiniteZeroStream izs;
+  IDataStream& ids = izs;
+  EXPECT_EQ(0, ids.read<int>());
+  EXPECT_EQ(0L, ids.read<long>());
+
+  // zim::fromLittleEndian() handles only integer types
+  // EXPECT_EQ(0.0, ids.read<double>());
+}
+
+TEST(IDataStream, readBlob)
+{
+  const size_t N = 16;
+  const char zerobuf[N] = {0};
+  InfiniteZeroStream izs;
+  IDataStream& ids = izs;
+  const IDataStream::Blob blob = ids.readBlob(N);
+  EXPECT_EQ(0, memcmp(blob.data(), zerobuf, N));
+}
+
+} // unnamed namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -11,7 +11,8 @@ tests = [
     'iterator',
     'find',
     'compression',
-    'impl_find'
+    'impl_find',
+    'idatastream'
 ]
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,7 +12,8 @@ tests = [
     'find',
     'compression',
     'impl_find',
-    'idatastream'
+    'idatastream',
+    'readerdatastreamwrapper'
 ]
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/meson.build
+++ b/test/meson.build
@@ -13,7 +13,8 @@ tests = [
     'compression',
     'impl_find',
     'idatastream',
-    'readerdatastreamwrapper'
+    'readerdatastreamwrapper',
+    'decodeddatastream'
 ]
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/readerdatastreamwrapper.cpp
+++ b/test/readerdatastreamwrapper.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "readerdatastreamwrapper.h"
+#include "buffer.h"
+#include "file_reader.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+using namespace zim;
+
+std::shared_ptr<Buffer> memoryViewBuffer(const char* str, size_t size)
+{
+  return std::make_shared<MemoryViewBuffer>(str, zsize_t(size));
+}
+
+std::string toString(const IDataStream::Blob& blob)
+{
+  return std::string(blob.data(), blob.size());
+}
+
+TEST(ReaderDataStreamWrapper, shouldJustWork)
+{
+  char data[] = "abcdefghijklmnopqrstuvwxyz";
+  toLittleEndian(uint32_t(1234), data);
+  toLittleEndian(int64_t(-987654321), data+18);
+
+  const BufferReader bufReader(memoryViewBuffer(data, sizeof(data)));
+  const Reader* readerPtr = &bufReader;
+
+  ReaderDataStreamWrapper rdsw(readerPtr);
+
+  ASSERT_EQ(1234,         rdsw.read<uint32_t>());
+  ASSERT_EQ("efgh",       toString(rdsw.readBlob(4)));
+  ASSERT_EQ("ijklmnopqr", toString(rdsw.readBlob(10)));
+  ASSERT_EQ(-987654321,   rdsw.read<int64_t>());
+}
+
+} // unnamed namespace

--- a/test/readerdatastreamwrapper.cpp
+++ b/test/readerdatastreamwrapper.cpp
@@ -44,8 +44,9 @@ TEST(ReaderDataStreamWrapper, shouldJustWork)
   toLittleEndian(uint32_t(1234), data);
   toLittleEndian(int64_t(-987654321), data+18);
 
-  const BufferReader bufReader(memoryViewBuffer(data, sizeof(data)));
-  const Reader* readerPtr = &bufReader;
+  const auto buffer = memoryViewBuffer(data, sizeof(data));
+  const auto bufReader = std::make_shared<BufferReader>(buffer);
+  const std::shared_ptr<const Reader> readerPtr = bufReader;
 
   ReaderDataStreamWrapper rdsw(readerPtr);
 


### PR DESCRIPTION
Fixes #78
Fixes #394 
Enables #395 for compressed clusters

1. Added `IDataStream` interface for sequential reading of data and its 3 implementations:
    - `BufDataStream`: reading data from a buffer
    - `DecodedDataStream`: for on the fly decompression of data coming from another data stream
    - `ReaderDataStreamWrapper`: a wrapper around `zim::Reader` presenting it as `IDataStream`

2. Converted `Cluster` into an abstract base class with two implementations:
    - `NonCompressedCluster`
    - `CompressedCluster`

3. Implemented partial/incremental decompression of compressed clusters using `DecodedDataStream`.

It is better to review this PR commit-by-commit.

---

Benchmarking data:

These changes are most beneficial to `kiwix-serve`. The benchmark was performed using the [`benchmark_kiwix_serve`](https://github.com/veloman-yunkan/kiwix-dev-utils/blob/80562e5de15faba59dfec1c3a2da147a699825c9/benchmark_kiwix_serve) script as follows:

```
./benchmark_kiwix_serve master 1000 zimfiles/wikipedia_hy_all_mini_2020-08.zim
./benchmark_kiwix_serve partial_decompression 1000 zimfiles/wikipedia_hy_all_mini_2020-08.zim
```

That script starts a kiwix server and fetches from it about 1000 articles (more accurately every 509'th article, which amounts to 1002 articles) using `wget --recursive -l 1`.

|   ZIM file     |    size (MB) | article count | cluster count | fetched item count | wget runtime (master) |  wget runtime (this PR) |
|----------------------------------------------------------------------|---------|-----------|---------|--------|------ |------|
|  [wikipedia_hy_all_mini_2020-08.zim][2]                    |   563 | 509611 | 1526 | 5677 | 59s | 37s |

(It was verified that the output directories created by wget from both runs are identical, with the exception of `/random`)

`zimcheck -A` exercises a flow that should not benefit from this optimization. In fact there is some (about 3%) slowdown:

|   ZIM file     |    size (MB) | article count | cluster count | zimcheck -A runtime (master) |  zimcheck -A runtime (this PR) |
|----------------------------------------------------------------------|---------|-----------|---------|--------------|-----------------|
|  wikipedia_en_climate_change_nopic_2020-01.zim  |  31    | 7646     | 51     | 5.663s      | 5.694s        |
|  [wikipedia_hy_all_mini_2020-07.zim][1]                    |   560 | 509325 | 1518 | 6m6.325s | 6m17.350s |
|  [wikipedia_hy_all_mini_2020-08.zim][2]                    |   563 | 509611 | 1526 | 6m7.287s | 6m19.535s |

[1]: http://download.kiwix.org/zim/wikipedia/wikipedia_hy_all_mini_2020-07.zim
[2]: http://download.kiwix.org/zim/wikipedia/wikipedia_hy_all_mini_2020-08.zim
