### PR TITLE
Fixed Cluster::getBlob() for 32-bit platforms

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -69,6 +69,9 @@ const Buffer Buffer::makeBuffer(const char* data, zsize_t size)
 
 Buffer Buffer::makeBuffer(zsize_t size)
 {
+  if (0 == size.v) {
+    return Buffer(DataPtr(nonOwnedDataPtr, nullptr), size);
+  }
   return Buffer(DataPtr(new char[size.v], std::default_delete<char[]>()), size);
 }
 

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -150,6 +150,9 @@ getClusterReader(const Reader& zimReader, offset_t offset, CompressionType* comp
   {
     if (n < count()) {
       const auto blobSize = getBlobSize(n);
+      if (blobSize.v > SIZE_MAX) {
+        return Blob();
+      }
       return getReader(n).get_buffer(offset_t(0), blobSize);
     } else {
       return Blob();

--- a/test/bufferstreamer.cpp
+++ b/test/bufferstreamer.cpp
@@ -32,11 +32,6 @@ using namespace zim;
 // BufferStreamer
 ////////////////////////////////////////////////////////////////////////////////
 
-std::string toString(const Buffer& buffer)
-{
-  return std::string(buffer.data(), buffer.size().v);
-}
-
 TEST(BufferStreamer, shouldJustWork)
 {
   char data[] = "abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
This is a tentative fix of issue #427