### PR TITLE
Fix compilation on libzim without xapian.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -32,8 +32,7 @@ common_sources = [
     'writer/article.cpp',
     'writer/cluster.cpp',
     'writer/dirent.cpp',
-    'writer/workers.cpp',
-    'writer/xapianIndexer.cpp'
+    'writer/workers.cpp'
 ]
 
 if host_machine.system() == 'windows'
@@ -44,7 +43,8 @@ endif
 
 xapian_sources = [
     'xapian/htmlparse.cc',
-    'xapian/myhtmlparse.cc'
+    'xapian/myhtmlparse.cc',
+    'writer/xapianIndexer.cpp'
 ]
 
 sources = common_sources

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "tools.h"
+#include "config.h"
 
 #include <sys/types.h>
 #include <dirent.h>
@@ -29,8 +30,7 @@
 #include <memory>
 #include <errno.h>
 
-#include <unicode/translit.h>
-#include <unicode/ucnv.h>
+
 
 #ifdef _WIN32
 # include <windows.h>
@@ -50,7 +50,10 @@
 # include <chrono>
 #endif
 
+#if defined(ENABLE_XAPIAN)
 
+#include <unicode/translit.h>
+#include <unicode/ucnv.h>
 std::string zim::removeAccents(const std::string& text)
 {
   ucnv_setDefaultName("UTF-8");
@@ -63,6 +66,7 @@ std::string zim::removeAccents(const std::string& text)
   ustring.toUTF8String(unaccentedText);
   return unaccentedText;
 }
+#endif
 
 
 void zim::microsleep(int microseconds) {

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -25,7 +25,6 @@
 #include "queue.h"
 #include "_dirent.h"
 #include "workers.h"
-#include "xapianIndexer.h"
 #include <vector>
 #include <map>
 #include <fstream>
@@ -34,6 +33,7 @@
 #include "direntPool.h"
 
 #if defined(ENABLE_XAPIAN)
+  #include "xapianIndexer.h"
   class XapianIndexer;
 #endif
 

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -80,6 +80,7 @@ namespace zim
       cluster->close();
     };
 
+#if defined(ENABLE_XAPIAN)
     void IndexTask::run(CreatorData* data) {
       Xapian::Stem stemmer;
       Xapian::TermGenerator indexer;
@@ -143,6 +144,8 @@ namespace zim
       data->indexer->writableDatabase.add_document(document);
       pthread_mutex_unlock(&s_dbaccessLock);
     }
+#endif
+
 
     void* taskRunner(void* arg) {
       auto creatorData = static_cast<zim::writer::CreatorData*>(arg);


### PR DESCRIPTION
Xapian is optional, we msut be able to compile without it.

While libzim compile without xapian, we have NOT tested that search api
and creator don't break when used without xapian.

This technically allow us to build libzim without xapian and this is needed to have a (first) libzim CI on windows.
But, as already said, it doesn't not enforce libzim works correctly without xapian.
Future PR will fix that.

See #423