### PR TITLE
Fix compilation of lru_cache on windows.

### DIFF
--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -276,7 +276,7 @@ offset_t readOffset(const Reader& reader, size_t idx)
       throw ZimFileFormatError("article index out of range");
 
     pthread_mutex_lock(&direntCacheLock);
-    auto v = direntCache.get(idx);
+    auto v = direntCache.get(idx.v);
     if (v.hit())
     {
       log_debug("dirent " << idx << " found in cache; hits "
@@ -329,7 +329,7 @@ offset_t readOffset(const Reader& reader, size_t idx)
 
     log_debug("dirent read from " << indexOffset);
     pthread_mutex_lock(&direntCacheLock);
-    direntCache.put(idx, dirent);
+    direntCache.put(idx.v, dirent);
     pthread_mutex_unlock(&direntCacheLock);
 
     return dirent;
@@ -368,7 +368,7 @@ offset_t readOffset(const Reader& reader, size_t idx)
     if (idx >= getCountClusters())
       throw ZimFileFormatError("cluster index out of range");
 
-    return clusterCache.getOrPut(idx, [=](){ return readCluster(idx); });
+    return clusterCache.getOrPut(idx.v, [=](){ return readCluster(idx); });
   }
 
   offset_t FileImpl::getClusterOffset(cluster_index_t idx) const

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -52,11 +52,11 @@ namespace zim
       std::unique_ptr<const Reader> urlPtrOffsetReader;
       std::unique_ptr<const Reader> clusterOffsetReader;
 
-      lru_cache<article_index_t, std::shared_ptr<const Dirent>> direntCache;
+      lru_cache<article_index_type, std::shared_ptr<const Dirent>> direntCache;
       pthread_mutex_t direntCacheLock;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
-      ConcurrentCache<cluster_index_t, ClusterHandle> clusterCache;
+      ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
       bool cacheUncompressedCluster;
       typedef std::map<char, article_index_t> NamespaceCache;


### PR DESCRIPTION
When using `zim::article_index_t`, MSVC fails to find the right
implementation to use for `!=` operator between:
- Internal implementation in some `xmemory` header
- libzim implementation `operator!=` defined for `zim::article_index_t`.

By using the plain `zim::article_index_type` (an alias for uint32_t),
there is no more conflict.

We do the same for `cluster_index_t`.

Fix #414