### PR TITLE
Better dirent access (reading)

### DIFF
--- a/src/_dirent.h
+++ b/src/_dirent.h
@@ -64,8 +64,11 @@ namespace zim
           ns('\0')
       {}
 
+<<<<<<< HEAD
       explicit Dirent(const Buffer& buffer);
 
+=======
+>>>>>>> bb6fd44... Enter DirentReader
       bool isRedirect() const                 { return mimeType == redirectMimeType; }
       bool isLinktarget() const               { return mimeType == linktargetMimeType; }
       bool isDeleted() const                  { return mimeType == deletedMimeType; }
@@ -118,7 +121,6 @@ namespace zim
 
       void setItem(uint16_t mimeType_, cluster_index_t clusterNumber_, blob_index_t blobNumber_)
       {
-        ASSERT(mimeType, ==, 0);
         mimeType = mimeType_;
         clusterNumber = clusterNumber_;
         blobNumber = blobNumber_;

--- a/src/_dirent.h
+++ b/src/_dirent.h
@@ -64,11 +64,6 @@ namespace zim
           ns('\0')
       {}
 
-<<<<<<< HEAD
-      explicit Dirent(const Buffer& buffer);
-
-=======
->>>>>>> bb6fd44... Enter DirentReader
       bool isRedirect() const                 { return mimeType == redirectMimeType; }
       bool isLinktarget() const               { return mimeType == linktargetMimeType; }
       bool isDeleted() const                  { return mimeType == deletedMimeType; }

--- a/src/dirent.cpp
+++ b/src/dirent.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "_dirent.h"
+#include "direntreader.h"
 #include <zim/zim.h>
 #include "buffer.h"
 #include "bufferstreamer.h"
@@ -38,18 +39,29 @@ namespace zim
   const uint16_t Dirent::linktargetMimeType;
   const uint16_t Dirent::deletedMimeType;
 
+<<<<<<< HEAD
   Dirent::Dirent(const Buffer& bufferRef)
     : Dirent()
+=======
+  bool DirentReader::initDirent(Dirent& dirent, const Blob& direntData) const
+>>>>>>> bb6fd44... Enter DirentReader
   {
     BufferStreamer reader(bufferRef);
     uint16_t mimeType = reader.read<uint16_t>();
     bool redirect = (mimeType == Dirent::redirectMimeType);
     bool linktarget = (mimeType == Dirent::linktargetMimeType);
     bool deleted = (mimeType == Dirent::deletedMimeType);
+<<<<<<< HEAD
     uint8_t extraLen = reader.read<uint8_t>();
     char ns = reader.read<char>();
     uint32_t version = reader.read<uint32_t>();
     setVersion(version);
+=======
+    uint8_t extraLen = bds.read<uint8_t>();
+    char ns = bds.read<char>();
+    uint32_t version = bds.read<uint32_t>();
+    dirent.setVersion(version);
+>>>>>>> bb6fd44... Enter DirentReader
 
 
     if (redirect)
@@ -58,12 +70,20 @@ namespace zim
 
       log_debug("redirectIndex=" << redirectIndex);
 
+<<<<<<< HEAD
       setRedirect(entry_index_t(redirectIndex));
+=======
+      dirent.setRedirect(article_index_t(redirectIndex));
+>>>>>>> bb6fd44... Enter DirentReader
     }
     else if (linktarget || deleted)
     {
       log_debug("linktarget or deleted entry");
+<<<<<<< HEAD
       setItem(mimeType, cluster_index_t(0), blob_index_t(0));
+=======
+      dirent.setArticle(mimeType, cluster_index_t(0), blob_index_t(0));
+>>>>>>> bb6fd44... Enter DirentReader
     }
     else
     {
@@ -74,7 +94,11 @@ namespace zim
 
       log_debug("mimeType=" << mimeType << " clusterNumber=" << clusterNumber << " blobNumber=" << blobNumber);
 
+<<<<<<< HEAD
       setItem(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
+=======
+      dirent.setArticle(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
+>>>>>>> bb6fd44... Enter DirentReader
     }
 
     std::string url;
@@ -83,6 +107,7 @@ namespace zim
 
     log_debug("read url, title and parameters");
 
+<<<<<<< HEAD
     size_type url_size = strnlen(
       reader.current(),
       reader.left().v - extraLen
@@ -107,10 +132,54 @@ namespace zim
        throw(InvalidSize());
     }
     parameter = std::string(reader.current(), extraLen);
+=======
+    offset_type url_size = strnlen(bds.data(), bds.size() - extraLen);
+    if (url_size >= bds.size())
+      return false;
 
-    setUrl(ns, url);
-    setTitle(title);
-    setParameter(parameter);
+    url = bds.readString(url_size);
+    bds.skip(1);
+
+    offset_type title_size = strnlen(bds.data(), bds.size() - extraLen);
+    if (title_size >= bds.size())
+      return false;
+
+    title = bds.readString(title_size);
+    bds.skip(1);
+
+    if (extraLen > bds.size())
+      return false;
+
+    parameter = bds.readString(extraLen);
+>>>>>>> bb6fd44... Enter DirentReader
+
+    dirent.setUrl(ns, url);
+    dirent.setTitle(title);
+    dirent.setParameter(parameter);
+    return true;
+  }
+
+  std::shared_ptr<const Dirent> DirentReader::readDirent(offset_t offset)
+  {
+    // We don't know the size of the dirent because it depends of the size of
+    // the title, url and extra parameters.
+    // This is a pity but we have no choice.
+    // We cannot take a buffer of the size of the file, it would be really
+    // inefficient. Let's do try, catch and retry while chosing a smart value
+    // for the buffer size. Most dirent will be "Article" entry (header's size
+    // == 16) without extra parameters. Let's hope that url + title size will
+    // be < 256 and if not try again with a bigger size.
+
+    size_t bufferSize(std::min(256UL, zimReader_->size().v-offset.v));
+    auto dirent = std::make_shared<Dirent>();
+    std::lock_guard<std::mutex> lock(bufferMutex_);
+    for ( ; ; bufferSize += 256 ) {
+      buffer_.reserve(bufferSize);
+      zimReader_->read(buffer_.data(), offset, zsize_t(bufferSize));
+      const Blob direntBuffer(buffer_.data(), bufferSize);
+      if ( initDirent(*dirent, Blob(buffer_.data(), bufferSize)) )
+        return dirent;
+    }
   }
 
   std::string Dirent::getLongUrl() const

--- a/src/dirent.cpp
+++ b/src/dirent.cpp
@@ -20,6 +20,7 @@
 #include "_dirent.h"
 #include "direntreader.h"
 #include <zim/zim.h>
+#include <zim/error.h>
 #include "buffer.h"
 #include "bufferstreamer.h"
 #include "endian_tools.h"
@@ -39,30 +40,17 @@ namespace zim
   const uint16_t Dirent::linktargetMimeType;
   const uint16_t Dirent::deletedMimeType;
 
-<<<<<<< HEAD
-  Dirent::Dirent(const Buffer& bufferRef)
-    : Dirent()
-=======
-  bool DirentReader::initDirent(Dirent& dirent, const Blob& direntData) const
->>>>>>> bb6fd44... Enter DirentReader
+  bool DirentReader::initDirent(Dirent& dirent, const Buffer& direntData) const
   {
-    BufferStreamer reader(bufferRef);
+    BufferStreamer reader(direntData);
     uint16_t mimeType = reader.read<uint16_t>();
     bool redirect = (mimeType == Dirent::redirectMimeType);
     bool linktarget = (mimeType == Dirent::linktargetMimeType);
     bool deleted = (mimeType == Dirent::deletedMimeType);
-<<<<<<< HEAD
     uint8_t extraLen = reader.read<uint8_t>();
     char ns = reader.read<char>();
     uint32_t version = reader.read<uint32_t>();
-    setVersion(version);
-=======
-    uint8_t extraLen = bds.read<uint8_t>();
-    char ns = bds.read<char>();
-    uint32_t version = bds.read<uint32_t>();
     dirent.setVersion(version);
->>>>>>> bb6fd44... Enter DirentReader
-
 
     if (redirect)
     {
@@ -70,20 +58,12 @@ namespace zim
 
       log_debug("redirectIndex=" << redirectIndex);
 
-<<<<<<< HEAD
-      setRedirect(entry_index_t(redirectIndex));
-=======
-      dirent.setRedirect(article_index_t(redirectIndex));
->>>>>>> bb6fd44... Enter DirentReader
+      dirent.setRedirect(entry_index_t(redirectIndex));
     }
     else if (linktarget || deleted)
     {
       log_debug("linktarget or deleted entry");
-<<<<<<< HEAD
-      setItem(mimeType, cluster_index_t(0), blob_index_t(0));
-=======
-      dirent.setArticle(mimeType, cluster_index_t(0), blob_index_t(0));
->>>>>>> bb6fd44... Enter DirentReader
+      dirent.setItem(mimeType, cluster_index_t(0), blob_index_t(0));
     }
     else
     {
@@ -94,11 +74,7 @@ namespace zim
 
       log_debug("mimeType=" << mimeType << " clusterNumber=" << clusterNumber << " blobNumber=" << blobNumber);
 
-<<<<<<< HEAD
-      setItem(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
-=======
-      dirent.setArticle(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
->>>>>>> bb6fd44... Enter DirentReader
+      dirent.setItem(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
     }
 
     std::string url;
@@ -107,13 +83,12 @@ namespace zim
 
     log_debug("read url, title and parameters");
 
-<<<<<<< HEAD
     size_type url_size = strnlen(
       reader.current(),
       reader.left().v - extraLen
     );
     if (url_size >= reader.left().v) {
-      throw(InvalidSize());
+      return false;
     }
     url = std::string(reader.current(), url_size);
     reader.skip(zsize_t(url_size+1));
@@ -123,36 +98,15 @@ namespace zim
       reader.left().v - extraLen
     );
     if (title_size >= reader.left().v) {
-      throw(InvalidSize());
+      return false;
     }
     title = std::string(reader.current(), title_size);
     reader.skip(zsize_t(title_size+1));
 
     if (extraLen > reader.left().v) {
-       throw(InvalidSize());
+      return false;
     }
     parameter = std::string(reader.current(), extraLen);
-=======
-    offset_type url_size = strnlen(bds.data(), bds.size() - extraLen);
-    if (url_size >= bds.size())
-      return false;
-
-    url = bds.readString(url_size);
-    bds.skip(1);
-
-    offset_type title_size = strnlen(bds.data(), bds.size() - extraLen);
-    if (title_size >= bds.size())
-      return false;
-
-    title = bds.readString(title_size);
-    bds.skip(1);
-
-    if (extraLen > bds.size())
-      return false;
-
-    parameter = bds.readString(extraLen);
->>>>>>> bb6fd44... Enter DirentReader
-
     dirent.setUrl(ns, url);
     dirent.setTitle(title);
     dirent.setParameter(parameter);
@@ -161,6 +115,11 @@ namespace zim
 
   std::shared_ptr<const Dirent> DirentReader::readDirent(offset_t offset)
   {
+    const auto totalSize = mp_zimReader->size();
+    if (offset.v >= totalSize.v) {
+      throw ZimFileFormatError("Invalid dirent pointer");
+    }
+
     // We don't know the size of the dirent because it depends of the size of
     // the title, url and extra parameters.
     // This is a pity but we have no choice.
@@ -170,14 +129,13 @@ namespace zim
     // == 16) without extra parameters. Let's hope that url + title size will
     // be < 256 and if not try again with a bigger size.
 
-    size_t bufferSize(std::min(256UL, zimReader_->size().v-offset.v));
+    size_t bufferSize(std::min(size_type(256), mp_zimReader->size().v-offset.v));
     auto dirent = std::make_shared<Dirent>();
-    std::lock_guard<std::mutex> lock(bufferMutex_);
+    std::lock_guard<std::mutex> lock(m_bufferMutex);
     for ( ; ; bufferSize += 256 ) {
-      buffer_.reserve(bufferSize);
-      zimReader_->read(buffer_.data(), offset, zsize_t(bufferSize));
-      const Blob direntBuffer(buffer_.data(), bufferSize);
-      if ( initDirent(*dirent, Blob(buffer_.data(), bufferSize)) )
+      m_buffer.reserve(bufferSize);
+      mp_zimReader->read(m_buffer.data(), offset, zsize_t(bufferSize));
+      if ( initDirent(*dirent, Buffer::makeBuffer(m_buffer.data(), zsize_t(bufferSize))) )
         return dirent;
     }
   }

--- a/src/dirent_accessor.cpp
+++ b/src/dirent_accessor.cpp
@@ -24,9 +24,10 @@
 
 using namespace zim;
 
-DirentAccessor::DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader)
+DirentAccessor::DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount)
   : mp_zimReader(zimReader),
     mp_urlPtrReader(std::move(urlPtrReader)),
+    m_direntCount(direntCount),
     m_bufferDirentZone(256)
 {}
 
@@ -38,6 +39,9 @@ std::shared_ptr<const Dirent> DirentAccessor::getDirent(entry_index_t idx) const
 
 offset_t DirentAccessor::getOffset(entry_index_t idx) const
 {
+  if (idx >= m_direntCount) {
+    throw std::out_of_range("entry index out of range");
+  }
   offset_t offset(mp_urlPtrReader->read_uint<offset_type>(offset_t(sizeof(offset_type)*idx.v)));
   return offset;
 }

--- a/src/dirent_accessor.cpp
+++ b/src/dirent_accessor.cpp
@@ -21,6 +21,9 @@
 
 #include "file_reader.h"
 #include "_dirent.h"
+#include "envvalue.h"
+
+#include <mutex>
 
 using namespace zim;
 
@@ -28,13 +31,26 @@ DirectDirentAccessor::DirectDirentAccessor(std::shared_ptr<FileReader> zimReader
   : mp_zimReader(zimReader),
     mp_urlPtrReader(std::move(urlPtrReader)),
     m_direntCount(direntCount),
+    m_direntCache(envValue("ZIM_DIRENTCACHE", DIRENT_CACHE_SIZE)),
     m_bufferDirentZone(256)
 {}
 
 std::shared_ptr<const Dirent> DirectDirentAccessor::getDirent(entry_index_t idx) const
 {
+  {
+    std::lock_guard<std::mutex> l(m_direntCacheLock);
+    auto v = m_direntCache.get(idx.v);
+    if (v.hit()) {
+      return v.value();
+    }
+  }
+
   auto direntOffset = getOffset(idx);
-  return readDirent(direntOffset);
+  auto dirent = readDirent(direntOffset);
+  std::lock_guard<std::mutex> l(m_direntCacheLock);
+  m_direntCache.put(idx.v, dirent);
+
+  return dirent;
 }
 
 offset_t DirectDirentAccessor::getOffset(entry_index_t idx) const

--- a/src/dirent_accessor.cpp
+++ b/src/dirent_accessor.cpp
@@ -24,20 +24,20 @@
 
 using namespace zim;
 
-DirentAccessor::DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount)
+DirectDirentAccessor::DirectDirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount)
   : mp_zimReader(zimReader),
     mp_urlPtrReader(std::move(urlPtrReader)),
     m_direntCount(direntCount),
     m_bufferDirentZone(256)
 {}
 
-std::shared_ptr<const Dirent> DirentAccessor::getDirent(entry_index_t idx) const
+std::shared_ptr<const Dirent> DirectDirentAccessor::getDirent(entry_index_t idx) const
 {
   auto direntOffset = getOffset(idx);
   return readDirent(direntOffset);
 }
 
-offset_t DirentAccessor::getOffset(entry_index_t idx) const
+offset_t DirectDirentAccessor::getOffset(entry_index_t idx) const
 {
   if (idx >= m_direntCount) {
     throw std::out_of_range("entry index out of range");
@@ -46,7 +46,7 @@ offset_t DirentAccessor::getOffset(entry_index_t idx) const
   return offset;
 }
 
-std::shared_ptr<const Dirent> DirentAccessor::readDirent(offset_t offset) const
+std::shared_ptr<const Dirent> DirectDirentAccessor::readDirent(offset_t offset) const
 {
   // We don't know the size of the dirent because it depends of the size of
   // the title, url and extra parameters.
@@ -81,4 +81,26 @@ std::shared_ptr<const Dirent> DirentAccessor::readDirent(offset_t offset) const
   }
 
   return dirent;
+}
+
+
+IndirectDirentAccessor::IndirectDirentAccessor(std::shared_ptr<const DirectDirentAccessor> direntAccessor, std::unique_ptr<const Reader> indexReader, title_index_t direntCount)
+  : mp_direntAccessor(direntAccessor),
+    mp_indexReader(std::move(indexReader)),
+    m_direntCount(direntCount)
+{}
+
+entry_index_t IndirectDirentAccessor::getDirectIndex(title_index_t idx) const
+{
+  if (idx >= m_direntCount) {
+    throw std::out_of_range("entry index out of range");
+  }
+  entry_index_t index(mp_indexReader->read_uint<entry_index_type>(offset_t(sizeof(entry_index_t)*idx.v)));
+  return index;
+}
+
+std::shared_ptr<const Dirent> IndirectDirentAccessor::getDirent(title_index_t idx) const
+{
+  auto directIndex = getDirectIndex(idx);
+  return mp_direntAccessor->getDirent(directIndex);
 }

--- a/src/dirent_accessor.cpp
+++ b/src/dirent_accessor.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "dirent_accessor.h"
+
+#include "file_reader.h"
+#include "_dirent.h"
+
+using namespace zim;
+
+DirentAccessor::DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader)
+  : mp_zimReader(zimReader),
+    mp_urlPtrReader(std::move(urlPtrReader)),
+    m_bufferDirentZone(256)
+{}
+
+std::shared_ptr<const Dirent> DirentAccessor::getDirent(entry_index_t idx) const
+{
+  auto direntOffset = getOffset(idx);
+  return readDirent(direntOffset);
+}
+
+offset_t DirentAccessor::getOffset(entry_index_t idx) const
+{
+  offset_t offset(mp_urlPtrReader->read_uint<offset_type>(offset_t(sizeof(offset_type)*idx.v)));
+  return offset;
+}
+
+std::shared_ptr<const Dirent> DirentAccessor::readDirent(offset_t offset) const
+{
+  // We don't know the size of the dirent because it depends of the size of
+  // the title, url and extra parameters.
+  // This is a pitty but we have no choices.
+  // We cannot take a buffer of the size of the file, it would be really inefficient.
+  // Let's do try, catch and retry while chosing a smart value for the buffer size.
+  // Most dirent will be "Article" entry (header's size == 16) without extra parameters.
+  // Let's hope that url + title size will be < 256 and if not try again with a bigger size.
+  std::shared_ptr<const Dirent> dirent;
+  {
+    std::lock_guard<std::mutex> l(m_bufferDirentLock);
+    zsize_t bufferSize = zsize_t(256);
+    // On very small file, the offset + 256 is higher than the size of the file,
+    // even if the file is valid.
+    // So read only to the end of the file.
+    auto totalSize = mp_zimReader->size();
+    if (offset.v + 256 > totalSize.v) bufferSize = zsize_t(totalSize.v-offset.v);
+    while (true) {
+        m_bufferDirentZone.reserve(size_type(bufferSize));
+        mp_zimReader->read(m_bufferDirentZone.data(), offset, bufferSize);
+        auto direntBuffer = Buffer::makeBuffer(m_bufferDirentZone.data(), bufferSize);
+        try {
+          dirent = std::make_shared<const Dirent>(direntBuffer);
+        } catch (InvalidSize&) {
+          // buffer size is not enougth, try again :
+          bufferSize += 256;
+          continue;
+        }
+        // Success !
+        break;
+    }
+  }
+
+  return dirent;
+}

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -22,6 +22,7 @@
 
 #include "zim_types.h"
 #include "debug.h"
+#include "lrucache.h"
 
 #include <memory>
 #include <mutex>
@@ -36,7 +37,7 @@ class FileReader;
 
 /**
  * DirectDirentAccessor is used to access a dirent from its index.
- * It doesn't provide any "advanced" features like lookup, find or cache.
+ * It doesn't provide any "advanced" features like lookup or find.
  *
  * This is the base class to locate a dirent (offset) and read it.
  *
@@ -58,6 +59,9 @@ private: // data
   std::shared_ptr<FileReader>    mp_zimReader;
   std::unique_ptr<const Reader>  mp_urlPtrReader;
   entry_index_t                  m_direntCount;
+
+  mutable lru_cache<entry_index_type, std::shared_ptr<const Dirent>> m_direntCache;
+  mutable std::mutex m_direntCacheLock;
 
   mutable std::vector<char>  m_bufferDirentZone;
   mutable std::mutex         m_bufferDirentLock;

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -44,10 +44,11 @@ class FileReader;
 class DirentAccessor
 {
 public: // functions
-  DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader);
+  DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
 
   offset_t    getOffset(entry_index_t idx) const;
   std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
+  entry_index_t getDirentCount() const  {  return m_direntCount; }
 
 private: // functions
   std::shared_ptr<const Dirent> readDirent(offset_t) const;
@@ -55,6 +56,7 @@ private: // functions
 private: // data
   std::shared_ptr<FileReader>    mp_zimReader;
   std::unique_ptr<const Reader>  mp_urlPtrReader;
+  entry_index_t                  m_direntCount;
 
   mutable std::vector<char>  m_bufferDirentZone;
   mutable std::mutex         m_bufferDirentLock;

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_DIRENT_ACCESSOR_H
+#define ZIM_DIRENT_ACCESSOR_H
+
+#include "zim_types.h"
+#include "debug.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace zim
+{
+
+class Dirent;
+class Reader;
+class FileReader;
+
+/**
+ * DirentAccessor is used to access a dirent from its index.
+ * It doesn't provide any "advanced" features like lookup, find or cache.
+ *
+ * This is the base class to locate a dirent (offset) and read it.
+ */
+
+class DirentAccessor
+{
+public: // functions
+  DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader);
+
+  offset_t    getOffset(entry_index_t idx) const;
+  std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
+
+private: // functions
+  std::shared_ptr<const Dirent> readDirent(offset_t) const;
+
+private: // data
+  std::shared_ptr<FileReader>    mp_zimReader;
+  std::unique_ptr<const Reader>  mp_urlPtrReader;
+
+  mutable std::vector<char>  m_bufferDirentZone;
+  mutable std::mutex         m_bufferDirentLock;
+};
+
+} // namespace zim
+
+#endif // ZIM_DIRENT_ACCESSOR_H

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -35,16 +35,17 @@ class Reader;
 class FileReader;
 
 /**
- * DirentAccessor is used to access a dirent from its index.
+ * DirectDirentAccessor is used to access a dirent from its index.
  * It doesn't provide any "advanced" features like lookup, find or cache.
  *
  * This is the base class to locate a dirent (offset) and read it.
+ *
  */
 
-class DirentAccessor
+class DirectDirentAccessor
 {
 public: // functions
-  DirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
+  DirectDirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
 
   offset_t    getOffset(entry_index_t idx) const;
   std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
@@ -60,6 +61,21 @@ private: // data
 
   mutable std::vector<char>  m_bufferDirentZone;
   mutable std::mutex         m_bufferDirentLock;
+};
+
+class IndirectDirentAccessor
+{
+  public:
+    IndirectDirentAccessor(std::shared_ptr<const DirectDirentAccessor>, std::unique_ptr<const Reader> indexReader, title_index_t direntCount);
+
+    entry_index_t getDirectIndex(title_index_t idx) const;
+    std::shared_ptr<const Dirent> getDirent(title_index_t idx) const;
+    title_index_t getDirentCount() const { return m_direntCount; }
+
+  private: // data
+    std::shared_ptr<const DirectDirentAccessor> mp_direntAccessor;
+    std::unique_ptr<const Reader>               mp_indexReader;
+    title_index_t                               m_direntCount;
 };
 
 } // namespace zim

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -33,7 +33,7 @@ namespace zim
 
 class Dirent;
 class Reader;
-class FileReader;
+class DirentReader;
 
 /**
  * DirectDirentAccessor is used to access a dirent from its index.
@@ -46,7 +46,7 @@ class FileReader;
 class DirectDirentAccessor
 {
 public: // functions
-  DirectDirentAccessor(std::shared_ptr<FileReader> zimReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
+  DirectDirentAccessor(std::shared_ptr<DirentReader> direntReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
 
   offset_t    getOffset(entry_index_t idx) const;
   std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
@@ -56,7 +56,7 @@ private: // functions
   std::shared_ptr<const Dirent> readDirent(offset_t) const;
 
 private: // data
-  std::shared_ptr<FileReader>    mp_zimReader;
+  std::shared_ptr<DirentReader>  mp_direntReader;
   std::unique_ptr<const Reader>  mp_urlPtrReader;
   entry_index_t                  m_direntCount;
 

--- a/src/dirent_lookup.h
+++ b/src/dirent_lookup.h
@@ -39,7 +39,7 @@ public: // types
   typedef std::pair<bool, entry_index_t> Result;
 
 public: // functions
-  DirentLookup(Impl* _impl, entry_index_type cacheEntryCount);
+  DirentLookup(const Impl* _impl, entry_index_type cacheEntryCount);
 
   entry_index_t getNamespaceRangeBegin(char ns) const;
   entry_index_t getNamespaceRangeEnd(char ns) const;
@@ -53,12 +53,12 @@ private: // types
   typedef std::map<char, entry_index_t> NamespaceBoundaryCache;
 
 private: // data
-  Impl* impl = nullptr;
+  const Impl* impl = nullptr;
 
   mutable NamespaceBoundaryCache namespaceBoundaryCache;
   mutable std::mutex cacheAccessMutex;
 
-  entry_index_type articleCount = 0;
+  entry_index_type direntCount = 0;
   NarrowDown lookupGrid;
 };
 
@@ -71,19 +71,19 @@ DirentLookup<Impl>::getDirentKey(entry_index_type i) const
 }
 
 template<class Impl>
-DirentLookup<Impl>::DirentLookup(Impl* _impl, entry_index_type cacheEntryCount)
+DirentLookup<Impl>::DirentLookup(const Impl* _impl, entry_index_type cacheEntryCount)
 {
   ASSERT(impl == nullptr, ==, true);
   impl = _impl;
-  articleCount = entry_index_type(impl->getCountArticles());
-  if ( articleCount )
+  direntCount = entry_index_type(impl->getDirentCount());
+  if ( direntCount )
   {
-    const entry_index_type step = std::max(1u, articleCount/cacheEntryCount);
-    for ( entry_index_type i = 0; i < articleCount-1; i += step )
+    const entry_index_type step = std::max(1u, direntCount/cacheEntryCount);
+    for ( entry_index_type i = 0; i < direntCount-1; i += step )
     {
         lookupGrid.add(getDirentKey(i), i, getDirentKey(i+1));
     }
-    lookupGrid.close(getDirentKey(articleCount - 1), articleCount - 1);
+    lookupGrid.close(getDirentKey(direntCount - 1), direntCount - 1);
   }
 }
 
@@ -94,7 +94,7 @@ entry_index_t getNamespaceBeginOffset(IMPL& impl, char ch)
   ASSERT(ch, <=, 127);
 
   entry_index_type lower = 0;
-  entry_index_type upper = entry_index_type(impl.getCountArticles());
+  entry_index_type upper = entry_index_type(impl.getDirentCount());
   auto d = impl.getDirent(entry_index_t(0));
   while (upper - lower > 1)
   {

--- a/src/direntreader.h
+++ b/src/direntreader.h
@@ -37,18 +37,18 @@ class DirentReader
 {
 public: // functions
   explicit DirentReader(std::shared_ptr<const Reader> zimReader)
-    : zimReader_(zimReader)
+    : mp_zimReader(zimReader)
   {}
 
   std::shared_ptr<const Dirent> readDirent(offset_t offset);
 
-private:
-  bool initDirent(Dirent& dirent, const Blob& direntData) const;
-
+private: // functions
+  bool initDirent(Dirent& dirent, const Buffer& direntData) const;
+  
 private: // data
-  std::shared_ptr<const Reader> zimReader_;
-  std::vector<char> buffer_;
-  std::mutex bufferMutex_;
+  std::shared_ptr<const Reader> mp_zimReader;
+  std::vector<char> m_buffer;
+  std::mutex m_bufferMutex;
 };
 
 } // namespace zim

--- a/src/direntreader.h
+++ b/src/direntreader.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_DIRENTREADER_H
+#define ZIM_DIRENTREADER_H
+
+#include "_dirent.h"
+#include "reader.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace zim
+{
+
+// Unlke FileReader and MemoryReader (which read data from a file and memory,
+// respectively), DirentReader is a helper class that reads Dirents (rather
+// than from a Dirent).
+class DirentReader
+{
+public: // functions
+  explicit DirentReader(std::shared_ptr<const Reader> zimReader)
+    : zimReader_(zimReader)
+  {}
+
+  std::shared_ptr<const Dirent> readDirent(offset_t offset);
+
+private:
+  bool initDirent(Dirent& dirent, const Blob& direntData) const;
+
+private: // data
+  std::shared_ptr<const Reader> zimReader_;
+  std::vector<char> buffer_;
+  std::mutex bufferMutex_;
+};
+
+} // namespace zim
+
+#endif // ZIM_DIRENTREADER_H

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -260,6 +260,18 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     return { false, entry_index_t(0) };
   }
 
+  static inline int direntCompareTitle(char ns, const std::string& title, const Dirent& dirent)
+  {
+    auto direntNs = dirent.getNamespace();
+    if (ns < direntNs) {
+      return -1;
+    }
+    if (ns > direntNs) {
+      return 1;
+    }
+    return title.compare(dirent.getTitle());
+  }
+
   FileImpl::FindxTitleResult FileImpl::findxByTitle(char ns, const std::string& title)
   {
     log_debug("find article by title " << ns << " \"" << title << "\", in file \"" << getFilename() << '"');
@@ -280,9 +292,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       entry_index_type p = l + (u - l) / 2;
       auto d = getDirentByTitle(title_index_t(p));
 
-      int c = ns < d->getNamespace() ? -1
-            : ns > d->getNamespace() ? 1
-            : title.compare(d->getTitle());
+      int c = direntCompareTitle(ns, title, *d);
 
       if (c < 0)
         u = p;
@@ -296,7 +306,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     }
 
     auto d = getDirentByTitle(title_index_t(l));
-    int c = title.compare(d->getTitle());
+    int c = direntCompareTitle(ns, title, *d);
 
     if (c == 0)
     {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -598,8 +598,9 @@ std::string pseudoTitle(const Dirent& d)
 
   bool FileImpl::checkTitleIndex() {
     const entry_index_type articleCount = getCountArticles().v;
+    const entry_index_type frontArticleCount = mp_titleDirentAccessor->getDirentCount().v;
     std::shared_ptr<const Dirent> prevDirent;
-    for ( entry_index_type i = 0; i < articleCount; ++i )
+    for ( entry_index_type i = 0; i < frontArticleCount; ++i )
     {
       if (mp_titleDirentAccessor->getDirectIndex(title_index_t(i)).v >= articleCount) {
         std::cerr << "Invalid title index entry" << std::endl;

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -105,7 +105,6 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     : zimFile(_zimFile),
       archiveStartOffset(offset),
       zimReader(makeFileReader(zimFile, offset, size)),
-      bufferDirentZone(256),
       direntCache(envValue("ZIM_DIRENTCACHE", DIRENT_CACHE_SIZE)),
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
       m_newNamespaceScheme(false),
@@ -129,10 +128,12 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       throw ZimFileFormatError("error reading zim-file header.");
     }
 
-    urlPtrOffsetReader = sectionSubReader(*zimReader,
-                                          "Dirent pointer table",
-                                          offset_t(header.getUrlPtrPos()),
-                                          zsize_t(8*header.getArticleCount()));
+    auto urlPtrReader = sectionSubReader(*zimReader,
+                                         "Dirent pointer table",
+                                         offset_t(header.getUrlPtrPos()),
+                                         zsize_t(8*header.getArticleCount()));
+
+    mp_urlDirentAccessor.reset(new DirentAccessor(zimReader, std::move(urlPtrReader)));
 
     titleIndexReader = sectionSubReader(*zimReader,
                                         "Title index table",
@@ -187,7 +188,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     if ( getCountArticles().v != 0 ) {
       // assuming that dirents are placed in the zim file in the same
       // order as the corresponding entries in the dirent pointer table
-      result = std::min(result, readOffset(*urlPtrOffsetReader, 0).v);
+      result = std::min(result, mp_urlDirentAccessor->getOffset(entry_index_t(0)).v);
 
       // assuming that clusters are placed in the zim file in the same
       // order as the corresponding entries in the cluster pointer table
@@ -335,49 +336,10 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
                 << direntCache.fillfactor());
     }
 
-    offset_t indexOffset = readOffset(*urlPtrOffsetReader, idx.v);
-    const auto dirent = readDirent(indexOffset);
+    const auto dirent = mp_urlDirentAccessor->getDirent(idx);
     std::lock_guard<std::mutex> l(direntCacheLock);
     direntCache.put(idx.v, dirent);
 
-    return dirent;
-  }
-
-  std::shared_ptr<const Dirent> FileImpl::readDirent(offset_t indexOffset)
-  {
-    // We don't know the size of the dirent because it depends of the size of
-    // the title, url and extra parameters.
-    // This is a pitty but we have no choices.
-    // We cannot take a buffer of the size of the file, it would be really inefficient.
-    // Let's do try, catch and retry while chosing a smart value for the buffer size.
-    // Most dirent will be "Article" entry (header's size == 16) without extra parameters.
-    // Let's hope that url + title size will be < 256 and if not try again with a bigger size.
-    std::shared_ptr<const Dirent> dirent;
-    {
-      std::lock_guard<std::mutex> l(bufferDirentLock);
-      zsize_t bufferSize = zsize_t(256);
-      // On very small file, the offset + 256 is higher than the size of the file,
-      // even if the file is valid.
-      // So read only to the end of the file.
-      auto totalSize = zimReader->size();
-      if (indexOffset.v + 256 > totalSize.v) bufferSize = zsize_t(totalSize.v-indexOffset.v);
-      while (true) {
-          bufferDirentZone.reserve(size_type(bufferSize));
-          zimReader->read(bufferDirentZone.data(), indexOffset, bufferSize);
-          auto direntBuffer = Buffer::makeBuffer(bufferDirentZone.data(), bufferSize);
-          try {
-            dirent = std::make_shared<const Dirent>(direntBuffer);
-          } catch (InvalidSize&) {
-            // buffer size is not enougth, try again :
-            bufferSize += 256;
-            continue;
-          }
-          // Success !
-          break;
-      }
-    }
-
-    log_debug("dirent read from " << indexOffset);
     return dirent;
   }
 
@@ -407,7 +369,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
           for(auto i = getStartUserEntry().v; i < endIdx; i++)
           {
               // This is the offset of the dirent in the zimFile
-              auto indexOffset = readOffset(*urlPtrOffsetReader, i);
+              auto indexOffset = mp_urlDirentAccessor->getOffset(entry_index_t(i));
               // Get the mimeType of the dirent (offset 0) to know the type of the dirent
               uint16_t mimeType = zimReader->read_uint<uint16_t>(indexOffset);
               if (mimeType==Dirent::redirectMimeType || mimeType==Dirent::linktargetMimeType || mimeType == Dirent::deletedMimeType) {
@@ -607,7 +569,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     const zsize_t direntMinSize(11);
     for ( entry_index_type i = 0; i < articleCount; ++i )
     {
-      const auto offset = readOffset(*urlPtrOffsetReader, i);
+      const auto offset = mp_urlDirentAccessor->getOffset(entry_index_t(i));
       if ( offset < validDirentRangeStart ||
            offset + direntMinSize > validDirentRangeEnd ) {
         std::cerr << "Invalid dirent pointer" << std::endl;
@@ -622,8 +584,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     std::shared_ptr<const Dirent> prevDirent;
     for ( entry_index_type i = 0; i < articleCount; ++i )
     {
-      const auto offset = readOffset(*urlPtrOffsetReader, i);
-      const std::shared_ptr<const Dirent> dirent = readDirent(offset);
+      const std::shared_ptr<const Dirent> dirent = mp_urlDirentAccessor->getDirent(entry_index_t(i));
       if ( prevDirent && !(prevDirent->getLongUrl() < dirent->getLongUrl()) )
       {
         std::cerr << "Dirent table is not properly sorted:\n"
@@ -676,8 +637,8 @@ std::string pseudoTitle(const Dirent& d)
         std::cerr << "Invalid title index entry" << std::endl;
         return false;
       }
-      const auto direntOffset = readOffset(*urlPtrOffsetReader, a);
-      const std::shared_ptr<const Dirent> dirent = readDirent(direntOffset);
+
+      const std::shared_ptr<const Dirent> dirent = mp_urlDirentAccessor->getDirent(entry_index_t(a));
       if ( prevDirent && !(pseudoTitle(*prevDirent) <= pseudoTitle(*dirent)) )
       {
         std::cerr << "Title index is not properly sorted:\n"

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -105,6 +105,10 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     : zimFile(_zimFile),
       archiveStartOffset(offset),
       zimReader(makeFileReader(zimFile, offset, size)),
+<<<<<<< HEAD
+=======
+      direntReader(zimReader),
+>>>>>>> bb6fd44... Enter DirentReader
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
       m_newNamespaceScheme(false),
       m_startUserEntry(0),
@@ -363,9 +367,77 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
           std::sort(articleListByCluster.begin(), articleListByCluster.end());
       });
 
+<<<<<<< HEAD
       if (idx.v >= articleListByCluster.size())
         throw std::out_of_range("entry index out of range");
       return entry_index_t(articleListByCluster[idx.v].second);
+=======
+      if (idx >= articleListByCluster.size())
+          return std::pair<bool, article_index_t>(false, article_index_t(0));
+      return std::pair<bool, article_index_t>(true, article_index_t(articleListByCluster[idx].second));
+  }
+
+  FileCompound::PartRange
+  FileImpl::getFileParts(offset_t offset, zsize_t size)
+  {
+    return zimFile->locate(offset, size);
+  }
+
+  std::shared_ptr<const Dirent> FileImpl::getDirent(article_index_t idx)
+  {
+    log_trace("FileImpl::getDirent(" << idx << ')');
+
+    if (idx >= getCountArticles())
+      throw ZimFileFormatError("article index out of range");
+
+    pthread_mutex_lock(&direntCacheLock);
+    auto v = direntCache.get(idx.v);
+    if (v.hit())
+    {
+      log_debug("dirent " << idx << " found in cache; hits "
+                << direntCache.getHits() << " misses "
+                << direntCache.getMisses() << " ratio "
+                << direntCache.hitRatio() * 100 << "% fillfactor "
+                << direntCache.fillfactor());
+      pthread_mutex_unlock(&direntCacheLock);
+      return v.value();
+    }
+
+    log_debug("dirent " << idx << " not found in cache; hits "
+              << direntCache.getHits() << " misses " << direntCache.getMisses()
+              << " ratio " << direntCache.hitRatio() * 100 << "% fillfactor "
+              << direntCache.fillfactor());
+    pthread_mutex_unlock(&direntCacheLock);
+
+    offset_t indexOffset = readOffset(*urlPtrOffsetReader, idx.v);
+
+    const auto dirent = direntReader.readDirent(indexOffset);
+
+    log_debug("dirent read from " << indexOffset);
+    pthread_mutex_lock(&direntCacheLock);
+    direntCache.put(idx.v, dirent);
+    pthread_mutex_unlock(&direntCacheLock);
+
+    return dirent;
+  }
+
+  std::shared_ptr<const Dirent> FileImpl::getDirentByTitle(article_index_t idx)
+  {
+    if (idx >= getCountArticles())
+      throw ZimFileFormatError("article index out of range");
+    return getDirent(getIndexByTitle(idx));
+  }
+
+  article_index_t FileImpl::getIndexByTitle(article_index_t idx)
+  {
+    if (idx >= getCountArticles())
+      throw ZimFileFormatError("article index out of range");
+
+    article_index_t ret(titleIndexReader->read_uint<article_index_type>(
+                            offset_t(sizeof(article_index_t)*idx.v)));
+
+    return ret;
+>>>>>>> bb6fd44... Enter DirentReader
   }
 
   FileImpl::ClusterHandle FileImpl::readCluster(cluster_index_t idx)

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -133,7 +133,8 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
                                          offset_t(header.getUrlPtrPos()),
                                          zsize_t(8*header.getArticleCount()));
 
-    mp_urlDirentAccessor.reset(new DirentAccessor(zimReader, std::move(urlPtrReader)));
+    mp_urlDirentAccessor.reset(
+        new DirentAccessor(zimReader, std::move(urlPtrReader), entry_index_t(header.getArticleCount())));
 
     titleIndexReader = sectionSubReader(*zimReader,
                                         "Title index table",
@@ -155,7 +156,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
   {
     if ( ! m_direntLookup ) {
       const auto cacheSize = envValue("ZIM_DIRENTLOOKUPCACHE", DIRENT_LOOKUP_CACHE_SIZE);
-      m_direntLookup.reset(new DirentLookup(this, cacheSize));
+      m_direntLookup.reset(new DirentLookup(mp_urlDirentAccessor.get(), cacheSize));
     }
     return *m_direntLookup;
   }

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -134,12 +134,16 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
                                          zsize_t(8*header.getArticleCount()));
 
     mp_urlDirentAccessor.reset(
-        new DirentAccessor(zimReader, std::move(urlPtrReader), entry_index_t(header.getArticleCount())));
+        new DirectDirentAccessor(zimReader, std::move(urlPtrReader), entry_index_t(header.getArticleCount())));
 
-    titleIndexReader = sectionSubReader(*zimReader,
+
+    auto titleIndexReader = sectionSubReader(*zimReader,
                                         "Title index table",
                                         offset_t(header.getTitleIdxPos()),
                                         zsize_t(4*header.getArticleCount()));
+
+    mp_titleDirentAccessor.reset(
+        new IndirectDirentAccessor(mp_urlDirentAccessor, std::move(titleIndexReader), title_index_t(header.getArticleCount())));
 
     clusterOffsetReader = sectionSubReader(*zimReader,
                                            "Cluster pointer table",
@@ -351,13 +355,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
 
   entry_index_t FileImpl::getIndexByTitle(title_index_t idx) const
   {
-    if (idx.v >= getCountArticles().v)
-      throw std::out_of_range("entry index out of range");
-
-    entry_index_t ret(titleIndexReader->read_uint<entry_index_type>(
-                            offset_t(sizeof(entry_index_t)*idx.v)));
-
-    return ret;
+    return mp_titleDirentAccessor->getDirectIndex(idx);
   }
 
   entry_index_t FileImpl::getIndexByClusterOrder(entry_index_t idx) const
@@ -632,14 +630,12 @@ std::string pseudoTitle(const Dirent& d)
     std::shared_ptr<const Dirent> prevDirent;
     for ( entry_index_type i = 0; i < articleCount; ++i )
     {
-      const offset_t offset(i*sizeof(entry_index_t));
-      const auto a = titleIndexReader->read_uint<entry_index_type>(offset);
-      if ( a >= articleCount ) {
+      if (mp_titleDirentAccessor->getDirectIndex(title_index_t(i)).v >= articleCount) {
         std::cerr << "Invalid title index entry" << std::endl;
         return false;
       }
 
-      const std::shared_ptr<const Dirent> dirent = mp_urlDirentAccessor->getDirent(entry_index_t(a));
+      const std::shared_ptr<const Dirent> dirent = mp_titleDirentAccessor->getDirent(title_index_t(i));
       if ( prevDirent && !(pseudoTitle(*prevDirent) <= pseudoTitle(*dirent)) )
       {
         std::cerr << "Title index is not properly sorted:\n"

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -409,23 +409,6 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     return direntLookup().getNamespaceRangeEnd(ch);
   }
 
-  std::string FileImpl::getNamespaces()
-  {
-    std::string namespaces;
-
-    auto d = mp_urlDirentAccessor->getDirent(entry_index_t(0));
-    namespaces = d->getNamespace();
-
-    entry_index_t idx(0);
-    while ((idx = getNamespaceEndOffset(d->getNamespace())) < getCountArticles())
-    {
-      d = mp_urlDirentAccessor->getDirent(idx);
-      namespaces += d->getNamespace();
-    }
-
-    return namespaces;
-  }
-
   const std::string& FileImpl::getMimeType(uint16_t idx) const
   {
     if (idx > mimeTypes.size())

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -52,9 +52,6 @@ namespace zim
       std::shared_ptr<const DirectDirentAccessor> mp_urlDirentAccessor;
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
-      lru_cache<entry_index_type, std::shared_ptr<const Dirent>> direntCache;
-      std::mutex direntCacheLock;
-
       typedef std::shared_ptr<const Cluster> ClusterHandle;
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -69,7 +69,7 @@ namespace zim
       mutable std::vector<pair_type> articleListByCluster;
       mutable std::once_flag orderOnceFlag;
 
-      using DirentLookup = zim::DirentLookup<FileImpl>;
+      using DirentLookup = zim::DirentLookup<DirentAccessor>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
 
     public:

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -37,6 +37,8 @@
 #include "file_compound.h"
 #include "fileheader.h"
 #include "zim_types.h"
+#include "direntreader.h"
+
 
 namespace zim
 {
@@ -45,6 +47,10 @@ namespace zim
       std::shared_ptr<FileCompound> zimFile;
       offset_t archiveStartOffset;
       std::shared_ptr<Reader> zimReader;
+<<<<<<< HEAD
+=======
+      DirentReader direntReader;
+>>>>>>> bb6fd44... Enter DirentReader
       Fileheader header;
 
       std::unique_ptr<const Reader> clusterOffsetReader;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -29,6 +29,7 @@
 #include "lrucache.h"
 #include "concurrent_cache.h"
 #include "_dirent.h"
+#include "dirent_accessor.h"
 #include "dirent_lookup.h"
 #include "cluster.h"
 #include "buffer.h"
@@ -44,13 +45,12 @@ namespace zim
       std::shared_ptr<FileCompound> zimFile;
       offset_t archiveStartOffset;
       std::shared_ptr<Reader> zimReader;
-      std::vector<char> bufferDirentZone;
-      std::mutex bufferDirentLock;
       Fileheader header;
 
       std::unique_ptr<const Reader> titleIndexReader;
-      std::unique_ptr<const Reader> urlPtrOffsetReader;
       std::unique_ptr<const Reader> clusterOffsetReader;
+
+      std::unique_ptr<const DirentAccessor> mp_urlDirentAccessor;
 
       lru_cache<entry_index_type, std::shared_ptr<const Dirent>> direntCache;
       std::mutex direntCacheLock;
@@ -131,7 +131,6 @@ namespace zim
 
       DirentLookup& direntLookup();
       ClusterHandle readCluster(cluster_index_t idx);
-      std::shared_ptr<const Dirent> readDirent(offset_t offset);
       offset_type getMimeListEndUpperLimit() const;
       void readMimeTypes();
       void quickCheckForCorruptFile();

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -47,10 +47,7 @@ namespace zim
       std::shared_ptr<FileCompound> zimFile;
       offset_t archiveStartOffset;
       std::shared_ptr<Reader> zimReader;
-<<<<<<< HEAD
-=======
-      DirentReader direntReader;
->>>>>>> bb6fd44... Enter DirentReader
+      std::shared_ptr<DirentReader> direntReader;
       Fileheader header;
 
       std::unique_ptr<const Reader> clusterOffsetReader;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -108,14 +108,11 @@ namespace zim
 
       entry_index_t getNamespaceBeginOffset(char ch);
       entry_index_t getNamespaceEndOffset(char ch);
-      entry_index_t getNamespaceCount(char ns)
-        { return getNamespaceEndOffset(ns) - getNamespaceBeginOffset(ns); }
 
       entry_index_t getStartUserEntry() const { return m_startUserEntry; }
       entry_index_t getEndUserEntry() const { return m_endUserEntry; }
       entry_index_t getUserEntryCount() const { return m_endUserEntry - m_startUserEntry; }
 
-      std::string getNamespaces();
       bool hasNamespace(char ch) const;
 
       const std::string& getMimeType(uint16_t idx) const;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -47,10 +47,10 @@ namespace zim
       std::shared_ptr<Reader> zimReader;
       Fileheader header;
 
-      std::unique_ptr<const Reader> titleIndexReader;
       std::unique_ptr<const Reader> clusterOffsetReader;
 
-      std::unique_ptr<const DirentAccessor> mp_urlDirentAccessor;
+      std::shared_ptr<const DirectDirentAccessor> mp_urlDirentAccessor;
+      std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
       lru_cache<entry_index_type, std::shared_ptr<const Dirent>> direntCache;
       std::mutex direntCacheLock;
@@ -69,7 +69,7 @@ namespace zim
       mutable std::vector<pair_type> articleListByCluster;
       mutable std::once_flag orderOnceFlag;
 
-      using DirentLookup = zim::DirentLookup<DirentAccessor>;
+      using DirentLookup = zim::DirentLookup<DirectDirentAccessor>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
 
     public:

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ common_sources = [
     'cluster.cpp',
     'buffer_reader.cpp',
     'dirent.cpp',
+    'dirent_accessor.cpp',
     'entry.cpp',
     'envvalue.cpp',
     'fileheader.cpp',

--- a/src/narrowdown.h
+++ b/src/narrowdown.h
@@ -196,7 +196,7 @@ private: // types
 
     bool operator()(const Entry& entry, const std::string& key) const
     {
-      return key.compare(getKeyContent(entry)) > 0;
+      return key.compare(getKeyContent(entry)) >= 0;
     }
 
     bool operator()(const std::string& key, const Entry& entry) const

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -36,15 +36,28 @@
 
 #include "../src/buffer.h"
 #include "../src/_dirent.h"
+#include "../src/direntreader.h"
 #include "../src/writer/_dirent.h"
 
+<<<<<<< HEAD
 #include "tools.h"
+=======
+#include "../src/memory_reader.h"
+
+#include "tempfile.h"
+>>>>>>> bb6fd44... Enter DirentReader
 
 namespace
 {
 
 using zim::unittests::TempFile;
 using zim::unittests::write_to_buffer;
+
+zim::Dirent read_from_buffer(const zim::Blob& buf)
+{
+  zim::DirentReader direntReader(std::make_shared<zim::MemoryReader>(buf));
+  return *direntReader.readDirent(zim::offset_t(0));
+}
 
 size_t writenDirentSize(const zim::writer::Dirent& dirent)
 {
@@ -95,7 +108,7 @@ TEST(DirentTest, read_write_article_dirent)
   ASSERT_EQ(dirent.getVersion(), 0U);
 
   auto buffer = write_to_buffer(dirent);
-  zim::Dirent dirent2(buffer);
+  zim::Dirent dirent2(read_from_buffer(buffer));
 
   ASSERT_TRUE(!dirent2.isRedirect());
   ASSERT_EQ(dirent2.getNamespace(), 'A');
@@ -121,7 +134,7 @@ TEST(DirentTest, read_write_article_dirent_unicode)
   ASSERT_EQ(dirent.getBlobNumber().v, 1234U);
 
   auto buffer = write_to_buffer(dirent);
-  zim::Dirent dirent2(buffer);
+  zim::Dirent dirent2(read_from_buffer(buffer));
 
   ASSERT_TRUE(!dirent2.isRedirect());
   ASSERT_EQ(dirent2.getNamespace(), 'A');
@@ -147,7 +160,7 @@ TEST(DirentTest, read_write_redirect_dirent)
   ASSERT_EQ(dirent.getRedirectIndex().v, 321U);
 
   auto buffer = write_to_buffer(dirent);
-  zim::Dirent dirent2(buffer);
+  zim::Dirent dirent2(read_from_buffer(buffer));
 
   ASSERT_TRUE(dirent2.isRedirect());
   ASSERT_EQ(dirent2.getNamespace(), 'A');
@@ -156,6 +169,55 @@ TEST(DirentTest, read_write_redirect_dirent)
   ASSERT_EQ(dirent2.getRedirectIndex().v, 321U);
 }
 
+<<<<<<< HEAD
+=======
+TEST(DirentTest, read_write_linktarget_dirent)
+{
+  zim::writer::Dirent dirent;
+  dirent.setUrl(zim::writer::Url('A', "Bar"));
+  dirent.setLinktarget();
+
+  ASSERT_TRUE(!dirent.isRedirect());
+  ASSERT_TRUE(dirent.isLinktarget());
+  ASSERT_TRUE(!dirent.isDeleted());
+  ASSERT_EQ(dirent.getNamespace(), 'A');
+  ASSERT_EQ(dirent.getUrl(), "Bar");
+
+  auto buffer = write_to_buffer(dirent);
+  zim::Dirent dirent2(read_from_buffer(buffer));
+
+  ASSERT_TRUE(!dirent2.isRedirect());
+  ASSERT_TRUE(dirent2.isLinktarget());
+  ASSERT_TRUE(!dirent2.isDeleted());
+  ASSERT_EQ(dirent2.getNamespace(), 'A');
+  ASSERT_EQ(dirent2.getUrl(), "Bar");
+  ASSERT_EQ(dirent2.getTitle(), "Bar");
+}
+
+TEST(DirentTest, read_write_deleted_dirent)
+{
+  zim::writer::Dirent dirent;
+  dirent.setUrl(zim::writer::Url('A', "Bar"));
+  dirent.setDeleted();
+
+  ASSERT_TRUE(!dirent.isRedirect());
+  ASSERT_TRUE(!dirent.isLinktarget());
+  ASSERT_TRUE(dirent.isDeleted());
+  ASSERT_EQ(dirent.getNamespace(), 'A');
+  ASSERT_EQ(dirent.getUrl(), "Bar");
+
+  auto buffer = write_to_buffer(dirent);
+  zim::Dirent dirent2(read_from_buffer(buffer));
+
+  ASSERT_TRUE(!dirent2.isRedirect());
+  ASSERT_TRUE(!dirent2.isLinktarget());
+  ASSERT_TRUE(dirent2.isDeleted());
+  ASSERT_EQ(dirent2.getNamespace(), 'A');
+  ASSERT_EQ(dirent2.getUrl(), "Bar");
+  ASSERT_EQ(dirent2.getTitle(), "Bar");
+}
+
+>>>>>>> bb6fd44... Enter DirentReader
 TEST(DirentTest, dirent_size)
 {
   zim::writer::Dirent dirent;

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -37,15 +37,10 @@
 #include "../src/buffer.h"
 #include "../src/_dirent.h"
 #include "../src/direntreader.h"
+#include "../src/buffer_reader.h"
 #include "../src/writer/_dirent.h"
 
-<<<<<<< HEAD
 #include "tools.h"
-=======
-#include "../src/memory_reader.h"
-
-#include "tempfile.h"
->>>>>>> bb6fd44... Enter DirentReader
 
 namespace
 {
@@ -53,9 +48,9 @@ namespace
 using zim::unittests::TempFile;
 using zim::unittests::write_to_buffer;
 
-zim::Dirent read_from_buffer(const zim::Blob& buf)
+zim::Dirent read_from_buffer(const zim::Buffer& buf)
 {
-  zim::DirentReader direntReader(std::make_shared<zim::MemoryReader>(buf));
+  zim::DirentReader direntReader(std::make_shared<zim::BufferReader>(buf));
   return *direntReader.readDirent(zim::offset_t(0));
 }
 
@@ -169,55 +164,6 @@ TEST(DirentTest, read_write_redirect_dirent)
   ASSERT_EQ(dirent2.getRedirectIndex().v, 321U);
 }
 
-<<<<<<< HEAD
-=======
-TEST(DirentTest, read_write_linktarget_dirent)
-{
-  zim::writer::Dirent dirent;
-  dirent.setUrl(zim::writer::Url('A', "Bar"));
-  dirent.setLinktarget();
-
-  ASSERT_TRUE(!dirent.isRedirect());
-  ASSERT_TRUE(dirent.isLinktarget());
-  ASSERT_TRUE(!dirent.isDeleted());
-  ASSERT_EQ(dirent.getNamespace(), 'A');
-  ASSERT_EQ(dirent.getUrl(), "Bar");
-
-  auto buffer = write_to_buffer(dirent);
-  zim::Dirent dirent2(read_from_buffer(buffer));
-
-  ASSERT_TRUE(!dirent2.isRedirect());
-  ASSERT_TRUE(dirent2.isLinktarget());
-  ASSERT_TRUE(!dirent2.isDeleted());
-  ASSERT_EQ(dirent2.getNamespace(), 'A');
-  ASSERT_EQ(dirent2.getUrl(), "Bar");
-  ASSERT_EQ(dirent2.getTitle(), "Bar");
-}
-
-TEST(DirentTest, read_write_deleted_dirent)
-{
-  zim::writer::Dirent dirent;
-  dirent.setUrl(zim::writer::Url('A', "Bar"));
-  dirent.setDeleted();
-
-  ASSERT_TRUE(!dirent.isRedirect());
-  ASSERT_TRUE(!dirent.isLinktarget());
-  ASSERT_TRUE(dirent.isDeleted());
-  ASSERT_EQ(dirent.getNamespace(), 'A');
-  ASSERT_EQ(dirent.getUrl(), "Bar");
-
-  auto buffer = write_to_buffer(dirent);
-  zim::Dirent dirent2(read_from_buffer(buffer));
-
-  ASSERT_TRUE(!dirent2.isRedirect());
-  ASSERT_TRUE(!dirent2.isLinktarget());
-  ASSERT_TRUE(dirent2.isDeleted());
-  ASSERT_EQ(dirent2.getNamespace(), 'A');
-  ASSERT_EQ(dirent2.getUrl(), "Bar");
-  ASSERT_EQ(dirent2.getTitle(), "Bar");
-}
-
->>>>>>> bb6fd44... Enter DirentReader
 TEST(DirentTest, dirent_size)
 {
   zim::writer::Dirent dirent;

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -48,7 +48,7 @@ const std::vector<std::pair<char, std::string>> articleurl = {
 
 struct GetDirentMock
 {
-  zim::entry_index_t getCountArticles() const {
+  zim::entry_index_t getDirentCount() const {
     return zim::entry_index_t(articleurl.size());
   }
 


### PR DESCRIPTION
This is the first PR corresponding to the split of #466
~~Based on #483 (not really needed for this PR but will be for the next, based on this one)~~ (merged in master)

- This change the architecture of the code as #466 does but do not change the creation behavior.
- Cherry-pick the `DirentReader` created by @veloman-yunkan in PR #430.
- ~~Add tests on zim creation.~~ (moved in #493)