### PR TITLE
Better deactivate xapian support.

### DIFF
--- a/.github/script/build_libzim.cmd
+++ b/.github/script/build_libzim.cmd
@@ -3,7 +3,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliar
 set CC=cl.exe
 set CXX=cl.exe
 
-meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
+meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dwith_xapian=disabled -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
 
 cd build
 

--- a/.github/script/build_libzim.cmd
+++ b/.github/script/build_libzim.cmd
@@ -3,7 +3,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliar
 set CC=cl.exe
 set CXX=cl.exe
 
-meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dwith_xapian=disabled -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
+meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dwith_xapian=false -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
 
 cd build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
           - android_arm64
           - win32_static
           - win32_dyn
+        with_xapian:
+          - enabled
+          - disabled
         include:
           - target: native_static
             image_variant: xenial
@@ -156,7 +159,7 @@ jobs:
           MESON_OPTION="$MESON_OPTION -Dandroid=true"
         fi
         cd $HOME/libzim
-        meson . build ${MESON_OPTION}
+        meson . build ${MESON_OPTION} -Dwith_xapian=${{matrix.with_xapian}}
         cd build
         ninja
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
           - win32_static
           - win32_dyn
         with_xapian:
-          - enabled
-          - disabled
+          - true
+          - false
         include:
           - target: native_static
             image_variant: xenial

--- a/include/meson.build
+++ b/include/meson.build
@@ -6,12 +6,18 @@ install_headers(
     'zim/error.h',
     'zim/item.h',
     'zim/entry.h',
-    'zim/search.h',
-    'zim/search_iterator.h',
     'zim/uuid.h',
     'zim/zim.h',
     subdir:'zim'
 )
+
+if xapian_dep.found()
+  install_headers(
+    'zim/search.h',
+    'zim/search_iterator.h',
+    subdir:'zim'
+  )
+endif
 
 install_headers(
     'zim/writer/item.h',

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,28 +1,3 @@
+subdir('zim')
+
 include_directory = include_directories('.')
-
-install_headers(
-    'zim/archive.h',
-    'zim/blob.h',
-    'zim/error.h',
-    'zim/item.h',
-    'zim/entry.h',
-    'zim/uuid.h',
-    'zim/zim.h',
-    subdir:'zim'
-)
-
-if xapian_dep.found()
-  install_headers(
-    'zim/search.h',
-    'zim/search_iterator.h',
-    subdir:'zim'
-  )
-endif
-
-install_headers(
-    'zim/writer/item.h',
-    'zim/writer/creator.h',
-    'zim/writer/contentProvider.h',
-    subdir:'zim/writer'
-)
-

--- a/include/zim/meson.build
+++ b/include/zim/meson.build
@@ -1,0 +1,30 @@
+zim_config = configure_file(output : 'zim_config.h',
+                            configuration : public_conf)
+
+install_headers(
+    'archive.h',
+    'blob.h',
+    'error.h',
+    'item.h',
+    'entry.h',
+    'uuid.h',
+    'zim.h',
+    zim_config,
+    subdir:'zim'
+)
+
+if xapian_dep.found()
+  install_headers(
+    'search.h',
+    'search_iterator.h',
+    subdir:'zim'
+  )
+endif
+
+install_headers(
+    'writer/item.h',
+    'writer/creator.h',
+    'writer/contentProvider.h',
+    subdir:'zim/writer'
+)
+

--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -32,6 +32,8 @@
 #endif
 
 
+#include <zim/zim_config.h>
+
 namespace zim
 {
   // An index of an entry (in a zim file)

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ if target_machine.system() == 'freebsd'
 endif
 
 xapian_dep = dependency('xapian-core',
-                        required:false,
+                        required:get_option('with_xapian'),
                         static:static_linkage)
 conf.set('ENABLE_XAPIAN', xapian_dep.found())
 

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,10 @@ cpp = meson.get_compiler('cpp')
 sizeof_off_t = cpp.sizeof('off_t')
 
 private_conf = configuration_data()
+public_conf = configuration_data()
+
 private_conf.set('VERSION', '"@0@"'.format(meson.project_version()))
+public_conf.set('LIBZIM_VERSION', '"@0@"'.format(meson.project_version()))
 private_conf.set('DIRENT_CACHE_SIZE', get_option('DIRENT_CACHE_SIZE'))
 private_conf.set('DIRENT_LOOKUP_CACHE_SIZE', get_option('DIRENT_LOOKUP_CACHE_SIZE'))
 private_conf.set('CLUSTER_CACHE_SIZE', get_option('CLUSTER_CACHE_SIZE'))
@@ -42,6 +45,7 @@ xapian_dep = dependency('xapian-core',
                         required:get_option('with_xapian'),
                         static:static_linkage)
 private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
+public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
 
 pkg_requires = ['liblzma', 'libzstd']
 if build_machine.system() == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -10,19 +10,19 @@ endif
 cpp = meson.get_compiler('cpp')
 sizeof_off_t = cpp.sizeof('off_t')
 
-conf = configuration_data()
-conf.set('VERSION', '"@0@"'.format(meson.project_version()))
-conf.set('DIRENT_CACHE_SIZE', get_option('DIRENT_CACHE_SIZE'))
-conf.set('DIRENT_LOOKUP_CACHE_SIZE', get_option('DIRENT_LOOKUP_CACHE_SIZE'))
-conf.set('CLUSTER_CACHE_SIZE', get_option('CLUSTER_CACHE_SIZE'))
-conf.set('LZMA_MEMORY_SIZE', get_option('LZMA_MEMORY_SIZE'))
-conf.set10('MMAP_SUPPORT_64', sizeof_off_t==8)
+private_conf = configuration_data()
+private_conf.set('VERSION', '"@0@"'.format(meson.project_version()))
+private_conf.set('DIRENT_CACHE_SIZE', get_option('DIRENT_CACHE_SIZE'))
+private_conf.set('DIRENT_LOOKUP_CACHE_SIZE', get_option('DIRENT_LOOKUP_CACHE_SIZE'))
+private_conf.set('CLUSTER_CACHE_SIZE', get_option('CLUSTER_CACHE_SIZE'))
+private_conf.set('LZMA_MEMORY_SIZE', get_option('LZMA_MEMORY_SIZE'))
+private_conf.set10('MMAP_SUPPORT_64', sizeof_off_t==8)
 if target_machine.system() == 'windows'
-    conf.set('ENABLE_USE_MMAP', false)
+    private_conf.set('ENABLE_USE_MMAP', false)
 else
-    conf.set('ENABLE_USE_MMAP', get_option('USE_MMAP'))
+    private_conf.set('ENABLE_USE_MMAP', get_option('USE_MMAP'))
 endif
-conf.set('ENABLE_USE_BUFFER_HEADER', get_option('USE_BUFFER_HEADER'))
+private_conf.set('ENABLE_USE_BUFFER_HEADER', get_option('USE_BUFFER_HEADER'))
 
 static_linkage = get_option('static-linkage')
 static_linkage = static_linkage or get_option('default_library')=='static'
@@ -41,7 +41,7 @@ endif
 xapian_dep = dependency('xapian-core',
                         required:get_option('with_xapian'),
                         static:static_linkage)
-conf.set('ENABLE_XAPIAN', xapian_dep.found())
+private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
 
 pkg_requires = ['liblzma', 'libzstd']
 if build_machine.system() == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -41,9 +41,11 @@ if target_machine.system() == 'freebsd'
     execinfo_dep = cpp.find_library('execinfo')
 endif
 
-xapian_dep = dependency('xapian-core',
-                        required:get_option('with_xapian'),
-                        static:static_linkage)
+if get_option('with_xapian')
+    xapian_dep = dependency('xapian-core', static:static_linkage)
+else
+    xapian_dep = dependency('', required:false)
+endif
 private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
 public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,3 +16,5 @@ option('static-linkage', type : 'boolean', value : false,
   description : 'Link statically with the dependencies.')
 option('doc', type : 'boolean', value : false,
   description : 'Build the documentations.')
+option('with_xapian', type : 'feature', value: 'enabled',
+  description: 'Build libzim with xapian support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,5 +16,5 @@ option('static-linkage', type : 'boolean', value : false,
   description : 'Link statically with the dependencies.')
 option('doc', type : 'boolean', value : false,
   description : 'Build the documentations.')
-option('with_xapian', type : 'feature', value: 'enabled',
+option('with_xapian', type : 'boolean', value: true,
   description: 'Build libzim with xapian support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 
 configure_file(output : 'config.h',
-               configuration : conf,
+               configuration : private_conf,
                input : 'config.h.in')
 
 src_directory = include_directories('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,11 +21,8 @@ common_sources = [
     'blob.cpp',
     'buffer.cpp',
     'md5.c',
-    'search.cpp',
-    'search_iterator.cpp',
     'template.cpp',
     'uuid.cpp',
-    'levenshtein.cpp',
     'tools.cpp',
     'compression.cpp',
     'istreamreader.cpp',
@@ -44,6 +41,9 @@ else
 endif
 
 xapian_sources = [
+    'search.cpp',
+    'search_iterator.cpp',
+    'levenshtein.cpp',
     'xapian/htmlparse.cc',
     'xapian/myhtmlparse.cc',
     'writer/xapianIndexer.cpp'

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -36,17 +36,14 @@
 #endif
 #include <errno.h>
 
-#if defined(ENABLE_XAPIAN)
 #include "xapian.h"
 #include <unicode/locid.h>
-#endif
 
 #define MAX_MATCHES_TO_SORT 10000
 
 namespace zim
 {
 
-#if defined(ENABLE_XAPIAN)
 namespace {
 /* Split string in a token array */
 std::vector<std::string> split(const std::string & str,
@@ -136,7 +133,6 @@ class LevenshteinDistanceMaker : public Xapian::KeyMaker {
 };
 
 }
-#endif
 
 Search::Search(const std::vector<Archive>& archives) :
     internal(new InternalData),
@@ -242,7 +238,6 @@ Search& Search::set_suggestion_mode(const bool suggestion_mode) {
 #define WITH_LEV 1
 
 Search::iterator Search::begin() const {
-#if defined(ENABLE_XAPIAN)
     if ( this->search_started ) {
         return new search_iterator::InternalData(this, internal->results.begin());
     }
@@ -416,21 +411,13 @@ Search::iterator Search::begin() const {
     search_started = true;
     estimated_matches_number = internal->results.get_matches_estimated();
     return new search_iterator::InternalData(this, internal->results.begin());
-#else
-    estimated_matches_number = 0;
-    return nullptr;
-#endif
 }
 
 Search::iterator Search::end() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! has_database ) {
         return nullptr;
     }
     return new search_iterator::InternalData(this, internal->results.end());
-#else
-    return nullptr;
-#endif
 }
 
 int Search::get_matches_estimated() const {

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -20,34 +20,25 @@
 #ifndef ZIM_SEARCH_INTERNAL_H
 #define ZIM_SEARCH_INTERNAL_H
 
-#include "config.h"
-
-#if defined(ENABLE_XAPIAN)
 #include <xapian.h>
-#endif
 
 #include <zim/entry.h>
 
 namespace zim {
 
 struct Search::InternalData {
-#if defined(ENABLE_XAPIAN)
     std::vector<Xapian::Database> xapian_databases;
     Xapian::Database database;
     Xapian::MSet results;
-#endif
 };
 
 struct search_iterator::InternalData {
-#if defined(ENABLE_XAPIAN)
     const Search* search;
     Xapian::MSetIterator iterator;
     Xapian::Document _document;
     bool document_fetched;
-#endif
     std::unique_ptr<Entry> _entry;
 
-#if defined(ENABLE_XAPIAN)
     InternalData(const InternalData& other) :
       search(other.search),
       iterator(other.iterator),
@@ -84,24 +75,18 @@ struct search_iterator::InternalData {
         }
         return _document;
     }
-#endif
 
     int get_databasenumber() {
-#if defined(ENABLE_XAPIAN)
         Xapian::docid docid = *iterator;
         return (docid - 1) % search->m_archives.size();
-#endif
-        return 0;
     }
 
     Entry& get_entry() {
-#if defined(ENABLE_XAPIAN)
         if ( !_entry ) {
             int databasenumber = get_databasenumber();
             auto archive = search->m_archives.at(databasenumber);
             _entry.reset(new Entry(archive.getEntryByPath(get_document().get_data())));
         }
-#endif
         return *_entry.get();
     }
 };

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -41,36 +41,24 @@ search_iterator::search_iterator(InternalData* internal_data)
 search_iterator::search_iterator(const search_iterator& it)
     : internal(nullptr)
 {
-#if defined(ENABLE_XAPIAN)
-    // Without xapian, internal is allways null
     if (it.internal) internal = std::unique_ptr<InternalData>(new InternalData(*it.internal));
-#endif
 }
 
 search_iterator & search_iterator::operator=(const search_iterator& it) {
-#if defined(ENABLE_XAPIAN)
-    // Without xapian, internal is allways null
     if ( ! it.internal ) internal.reset();
     else if ( ! internal ) internal = std::unique_ptr<InternalData>(new InternalData(*it.internal));
     else *internal = *it.internal;
-#endif
 
     return *this;
 }
 
 bool search_iterator::operator==(const search_iterator& it) const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal && ! it.internal)
         return true;
     if ( ! internal || ! it.internal)
         return false;
     return (internal->search == it.internal->search
          && internal->iterator == it.internal->iterator);
-#else
-    // If there is no xapian, there is no search. There is only one iterator: end.
-    // So all iterators are equal.
-    return true;
-#endif
 }
 
 bool search_iterator::operator!=(const search_iterator& it) const {
@@ -78,14 +66,12 @@ bool search_iterator::operator!=(const search_iterator& it) const {
 }
 
 search_iterator& search_iterator::operator++() {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return *this;
     }
     ++(internal->iterator);
     internal->document_fetched = false;
     internal->_entry.reset();
-#endif
     return *this;
 }
 
@@ -96,14 +82,12 @@ search_iterator search_iterator::operator++(int) {
 }
 
 search_iterator& search_iterator::operator--() {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return *this;
     }
     --(internal->iterator);
     internal->document_fetched = false;
     internal->_entry.reset();
-#endif
     return *this;
 }
 
@@ -114,18 +98,13 @@ search_iterator search_iterator::operator--(int) {
 }
 
 std::string search_iterator::get_url() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return "";
     }
     return internal->get_document().get_data();
-#else
-    return "";
-#endif
 }
 
 std::string search_iterator::get_title() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return "";
     }
@@ -138,23 +117,17 @@ std::string search_iterator::get_title() const {
     {
         return internal->get_document().get_value(internal->search->valuesmap["title"]);
     }
-#endif
     return "";
 }
 
 int search_iterator::get_score() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return 0;
     }
     return internal->iterator.get_percent();
-#else
-    return 0;
-#endif
 }
 
 std::string search_iterator::get_snippet() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return "";
     }
@@ -179,19 +152,15 @@ std::string search_iterator::get_snippet() const {
         zim::MyHtmlParser htmlParser;
         std::string content = entry.getItem().getData();
         try {
-            htmlParser.parse_html(content, "UTF-8", true);
+          htmlParser.parse_html(content, "UTF-8", true);
         } catch (...) {}
         return internal->search->internal->results.snippet(htmlParser.dump, 500);
-    } catch(...) {
+    } catch (...) {
       return "";
     }
-#else
-    return "";
-#endif
 }
 
 int search_iterator::get_size() const {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return -1;
     }
@@ -204,14 +173,12 @@ int search_iterator::get_size() const {
     {
         return atoi(internal->get_document().get_value(internal->search->valuesmap["size"]).c_str());
     }
-#endif
     /* The size is never used. Do we really want to get the content and
        calculate the size ? */
     return -1;
 }
 
 int search_iterator::get_wordCount() const      {
-#if defined(ENABLE_XAPIAN)
     if ( ! internal ) {
         return -1;
     }
@@ -224,16 +191,13 @@ int search_iterator::get_wordCount() const      {
     {
         return atoi(internal->get_document().get_value(internal->search->valuesmap["wordcount"]).c_str());
     }
-#endif
     return -1;
 }
 
 int search_iterator::get_fileIndex() const {
-#if defined(ENABLE_XAPIAN)
     if ( internal ) {
         return internal->get_databasenumber();
     }
-#endif
     return 0;
 }
 

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -36,7 +36,6 @@
 
 #if defined(ENABLE_XAPIAN)
   #include "xapianIndexer.h"
-  class XapianIndexer;
 #endif
 
 namespace zim

--- a/src/writer/xapianIndexer.h
+++ b/src/writer/xapianIndexer.h
@@ -32,7 +32,6 @@ namespace zim {
     class IndexTask;
   }
 }
-class XapianIndexer;
 
 enum class IndexingMode {
   TITLE,


### PR DESCRIPTION
Simply remove the search api if libzim is compiled without xapian (related to #423).

The writer part is not changed. It will be better handled with implementation of https://github.com/openzim/libzim/issues/397