### PR TITLE
Fix parseLongPath() to handle namespaces

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -272,15 +272,28 @@ namespace zim
     // A findx with a will return 0
     // A find with b will return 4
     entry_index_t begin_idx, end_idx;
-    if (m_impl->hasNewNamespaceScheme()) {
+    if (path.empty() || path == "/") {
+      begin_idx = m_impl->getStartUserEntry();
+      end_idx = m_impl->getEndUserEntry(); 
+    } else if (m_impl->hasNewNamespaceScheme()) {
       begin_idx = m_impl->findx('C', path).second;
       path.back()++;
       end_idx = m_impl->findx('C', path).second;
     } else {
-      begin_idx = m_impl->findx(path).second;
-      path.back()++;
-      end_idx = m_impl->findx(path).second;
-    }
+      char ns;
+      try {
+        std::tie(ns, path) = parseLongPath(path);
+      } catch (...) {
+        return Archive::EntryRange<EntryOrder::pathOrder>(m_impl, 0, 0);
+      }
+      begin_idx = m_impl->findx(ns, path).second;
+      if (path.empty()) {
+        ns++;
+      } else {
+        path.back()++;
+      }
+      end_idx = m_impl->findx(ns, path).second;
+    } 
     return Archive::EntryRange<EntryOrder::pathOrder>(m_impl, begin_idx.v, end_idx.v);
   }
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -106,11 +106,11 @@ std::tuple<char, std::string> zim::parseLongPath(const std::string& longPath)
 {
   /* Index of the namespace char; discard '/' from absolute paths */
   const unsigned int i = (longPath[0] == '/') ? 1 : 0;
-  if (i + 2 >= longPath.size() || longPath[i] == '/' || longPath[i+1] != '/')
+  if (i + 1 > longPath.size() || longPath[i] == '/' || (i + 1 < longPath.size() && longPath[i+1] != '/'))
     throw std::runtime_error("Cannot parse path");
 
   auto ns = longPath[i];
-  auto shortPath = longPath.substr(i+2, std::string::npos);
+  auto shortPath = longPath.substr(std::min(i+2, (unsigned int)longPath.size()));
 
   return std::make_tuple(ns, shortPath);
 }

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -46,9 +46,13 @@ TEST(FindTests, NotFoundByPath)
     auto range0 = archive.findByPath("unkwonUrl");
     auto range1 = archive.findByPath("U/unkwonUrl");
     auto range2 = archive.findByPath("A/unkwonUrl");
+    auto range3 = archive.findByPath("X");
+    auto range4 = archive.findByPath("X/");
     ASSERT_EQ(range0.begin(), range0.end());
     ASSERT_EQ(range1.begin(), range1.end());
     ASSERT_EQ(range2.begin(), range2.end());
+    ASSERT_EQ(range3.begin(), range3.end());
+    ASSERT_EQ(range4.begin(), range4.end());
 }
 
 // Found cases
@@ -103,6 +107,10 @@ TEST(FindTests, ByPath)
     auto range0 = archive.findByPath("A/Main_Page.html");
     auto range1 = archive.findByPath("I/s/");
     auto range2 = archive.findByPath("-/j/head.js");
+    auto range3 = archive.findByPath("I");
+    auto range4 = archive.findByPath("I/");
+    auto range5 = archive.findByPath("");
+    auto range6 = archive.findByPath("/");
 
     ASSERT_EQ(range0.begin()->getIndex(), 5);
     auto count = 0;
@@ -122,12 +130,45 @@ TEST(FindTests, ByPath)
     ASSERT_EQ(count, 31);
 
     ASSERT_EQ(range2.begin()->getIndex(), 2);
-     count = 0;
+    count = 0;
     for(auto& entry: range2) {
       count++;
       ASSERT_EQ(entry.getPath().find("-/j/head.js"), 0);
     }
     ASSERT_EQ(count, 1);
+
+    ASSERT_EQ(range3.begin()->getIndex(), 75);
+    count = 0;
+    for(auto& entry: range3) {
+      count++;
+      std::cout << entry.getPath() << std::endl;
+      ASSERT_EQ(entry.getPath().find("I"), 0);
+    }
+    ASSERT_EQ(count, 34);
+
+    ASSERT_EQ(range4.begin()->getIndex(), 75);
+    count = 0;
+    for(auto& entry: range4) {
+      count++;
+      std::cout << entry.getPath() << std::endl;
+      ASSERT_EQ(entry.getPath().find("I/"), 0);
+    }
+    ASSERT_EQ(count, 34);
+
+    ASSERT_EQ(range5.begin()->getIndex(), 0);
+    count = 0;
+    for(auto& entry: range5) {
+      count++;
+    }
+    ASSERT_EQ(count, 118);
+
+    ASSERT_EQ(range6.begin()->getIndex(), 0);
+    count = 0;
+    for(auto& entry: range6) {
+      count++;
+    }
+    ASSERT_EQ(count, 118);
+    
 }
 
 } // namespace

--- a/test/parseLongPath.cpp
+++ b/test/parseLongPath.cpp
@@ -32,15 +32,12 @@ namespace
 TEST(ParseLongPathTest, invalid)
 {
   ASSERT_THROW(parseLongPath(""), std::runtime_error);
-  ASSERT_THROW(parseLongPath("A"), std::runtime_error);
-  ASSERT_THROW(parseLongPath("A/"), std::runtime_error);
   ASSERT_THROW(parseLongPath("AB"), std::runtime_error);
   ASSERT_THROW(parseLongPath("AB/path"), std::runtime_error);
   ASSERT_THROW(parseLongPath("/"), std::runtime_error);
   ASSERT_THROW(parseLongPath("//"), std::runtime_error);
-  ASSERT_THROW(parseLongPath("/A"), std::runtime_error);
-  ASSERT_THROW(parseLongPath("/A/"), std::runtime_error);
   ASSERT_THROW(parseLongPath("/AB"), std::runtime_error);
+  ASSERT_THROW(parseLongPath("AB/"), std::runtime_error);
   ASSERT_THROW(parseLongPath("/AB/path"), std::runtime_error);
   ASSERT_THROW(parseLongPath("//A/path"), std::runtime_error);
 }
@@ -78,9 +75,24 @@ TEST(ParseLongPathTest, valid)
   ASSERT_EQ(ns, 'L');
   ASSERT_EQ(path, "path/with/separator");
 
-   std::tie(ns, path) = parseLongPath("L//path/with/separator");
+  std::tie(ns, path) = parseLongPath("L//path/with/separator");
   ASSERT_EQ(ns, 'L');
   ASSERT_EQ(path, "/path/with/separator");
 
- }
+  std::tie(ns, path) = parseLongPath("A");
+  ASSERT_EQ(ns, 'A');
+  ASSERT_EQ(path, "");
+
+  std::tie(ns, path) = parseLongPath("/A");
+  ASSERT_EQ(ns, 'A');
+  ASSERT_EQ(path, "");
+
+  std::tie(ns, path) = parseLongPath("A/");
+  ASSERT_EQ(ns, 'A');
+  ASSERT_EQ(path, "");
+
+  std::tie(ns, path) = parseLongPath("/A/");
+  ASSERT_EQ(ns, 'A');
+  ASSERT_EQ(path, "");
+}
 };


### PR DESCRIPTION
Fixes #477 
If a `path` of length 1 is passed and qualifies as a namespace character, return `(ns, "")`
