### PR TITLE
No pthread

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,14 +42,19 @@ conf.set('ENABLE_XAPIAN', xapian_dep.found())
 
 pkg_requires = ['liblzma', 'libzstd']
 if build_machine.system() == 'windows'
-    thread_dep = dependency('libpthreadVC2')
-    pkg_requires += ['libpthreadVC2']
     extra_link_args = ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-licuuc', '-licuin']
     extra_cpp_args = ['-DSORTPP_PASS']
 else
-    thread_dep = dependency('threads')
     extra_link_args = []
     extra_cpp_args = []
+endif
+
+compiler = meson.get_compiler('cpp')
+if compiler.get_id() == 'gcc' and build_machine.system() == 'linux'
+  # C++ std::thread is implemented using pthread on linux by gcc
+  thread_dep = dependency('threads')
+else
+  thread_dep = dependency('', required:false)
 endif
 
 if xapian_dep.found()

--- a/src/debug.h
+++ b/src/debug.h
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <stdlib.h>
 
 #if defined (NDEBUG)

--- a/src/file_reader.cpp
+++ b/src/file_reader.cpp
@@ -26,7 +26,6 @@
 #include <string.h>
 #include <cstring>
 #include <fcntl.h>
-#include <pthread.h>
 #include <sstream>
 #include <system_error>
 #include <algorithm>

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <map>
 #include <memory>
-#include <pthread.h>
 #include <zim/zim.h>
 #include <zim/fileheader.h>
 #include <mutex>
@@ -45,7 +44,7 @@ namespace zim
       std::shared_ptr<FileCompound> zimFile;
       std::shared_ptr<FileReader> zimReader;
       std::vector<char> bufferDirentZone;
-      pthread_mutex_t bufferDirentLock;
+      std::mutex bufferDirentLock;
       Fileheader header;
       std::string filename;
 
@@ -54,7 +53,7 @@ namespace zim
       std::unique_ptr<const Reader> clusterOffsetReader;
 
       lru_cache<article_index_type, std::shared_ptr<const Dirent>> direntCache;
-      pthread_mutex_t direntCacheLock;
+      std::mutex direntCacheLock;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -78,12 +78,10 @@ void Cluster::close() {
     compress();
     clear_raw_data();
   }
-  std::lock_guard<std::mutex> l(m_closedMutex);
   closed = true;
 }
 
 bool Cluster::isClosed() const{
-  std::lock_guard<std::mutex> l(m_closedMutex);
   return closed;
 }
 

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -45,11 +45,9 @@ Cluster::Cluster(CompressionType compression)
     _size(0)
 {
   blobOffsets.push_back(offset_t(0));
-  pthread_mutex_init(&m_closedMutex,NULL);
 }
 
 Cluster::~Cluster() {
-  pthread_mutex_destroy(&m_closedMutex);
   if (compressed_data.data()) {
     delete[] compressed_data.data();
   }
@@ -80,17 +78,13 @@ void Cluster::close() {
     compress();
     clear_raw_data();
   }
-  pthread_mutex_lock(&m_closedMutex);
+  std::lock_guard<std::mutex> l(m_closedMutex);
   closed = true;
-  pthread_mutex_unlock(&m_closedMutex);
 }
 
 bool Cluster::isClosed() const{
-  bool v;
-  pthread_mutex_lock(&m_closedMutex);
-  v = closed;
-  pthread_mutex_unlock(&m_closedMutex);
-  return v;
+  std::lock_guard<std::mutex> l(m_closedMutex);
+  return closed;
 }
 
 zsize_t Cluster::size() const

--- a/src/writer/cluster.h
+++ b/src/writer/cluster.h
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <vector>
 #include <functional>
-#include <mutex>
+#include <atomic>
 
 #include <zim/writer/article.h>
 #include "../zim_types.h"
@@ -88,8 +88,7 @@ class Cluster {
     ClusterData _data;
     mutable Blob compressed_data;
     std::string tmp_filename;
-    mutable std::mutex m_closedMutex;
-    bool closed = false;
+    std::atomic<bool> closed { false };
 
   private:
     void write_content(writer_t writer) const;

--- a/src/writer/cluster.h
+++ b/src/writer/cluster.h
@@ -24,8 +24,8 @@
 #include <zim/blob.h>
 #include <iostream>
 #include <vector>
-#include <pthread.h>
 #include <functional>
+#include <mutex>
 
 #include <zim/writer/article.h>
 #include "../zim_types.h"
@@ -88,7 +88,7 @@ class Cluster {
     ClusterData _data;
     mutable Blob compressed_data;
     std::string tmp_filename;
-    mutable pthread_mutex_t m_closedMutex;
+    mutable std::mutex m_closedMutex;
     bool closed = false;
 
   private:

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -88,12 +88,11 @@ namespace zim
 
       for(unsigned i=0; i<nbWorkerThreads; i++)
       {
-        pthread_t thread;
-        pthread_create(&thread, NULL, taskRunner, this->data.get());
-        data->workerThreads.push_back(thread);
+        std::thread thread(taskRunner, this->data.get());
+        data->workerThreads.push_back(std::move(thread));
       }
 
-      pthread_create(&data->writerThread, NULL, clusterWriter, this->data.get());
+      data->writerThread = std::thread(clusterWriter, this->data.get());
     }
 
     void Creator::addArticle(std::shared_ptr<Article> article)
@@ -209,12 +208,12 @@ namespace zim
         data->taskList.pushToQueue(nullptr);
       }
       for(auto& thread: data->workerThreads) {
-        pthread_join(thread, nullptr);
+        thread.join();
       }
 
       // Wait for writerThread to finish.
       data->clusterToWrite.pushToQueue(nullptr);
-      pthread_join(data->writerThread, nullptr);
+      data->writerThread.join();
 
       TINFO("ResolveRedirectIndexes");
       data->resolveRedirectIndexes();

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -29,6 +29,7 @@
 #include <vector>
 #include <map>
 #include <fstream>
+#include <thread>
 #include "config.h"
 
 #include "direntPool.h"
@@ -67,7 +68,7 @@ namespace zim
         typedef std::vector<Cluster*> ClusterList;
         typedef Queue<Cluster*> ClusterQueue;
         typedef Queue<Task*> TaskQueue;
-        typedef std::vector<pthread_t> ThreadList;
+        typedef std::vector<std::thread> ThreadList;
 
         CreatorData(const std::string& fname, bool verbose,
                        bool withIndex, std::string language,
@@ -103,7 +104,7 @@ namespace zim
         ClusterQueue clusterToWrite;
         TaskQueue taskList;
         ThreadList workerThreads;
-        pthread_t  writerThread;
+        std::thread  writerThread;
         const CompressionType compression;
         std::string basename;
         bool isEmpty = true;

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -41,11 +41,12 @@
 #include <limits>
 #include <stdexcept>
 #include <sstream>
+#include <mutex>
 #include "log.h"
 #include "../fs.h"
 #include "../tools.h"
 
-static pthread_mutex_t s_dbaccessLock = PTHREAD_MUTEX_INITIALIZER;
+static std::mutex s_dbaccessLock;
 std::atomic<unsigned long> zim::writer::ClusterTask::waiting_task(0);
 std::atomic<unsigned long> zim::writer::IndexTask::waiting_task(0);
 
@@ -140,9 +141,8 @@ namespace zim
         indexer.index_text_without_positions(content);
       }
 
-      pthread_mutex_lock(&s_dbaccessLock);
+      std::lock_guard<std::mutex> l(s_dbaccessLock);
       data->indexer->writableDatabase.add_document(document);
-      pthread_mutex_unlock(&s_dbaccessLock);
     }
 #endif
 

--- a/src/xapian/htmlparse.cc
+++ b/src/xapian/htmlparse.cc
@@ -29,12 +29,12 @@
 // #include "utf8convert.h"
 
 #include <algorithm>
+#include <mutex>
 
 #include <ctype.h>
 #include <cstring>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
 
 using namespace std;
 
@@ -47,7 +47,7 @@ lowercase_string(string &str)
 }
 
 map<string, unsigned int> zim::HtmlParser::named_ents;
-static pthread_mutex_t sInitLock = PTHREAD_MUTEX_INITIALIZER;
+static std::mutex sInitLock;
 
 inline static bool
 p_notdigit(char c)
@@ -107,7 +107,7 @@ zim::HtmlParser::HtmlParser()
 #include "namedentities.h"
 	{ NULL, 0 }
     };
-    pthread_mutex_lock(&sInitLock);
+    std::lock_guard<std::mutex> l(sInitLock);
     if (named_ents.empty()) {
 	const struct ent *i = ents;
 	while (i->n) {
@@ -115,7 +115,6 @@ zim::HtmlParser::HtmlParser()
 	    ++i;
 	}
     }
-    pthread_mutex_unlock(&sInitLock);
 }
 
 void

--- a/test/tools.h
+++ b/test/tools.h
@@ -85,6 +85,15 @@ public:
 };
 
 template<typename T>
+std::string to_string(const T& value)
+{
+  std::ostringstream ss;
+  ss << value;
+  return ss.str();
+}
+
+
+template<typename T>
 zim::Buffer write_to_buffer(const T& object)
 {
   TempFile tmpFile("test_temp_file");

--- a/test/zimfile.cpp
+++ b/test/zimfile.cpp
@@ -85,8 +85,8 @@ TEST(ZimFile, openingAnInvalidZimFileFails)
       for ( int count = 0; count < 100; count += 10 ) {
         const TestContext ctx{
                 {"prefix",  prefix.size() ? "yes" : "no" },
-                {"byte", std::to_string(byte) },
-                {"count", std::to_string(count) }
+                {"byte", zim::unittests::to_string(byte) },
+                {"count", zim::unittests::to_string(count) }
         };
         const std::string zimfileContent = prefix + std::string(count, byte);
         const auto tmpfile = makeTempFile("invalid_zim_file", zimfileContent);
@@ -120,7 +120,7 @@ TEST(ZimFile, nastyEmptyZimFile)
   const std::string correctContent = emptyZimFileContent();
   for ( int offset = 0; offset < 80; ++offset ) {
     if ( isNastyOffset(offset) ) {
-      const TestContext ctx{ {"offset", std::to_string(offset) } };
+      const TestContext ctx{ {"offset", zim::unittests::to_string(offset) } };
       std::string nastyContent(correctContent);
       nastyContent[offset] = '\xff';
       const auto tmpfile = makeTempFile("wrong_checksum_empty_zim_file", nastyContent);


### PR DESCRIPTION
This PR remove strong dependency on pthread.
We use c++11 thread library which uses native thread and mutex api.

We still use pthread on linux but it allow use to don't use a wrapping pthread library on Windows.