### PR TITLE
Groundwork for partial/incremental decompression of clusters

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -141,4 +141,11 @@ namespace zim
       return _read_size<uint32_t>(reader, offset);
   }
 
+  std::shared_ptr<Cluster> Cluster::read(const Reader& zimReader, offset_t clusterOffset)
+  {
+    CompressionType comp;
+    bool extended;
+    std::shared_ptr<const Reader> reader = zimReader.sub_clusterReader(clusterOffset, &comp, &extended);
+    return std::make_shared<Cluster>(reader, comp, extended);
+  }
 }

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <sstream>
 
+#include "compression.h"
 #include "log.h"
 
 #include "config.h"
@@ -140,6 +141,59 @@ namespace zim
     else
       return _read_size<uint32_t>(reader, offset);
   }
+
+std::shared_ptr<const Buffer> Reader::get_clusterBuffer(offset_t offset, CompressionType comp) const
+{
+  zsize_t uncompressed_size(0);
+  std::unique_ptr<char[]> uncompressed_data;
+  switch (comp) {
+    case zimcompLzma:
+      uncompressed_data = uncompress<LZMA_INFO>(this, offset, &uncompressed_size);
+      break;
+    case zimcompZip:
+#if defined(ENABLE_ZLIB)
+      uncompressed_data = uncompress<ZIP_INFO>(this, offset, &uncompressed_size);
+#else
+      throw std::runtime_error("zlib not enabled in this library");
+#endif
+      break;
+    case zimcompZstd:
+      uncompressed_data = uncompress<ZSTD_INFO>(this, offset, &uncompressed_size);
+      break;
+    default:
+      throw std::logic_error("compressions should not be something else than zimcompLzma, zimComZip or zimcompZstd.");
+  }
+  return std::make_shared<MemoryBuffer>(std::move(uncompressed_data), uncompressed_size);
+}
+
+std::unique_ptr<const Reader> Reader::sub_clusterReader(offset_t offset, CompressionType* comp, bool* extended) const {
+  uint8_t clusterInfo = read(offset);
+  *comp = static_cast<CompressionType>(clusterInfo & 0x0F);
+  *extended = clusterInfo & 0x10;
+
+  switch (*comp) {
+    case zimcompDefault:
+    case zimcompNone:
+      {
+        auto size = Cluster::read_size(this, *extended, offset + offset_t(1));
+      // No compression, just a sub_reader
+        return sub_reader(offset+offset_t(1), size);
+      }
+      break;
+    case zimcompLzma:
+    case zimcompZip:
+    case zimcompZstd:
+      {
+        auto buffer = get_clusterBuffer(offset+offset_t(1), *comp);
+        return std::unique_ptr<Reader>(new BufferReader(buffer));
+      }
+      break;
+    case zimcompBzip2:
+      throw std::runtime_error("bzip2 not enabled in this library");
+    default:
+      throw ZimFileFormatError("Invalid compression flag");
+  }
+}
 
   std::shared_ptr<Cluster> Cluster::read(const Reader& zimReader, offset_t clusterOffset)
   {

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -125,6 +125,9 @@ namespace zim
     }
   }
 
+namespace
+{
+
   template<typename OFFSET_TYPE>
   zsize_t _read_size(const Reader* reader, offset_t offset)
   {
@@ -134,16 +137,13 @@ namespace zim
     return zsize_t(s);
   }
 
-  zsize_t Cluster::read_size(const Reader* reader, bool isExtended, offset_t offset)
+  zsize_t read_size(const Reader* reader, bool isExtended, offset_t offset)
   {
     if (isExtended)
       return _read_size<uint64_t>(reader, offset);
     else
       return _read_size<uint32_t>(reader, offset);
   }
-
-namespace
-{
 
 std::shared_ptr<const Buffer>
 getClusterBuffer(const Reader& zimReader, offset_t offset, CompressionType comp)
@@ -181,7 +181,7 @@ getClusterReader(const Reader& zimReader, offset_t offset, CompressionType* comp
     case zimcompDefault:
     case zimcompNone:
       {
-        auto size = Cluster::read_size(&zimReader, *extended, offset + offset_t(1));
+        auto size = read_size(&zimReader, *extended, offset + offset_t(1));
       // No compression, just a sub_reader
         return zimReader.sub_reader(offset+offset_t(1), size);
       }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -70,6 +70,7 @@ namespace zim
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 
       static zsize_t read_size(const Reader* reader, bool isExtended, offset_t offset);
+      static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
   };
 
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -72,7 +72,6 @@ namespace zim
       Blob getBlob(blob_index_t n) const;
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 
-      static zsize_t read_size(const Reader* reader, bool isExtended, offset_t offset);
       static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
   };
 

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -39,8 +39,11 @@ namespace zim
   class Cluster : public std::enable_shared_from_this<Cluster> {
       typedef std::vector<offset_t> Offsets;
 
+    public:
       const CompressionType compression;
       const bool isExtended;
+
+    private:
       std::shared_ptr<const Reader> reader;
 
       // offset of the first blob of this cluster relative to the beginning

--- a/src/file_reader.cpp
+++ b/src/file_reader.cpp
@@ -23,7 +23,6 @@
 #include "file_compound.h"
 #include "cluster.h"
 #include "buffer.h"
-#include "compression.h"
 #include <errno.h>
 #include <string.h>
 #include <cstring>
@@ -157,59 +156,6 @@ bool Reader::can_read(offset_t offset, zsize_t size)
     return (offset.v <= this->size().v && (offset.v+size.v) <= this->size().v);
 }
 
-
-std::shared_ptr<const Buffer> Reader::get_clusterBuffer(offset_t offset, CompressionType comp) const
-{
-  zsize_t uncompressed_size(0);
-  std::unique_ptr<char[]> uncompressed_data;
-  switch (comp) {
-    case zimcompLzma:
-      uncompressed_data = uncompress<LZMA_INFO>(this, offset, &uncompressed_size);
-      break;
-    case zimcompZip:
-#if defined(ENABLE_ZLIB)
-      uncompressed_data = uncompress<ZIP_INFO>(this, offset, &uncompressed_size);
-#else
-      throw std::runtime_error("zlib not enabled in this library");
-#endif
-      break;
-    case zimcompZstd:
-      uncompressed_data = uncompress<ZSTD_INFO>(this, offset, &uncompressed_size);
-      break;
-    default:
-      throw std::logic_error("compressions should not be something else than zimcompLzma, zimComZip or zimcompZstd.");
-  }
-  return std::make_shared<MemoryBuffer>(std::move(uncompressed_data), uncompressed_size);
-}
-
-std::unique_ptr<const Reader> Reader::sub_clusterReader(offset_t offset, CompressionType* comp, bool* extended) const {
-  uint8_t clusterInfo = read(offset);
-  *comp = static_cast<CompressionType>(clusterInfo & 0x0F);
-  *extended = clusterInfo & 0x10;
-
-  switch (*comp) {
-    case zimcompDefault:
-    case zimcompNone:
-      {
-        auto size = Cluster::read_size(this, *extended, offset + offset_t(1));
-      // No compression, just a sub_reader
-        return sub_reader(offset+offset_t(1), size);
-      }
-      break;
-    case zimcompLzma:
-    case zimcompZip:
-    case zimcompZstd:
-      {
-        auto buffer = get_clusterBuffer(offset+offset_t(1), *comp);
-        return std::unique_ptr<Reader>(new BufferReader(buffer));
-      }
-      break;
-    case zimcompBzip2:
-      throw std::runtime_error("bzip2 not enabled in this library");
-    default:
-      throw ZimFileFormatError("Invalid compression flag");
-  }
-}
 
 std::unique_ptr<const Reader> FileReader::sub_reader(offset_t offset, zsize_t size) const
 {

--- a/src/file_reader.cpp
+++ b/src/file_reader.cpp
@@ -21,7 +21,6 @@
 #include <zim/error.h>
 #include "file_reader.h"
 #include "file_compound.h"
-#include "cluster.h"
 #include "buffer.h"
 #include <errno.h>
 #include <string.h>

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -20,53 +20,11 @@
 #ifndef ZIM_FILE_READER_H_
 #define ZIM_FILE_READER_H_
 
-#include <memory>
-
-#include "zim_types.h"
-#include "endian_tools.h"
-#include "debug.h"
+#include "reader.h"
 
 namespace zim {
 
-class Buffer;
 class FileCompound;
-
-class Reader {
-  public:
-    Reader() {};
-    virtual zsize_t size() const = 0;
-    virtual ~Reader() {};
-
-    virtual void read(char* dest, offset_t offset, zsize_t size) const = 0;
-    template<typename T>
-    T read_uint(offset_t offset) const {
-      ASSERT(offset.v, <, size().v);
-      ASSERT(offset.v+sizeof(T), <=, size().v);
-      char tmp_buf[sizeof(T)];
-      read(tmp_buf, offset, zsize_t(sizeof(T)));
-      return fromLittleEndian<T>(tmp_buf);
-    }
-    virtual char read(offset_t offset) const = 0;
-
-    virtual std::shared_ptr<const Buffer> get_buffer(offset_t offset, zsize_t size) const = 0;
-    std::shared_ptr<const Buffer> get_buffer(offset_t offset) const {
-      return get_buffer(offset, zsize_t(size().v-offset.v));
-    }
-    virtual std::unique_ptr<const Reader> sub_reader(offset_t offset, zsize_t size) const = 0;
-    std::unique_ptr<const Reader> sub_reader(offset_t offset) const {
-      return sub_reader(offset, zsize_t(size().v-offset.v));
-    }
-    virtual offset_t offset() const = 0;
-
-    std::unique_ptr<const Reader> sub_clusterReader(offset_t offset,
-                                                    CompressionType* comp,
-                                                    bool* extented) const;
-
-    bool can_read(offset_t offset, zsize_t size);
-
-  private:
-    std::shared_ptr<const Buffer> get_clusterBuffer(offset_t offset, CompressionType comp) const;
-};
 
 class FileReader : public Reader {
   public:

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -357,10 +357,7 @@ offset_t readOffset(const Reader& reader, size_t idx)
   {
     offset_t clusterOffset(getClusterOffset(idx));
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
-    CompressionType comp;
-    bool extended;
-    std::shared_ptr<const Reader> reader = zimReader->sub_clusterReader(clusterOffset, &comp, &extended);
-    return std::make_shared<Cluster>(reader, comp, extended);
+    return Cluster::read(*zimReader, clusterOffset);
   }
 
   std::shared_ptr<const Cluster> FileImpl::getCluster(cluster_index_t idx)

--- a/src/reader.h
+++ b/src/reader.h
@@ -57,14 +57,7 @@ class Reader {
     }
     virtual offset_t offset() const = 0;
 
-    std::unique_ptr<const Reader> sub_clusterReader(offset_t offset,
-                                                    CompressionType* comp,
-                                                    bool* extented) const;
-
     bool can_read(offset_t offset, zsize_t size);
-
-  private:
-    std::shared_ptr<const Buffer> get_clusterBuffer(offset_t offset, CompressionType comp) const;
 };
 
 };

--- a/src/reader.h
+++ b/src/reader.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_READER_H_
+#define ZIM_READER_H_
+
+#include <memory>
+
+#include "zim_types.h"
+#include "endian_tools.h"
+#include "debug.h"
+
+namespace zim {
+
+class Buffer;
+
+class Reader {
+  public:
+    Reader() {};
+    virtual zsize_t size() const = 0;
+    virtual ~Reader() {};
+
+    virtual void read(char* dest, offset_t offset, zsize_t size) const = 0;
+    template<typename T>
+    T read_uint(offset_t offset) const {
+      ASSERT(offset.v, <, size().v);
+      ASSERT(offset.v+sizeof(T), <=, size().v);
+      char tmp_buf[sizeof(T)];
+      read(tmp_buf, offset, zsize_t(sizeof(T)));
+      return fromLittleEndian<T>(tmp_buf);
+    }
+    virtual char read(offset_t offset) const = 0;
+
+    virtual std::shared_ptr<const Buffer> get_buffer(offset_t offset, zsize_t size) const = 0;
+    std::shared_ptr<const Buffer> get_buffer(offset_t offset) const {
+      return get_buffer(offset, zsize_t(size().v-offset.v));
+    }
+    virtual std::unique_ptr<const Reader> sub_reader(offset_t offset, zsize_t size) const = 0;
+    std::unique_ptr<const Reader> sub_reader(offset_t offset) const {
+      return sub_reader(offset, zsize_t(size().v-offset.v));
+    }
+    virtual offset_t offset() const = 0;
+
+    std::unique_ptr<const Reader> sub_clusterReader(offset_t offset,
+                                                    CompressionType* comp,
+                                                    bool* extented) const;
+
+    bool can_read(offset_t offset, zsize_t size);
+
+  private:
+    std::shared_ptr<const Buffer> get_clusterBuffer(offset_t offset, CompressionType comp) const;
+};
+
+};
+
+#endif // ZIM_READER_H_

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -161,12 +161,9 @@ TEST(ClusterTest, read_write_clusterZ)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(0)).v, blob0.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(2)).v, blob2.size());
-  auto b = cluster2.getBlob(zim::blob_index_t(0));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob0.data()));
-  b = cluster2.getBlob(zim::blob_index_t(1));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob1.data()));
-  b = cluster2.getBlob(zim::blob_index_t(2));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob2.data()));
+  ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
+  ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
+  ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
 }
 
 #endif
@@ -192,12 +189,9 @@ TEST(ClusterTest, read_write_clusterLzma)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(0)).v, blob0.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(2)).v, blob2.size());
-  auto b = cluster2.getBlob(zim::blob_index_t(0));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob0.data()));
-  b = cluster2.getBlob(zim::blob_index_t(1));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob1.data()));
-  b = cluster2.getBlob(zim::blob_index_t(2));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob2.data()));
+  ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
+  ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
+  ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
 }
 
 TEST(ClusterTest, read_write_clusterZstd)
@@ -221,12 +215,9 @@ TEST(ClusterTest, read_write_clusterZstd)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(0)).v, blob0.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(2)).v, blob2.size());
-  auto b = cluster2.getBlob(zim::blob_index_t(0));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob0.data()));
-  b = cluster2.getBlob(zim::blob_index_t(1));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob1.data()));
-  b = cluster2.getBlob(zim::blob_index_t(2));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob2.data()));
+  ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
+  ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
+  ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
 }
 
 #if !defined(__APPLE__)
@@ -289,12 +280,9 @@ TEST(ClusterTest, read_write_extended_cluster)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(2)).v, blob2.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(3)).v, bigger_than_4g);
-  auto b = cluster2.getBlob(zim::blob_index_t(0));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob0.data()));
-  b = cluster2.getBlob(zim::blob_index_t(1));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob1.data()));
-  b = cluster2.getBlob(zim::blob_index_t(2));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob2.data()));
+  ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
+  ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
+  ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
 }
 #endif
 
@@ -370,14 +358,11 @@ TEST(ClusterTest, read_extended_cluster)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(3)).v, bigger_than_4g);
 
 
-  auto b = cluster2.getBlob(zim::blob_index_t(0));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob0.data()));
-  b = cluster2.getBlob(zim::blob_index_t(1));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob1.data()));
-  b = cluster2.getBlob(zim::blob_index_t(2));
-  ASSERT_TRUE(std::equal(b.data(), b.end(), blob2.data()));
+  ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
+  ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
+  ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
 
-  b = cluster2.getBlob(zim::blob_index_t(3));
+  const zim::Blob b = cluster2.getBlob(zim::blob_index_t(3));
   if (SIZE_MAX == UINT32_MAX) {
     ASSERT_EQ(b.data(), nullptr);
     ASSERT_EQ(b.size(), 0U);


### PR DESCRIPTION
This PR contains some groundwork for #411, however it should be useful on its own even if the latter PR is not merged.

Save for the last commit, the changes are merely of refactoring nature. The last commit corrects a bug in the cluster unit-test that allows an empty (or, more generally, undersized) blob returned by `Cluster::getBlob()` to pass the check.

As is usual for a sequence of relatively small refactoring changes, it is recommended to review this PR commit by commit.