### PR TITLE
Using path in Entry error message

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -61,7 +61,7 @@ Item Entry::getItem(bool follow) const
   if (isRedirect()) {
     if (! follow) {
       std::ostringstream sstream;
-      sstream << "Entry " << m_idx << " is a redirect entry.";
+      sstream << "Entry " << getPath() << " is a redirect entry.";
       throw InvalidType(sstream.str());
     }
     return getRedirect();
@@ -82,7 +82,7 @@ Item Entry::getRedirect() const {
 Entry Entry::getRedirectEntry() const  {
   if (!isRedirect()) {
     std::ostringstream sstream;
-    sstream << "Entry " << m_idx << " is not a redirect entry.";
+    sstream << "Entry " << getPath() << " is not a redirect entry.";
     throw InvalidType(sstream.str());
   }
   return Entry(m_file, static_cast<entry_index_type>(m_dirent->getRedirectIndex()));


### PR DESCRIPTION
Since libzim is path-first, it makes more sense to display the path on error message rather than the index.

Found in https://github.com/openzim/python-libzim/pull/82