### PR TITLE
Fixed getNamespaceEndOffset()

### DIFF
--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -63,8 +63,6 @@ namespace zim
 
       NamespaceCache namespaceBeginCache;
       pthread_mutex_t namespaceBeginLock;
-      NamespaceCache namespaceEndCache;
-      pthread_mutex_t namespaceEndLock;
 
       typedef std::vector<std::string> MimeTypes;
       MimeTypes mimeTypes;
@@ -163,6 +161,9 @@ namespace zim
   template<typename IMPL>
   article_index_t getNamespaceBeginOffset(IMPL& impl, char ch)
   {
+    ASSERT(ch, >=, 32);
+    ASSERT(ch, <=, 127);
+
     article_index_type lower = 0;
     article_index_type upper = article_index_type(impl.getCountArticles());
     auto d = impl.getDirent(article_index_t(0));
@@ -183,18 +184,9 @@ namespace zim
   template<typename IMPL>
   article_index_t getNamespaceEndOffset(IMPL& impl, char ch)
   {
-    article_index_type lower = 0;
-    article_index_type upper = article_index_type(impl.getCountArticles());
-    while (upper - lower > 1)
-    {
-      article_index_type m = lower + (upper - lower) / 2;
-      auto d = impl.getDirent(article_index_t(m));
-      if (d->getNamespace() > ch)
-        upper = m;
-      else
-        lower = m;
-    }
-    return article_index_t(upper);
+    ASSERT(ch, >=, 32);
+    ASSERT(ch, <, 127);
+    return getNamespaceBeginOffset(impl, ch+1);
   }
 
 

--- a/test/impl_find.cpp
+++ b/test/impl_find.cpp
@@ -42,6 +42,8 @@ const std::vector<std::pair<char, std::string>> articleurl = {
   {'A', "cccccc"},   //8
   {'M', "foo"},      //9
   {'a', "aa"},       //10
+  {'a', "bb"},       //11
+  {'b', "aa"}        //12
 };
 
 struct MockNamespace
@@ -69,6 +71,15 @@ TEST_F(NamespaceTest, BeginOffset)
   auto result = zim::getNamespaceBeginOffset(impl, 'a');
   ASSERT_EQ(result.v, 10);
 
+  result = zim::getNamespaceBeginOffset(impl, 'b');
+  ASSERT_EQ(result.v, 12);
+
+  result = zim::getNamespaceBeginOffset(impl, 'c');
+  ASSERT_EQ(result.v, 13);
+
+  result = zim::getNamespaceBeginOffset(impl, 'A'-1);
+  ASSERT_EQ(result.v, 0);
+
   result = zim::getNamespaceBeginOffset(impl, 'A');
   ASSERT_EQ(result.v, 0);
 
@@ -82,7 +93,16 @@ TEST_F(NamespaceTest, BeginOffset)
 TEST_F(NamespaceTest, EndOffset)
 {
   auto result = zim::getNamespaceEndOffset(impl, 'a');
-  ASSERT_EQ(result.v, 11);
+  ASSERT_EQ(result.v, 12);
+
+  result = zim::getNamespaceEndOffset(impl, 'b');
+  ASSERT_EQ(result.v, 13);
+
+  result = zim::getNamespaceEndOffset(impl, 'c');
+  ASSERT_EQ(result.v, 13);
+
+  result = zim::getNamespaceEndOffset(impl, 'A'-1);
+  ASSERT_EQ(result.v, 0);
 
   result = zim::getNamespaceEndOffset(impl, 'A');
   ASSERT_EQ(result.v, 9);
@@ -92,6 +112,14 @@ TEST_F(NamespaceTest, EndOffset)
 
   result = zim::getNamespaceEndOffset(impl, 'U');
   ASSERT_EQ(result.v, 10);
+}
+
+TEST_F(NamespaceTest, EndEqualStartPlus1)
+{
+  for (char ns=32; ns<127; ns++){
+    std::cout << "ns: " << ns << "|" << (int)ns << std::endl;
+    ASSERT_EQ(zim::getNamespaceEndOffset(impl, ns).v, zim::getNamespaceBeginOffset(impl, ns+1).v);
+  }
 }
 
 


### PR DESCRIPTION
Fixes #407

The first commit of this PR is borrowed from #408, the second one is just an [earlier review comment](https://github.com/openzim/libzim/pull/382#discussion_r461154489) put into life, which automatically fixed the problem with `getNamespaceEndOffset()`.