### PR TITLE
CI windows

### DIFF
--- a/.github/script/build_libzim.cmd
+++ b/.github/script/build_libzim.cmd
@@ -1,0 +1,10 @@
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+
+set CC=cl.exe
+set CXX=cl.exe
+
+meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
+
+cd build
+
+ninja.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,29 @@ jobs:
         env:
           SKIP_BIG_MEMORY_TEST: 1
 
+  Windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Setup python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - name: Install packages
+        run:
+          choco install ninja
+      - name: Install python modules
+        run: pip3 install meson
+      - name: Compile
+        shell: cmd
+        run: .github\script\build_libzim.cmd
+      - name: Test
+        shell: cmd
+        run: |
+          cd build
+          meson test --verbose
+
   Linux:
     strategy:
       fail-fast: false

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,9 @@ static_linkage = get_option('static-linkage')
 static_linkage = static_linkage or get_option('default_library')=='static'
 
 lzma_dep = dependency('liblzma', static:static_linkage)
+if static_linkage
+  add_project_arguments('-DLZMA_API_STATIC', language: 'cpp')
+endif
 
 zstd_dep = dependency('libzstd', static:static_linkage)
 

--- a/subprojects/liblzma.wrap
+++ b/subprojects/liblzma.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = xz-5.2.1
+
+source_url = http://tukaani.org/xz/xz-5.2.1.tar.xz
+source_filename = xz-5.2.1.tar.xz
+source_hash = 6ecdd4d80b12001497df0741d6037f918d270fa0f9a1ab4e2664bf4157ae323c
+
+patch_url = https://download.kiwix.org/dev/xz-5.2.1-wrap.zip
+patch_filename = xz-5.2.1-wrap.zip
+patch_hash = 782a4e56bcc26ebda18041a05f2f85dce70284109a5ce99ea960c6b4432a99e9
+
+[provide]
+liblzma = lzma_dep

--- a/subprojects/zstd.wrap
+++ b/subprojects/zstd.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = zstd-1.4.5
+source_url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz
+source_filename = zstd-1.4.5.tar.gz
+source_hash = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
+
+patch_url = https://download.kiwix.org/dev/zstd-1.4.5-wrap.zip
+patch_filename = zstd-1.4.5-wrap.zip
+patch_hash = 4462693b58939b61ab76c5e5597343ab156eb0681b60a77908d2b88e17dca7cc
+
+[provide]
+libzstd = libzstd_dep
+


### PR DESCRIPTION
This add a CI on windows (msvc compiler).

lzma and zstd dependencies are build using meson wrap file system.
The wrap patch archives are generated from projects https://github.com/kymeria/liblzma and https://github.com/kymeria/zstd which contains the patches I apply to the meson build system.
These patches will be send upstream.

Depends of #443 
Fix #357 