### PR TITLE
Title index check allows duplicate titles

### DIFF
--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -627,7 +627,7 @@ std::string pseudoTitle(const Dirent& d)
       }
       const auto direntOffset = readOffset(*urlPtrOffsetReader, a);
       const std::shared_ptr<const Dirent> dirent = readDirent(direntOffset);
-      if ( prevDirent && !(pseudoTitle(*prevDirent) < pseudoTitle(*dirent)) )
+      if ( prevDirent && !(pseudoTitle(*prevDirent) <= pseudoTitle(*dirent)) )
       {
         std::cerr << "Title index is not properly sorted:\n"
                   << "  #" << i-1 << ": " << pseudoTitle(*prevDirent) << "\n"


### PR DESCRIPTION
Fixes #456 

This is an easy fix, however it won't show up in zim-tools until openzim/zim-tools#196 is merged (zim-tools still depends on the old libzim API, its compilation is broken and I don't know of any kiwix configuration & release management procedure of backporting a bugfix).