### PR TITLE
Fix for NarrowDown failing to locate the last item

### DIFF
--- a/src/narrowdown.h
+++ b/src/narrowdown.h
@@ -130,7 +130,7 @@ public: // functions
     const index_type prevEntryLindex = (it-1)->lindex;
 
     if ( it == entries.end() )
-      return {prevEntryLindex+1, prevEntryLindex+1};
+      return {prevEntryLindex, prevEntryLindex+1};
 
     return {prevEntryLindex, it->lindex+1};
   }

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -143,6 +143,10 @@ TEST_F(FindxTest, ExactMatch)
   result = dl.find('A', "aabbbb");
   ASSERT_EQ(result.first, true);
   ASSERT_EQ(result.second.v, 6);
+
+  result = dl.find('b', "aa");
+  ASSERT_EQ(result.first, true);
+  ASSERT_EQ(result.second.v, 12);
 }
 
 


### PR DESCRIPTION
There was a bug in #430 - `zim::NarrowDown::getRange()` failed to locate the last item (entered via `zim::NarrowDown::close()`). This bug was caught by a zim-tools unit tests [CI run](https://github.com/openzim/zim-tools/pull/169/checks?check_run_id=1317019271). For some reason in my build tree the unit-tests of zim-tools don't run:

```
$ (cd BUILD_native_static/zim-tools && meson test -v)
ninja: Entering directory `~/Kiwix/builddir/BUILD_native_static/zim-tools'
ninja: no work to do.
No tests defined.
```