### PR TITLE
Allow reading of zero sized data on zero sized reader.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ private_conf.set('LZMA_MEMORY_SIZE', get_option('LZMA_MEMORY_SIZE'))
 private_conf.set10('MMAP_SUPPORT_64', sizeof_off_t==8)
 if target_machine.system() == 'windows'
     private_conf.set('ENABLE_USE_MMAP', false)
+    add_project_arguments('-DNOMINMAX', language: 'cpp')
 else
     private_conf.set('ENABLE_USE_MMAP', get_option('USE_MMAP'))
 endif

--- a/src/buffer_reader.cpp
+++ b/src/buffer_reader.cpp
@@ -50,7 +50,7 @@ offset_t BufferReader::offset() const
 
 
 void BufferReader::read(char* dest, offset_t offset, zsize_t size) const {
-  ASSERT(offset.v, <, source.size().v);
+  ASSERT(offset.v, <=, source.size().v);
   ASSERT(offset+offset_t(size.v), <=, offset_t(source.size().v));
   if (! size ) {
     return;

--- a/src/file_reader.cpp
+++ b/src/file_reader.cpp
@@ -86,9 +86,8 @@ char MultiPartFileReader::read(offset_t offset) const {
   return ret;
 }
 
-
 void MultiPartFileReader::read(char* dest, offset_t offset, zsize_t size) const {
-  ASSERT(offset.v, <, _size.v);
+  ASSERT(offset.v, <=, _size.v);
   ASSERT(offset.v+size.v, <=, _size.v);
   if (! size ) {
     return;
@@ -250,7 +249,7 @@ char FileReader::read(offset_t offset) const
 
 void FileReader::read(char* dest, offset_t offset, zsize_t size) const
 {
-  ASSERT(offset.v, <, _size.v);
+  ASSERT(offset.v, <=, _size.v);
   ASSERT(offset.v+size.v, <=, _size.v);
   if (! size ) {
     return;

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -31,7 +31,7 @@
 namespace
 {
 
-using zim::unittests::TempFile;
+using zim::unittests::makeTempFile;
 
 using TestContextImpl = std::vector<std::pair<std::string, std::string> >;
 struct TestContext : TestContextImpl {
@@ -69,16 +69,6 @@ emptyZimArchiveContent()
   content += "\x9f\x3e\xcd\x95\x46\xf6\xc5\x3b\x35\xb4\xc6\xd4\xc0\x8e\xd0\x66"; // md5sum
   return content;
 }
-
-std::unique_ptr<TempFile>
-makeTempFile(const char* name, const std::string& content)
-{
-  std::unique_ptr<TempFile> p(new TempFile(name));
-  write(p->fd(), &content[0], content.size());
-  p->close();
-  return p;
-}
-
 
 TEST(ZimArchive, openingAnInvalidZimArchiveFails)
 {

--- a/test/meson.build
+++ b/test/meson.build
@@ -9,6 +9,7 @@ tests = [
     'template',
     'archive',
     'iterator',
+    'reader',
     'find',
     'compression',
     'dirent_lookup',

--- a/test/reader.cpp
+++ b/test/reader.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "tools.h"
+#include "buffer_reader.h"
+#include "file_reader.h"
+#include "fs.h"
+#include "file_compound.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+using namespace zim;
+using zim::unittests::makeTempFile;
+
+////////////////////////////////////////////////////////////////////////////////
+// FileReader
+////////////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<Reader> createFileReader(const char* data, zsize_t size) {
+  const auto tmpfile = makeTempFile("data", data);
+  auto fd = DEFAULTFS::openFile(tmpfile->path());
+  return std::unique_ptr<Reader>(new FileReader(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size));
+}
+
+std::unique_ptr<Reader> createMultiFileReader(const char* data, zsize_t size) {
+  const auto tmpfile = makeTempFile("data", data);
+  auto fileCompound = std::make_shared<FileCompound>(tmpfile->path());
+  return std::unique_ptr<Reader>(new MultiPartFileReader(fileCompound));
+}
+
+std::unique_ptr<Reader> createBufferReader(const char* data, zsize_t size) {
+  auto buffer = Buffer::makeBuffer(data, size);
+  return std::unique_ptr<Reader>(new BufferReader(buffer));
+}
+
+auto createReaders = {
+  createFileReader,
+  createMultiFileReader,
+  createBufferReader
+};
+
+TEST(FileReader, shouldJustWork)
+{
+  char data[] = "abcdefghijklmnopqrstuvwxyz";
+  for(auto& createReader:createReaders) {
+    auto baseOffset = createReader==createBufferReader ? ((offset_type)data) : 0;
+    auto reader = createReader(data, zsize_t(26));
+
+    ASSERT_EQ(offset_t(baseOffset+0), reader->offset());
+    ASSERT_EQ(zsize_t(sizeof(data)-1), reader->size());
+
+    ASSERT_EQ('a', reader->read(offset_t(0)));
+    ASSERT_EQ('e', reader->read(offset_t(4)));
+
+    char out[4] = {0, 0, 0, 0};
+    reader->read(out, offset_t(0), zsize_t(4));
+    ASSERT_EQ(0, memcmp(out, "abcd", 4));
+
+    reader->read(out, offset_t(5), zsize_t(2));
+    ASSERT_EQ(0, memcmp(out, "fgcd", 4));
+
+    reader->read(out, offset_t(10), zsize_t(0));
+    ASSERT_EQ(0, memcmp(out, "fgcd", 4));
+
+    reader->read(out, offset_t(10), zsize_t(4));
+    ASSERT_EQ(0, memcmp(out, "klmn", 4));
+
+    // Can read last bit of the file.
+    ASSERT_EQ('z', reader->read(offset_t(25)));
+    reader->read(out, offset_t(25), zsize_t(1));
+    ASSERT_EQ(0, memcmp(out, "zlmn", 4));
+
+    // Fail if we try to read out of the file.
+    ASSERT_THROW(reader->read(offset_t(26)), std::runtime_error);
+    ASSERT_THROW(reader->read(out, offset_t(25), zsize_t(4)), std::runtime_error);
+    ASSERT_THROW(reader->read(out, offset_t(30), zsize_t(4)), std::runtime_error);
+    ASSERT_THROW(reader->read(out, offset_t(30), zsize_t(0)), std::runtime_error);
+  }
+}
+
+TEST(FileReader, subReader)
+{
+  char data[] = "abcdefghijklmnopqrstuvwxyz";
+  for(auto& createReader:createReaders) {
+    auto baseOffset = createReader==createBufferReader ? ((offset_type)data) : 0;
+    auto reader = createReader(data, zsize_t(26));
+
+    auto subReader = reader->sub_reader(offset_t(4), zsize_t(20));
+
+    ASSERT_EQ(offset_t(baseOffset+4), subReader->offset());
+    ASSERT_EQ(zsize_t(20), subReader->size());
+
+    ASSERT_EQ('e', subReader->read(offset_t(0)));
+    ASSERT_EQ('i', subReader->read(offset_t(4)));
+
+    char out[4] = {0, 0, 0, 0};
+    subReader->read(out, offset_t(0), zsize_t(4));
+    ASSERT_EQ(0, memcmp(out, "efgh", 4));
+
+    subReader->read(out, offset_t(5), zsize_t(2));
+    ASSERT_EQ(0, memcmp(out, "jkgh", 4));
+
+    // Can read last bit of the file.
+    ASSERT_EQ('x', subReader->read(offset_t(19)));
+    subReader->read(out, offset_t(19), zsize_t(1));
+    ASSERT_EQ(0, memcmp(out, "xkgh", 4));
+
+    // Fail if we try to read out of the file.
+    ASSERT_THROW(subReader->read(offset_t(20)), std::runtime_error);
+    ASSERT_THROW(subReader->read(out, offset_t(18), zsize_t(4)), std::runtime_error);
+    ASSERT_THROW(subReader->read(out, offset_t(30), zsize_t(4)), std::runtime_error);
+    ASSERT_THROW(subReader->read(out, offset_t(30), zsize_t(0)), std::runtime_error);
+  }
+}
+
+TEST(FileReader, zeroReader)
+{
+  char data[] = "";
+  for(auto& createReader:createReaders) {
+    auto baseOffset = createReader==createBufferReader ? ((offset_type)data) : 0;
+    auto reader = createReader(data, zsize_t(0));
+
+    ASSERT_EQ(offset_t(baseOffset), reader->offset());
+    ASSERT_EQ(zsize_t(0), reader->size());
+
+    // Fail if we try to read out of the file.
+    ASSERT_THROW(reader->read(offset_t(0)), std::runtime_error);
+    char out[4] = {0, 0, 0, 0};
+    ASSERT_THROW(reader->read(out, offset_t(0), zsize_t(4)), std::runtime_error);
+
+    // Ok to read 0 byte on a 0 sized reader
+    reader->read(out, offset_t(0), zsize_t(0));
+    const char nullarray[] = {0, 0, 0, 0};
+    ASSERT_EQ(0, memcmp(out, nullarray, 4));
+  }
+}
+
+} // unnamed namespace

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -85,6 +85,16 @@ void TempFile::close()
   }
 }
 
+std::unique_ptr<TempFile>
+makeTempFile(const char* name, const std::string& content)
+{
+  std::unique_ptr<TempFile> p(new TempFile(name));
+  write(p->fd(), &content[0], content.size());
+  p->close();
+  return p;
+}
+
+
 } // namespace unittests
 
 } // namespace zim

--- a/test/tools.h
+++ b/test/tools.h
@@ -94,6 +94,9 @@ std::string to_string(const T& value)
   return ss.str();
 }
 
+std::unique_ptr<TempFile>
+makeTempFile(const char* name, const std::string& content);
+
 
 template<typename T>
 zim::Buffer write_to_buffer(const T& object)


### PR DESCRIPTION
It is technically valid to read a zero sized at offset zero on a
zero sized reader.

The real assertion is that don't read past the end of the reader so
only `ASSERT(offset.v+size.v, <=, _size.v);` is needed.

This happen when reading a zim file with empty content and we don't
use mmap (on windows).
The cluster create a sub-reader of 0 size for the content and when
we try to read the 0 size content on the reader, we hit the ASSERT.
If we use mmap, we don't read from the reader, we create a mmap and
everything is fine.

The crashing assert is the one from FileReader but the logic is the
same for the BufferReader.

Fix kiwix/kiwix-lib#448