### PR TITLE
Fixes #489 Mentioning function explicitly

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -110,7 +110,7 @@ std::tuple<char, std::string> zim::parseLongPath(const std::string& longPath)
     throw std::runtime_error("Cannot parse path");
 
   auto ns = longPath[i];
-  auto shortPath = longPath.substr(std::min(i+2, (unsigned int)longPath.size()));
+  auto shortPath = longPath.substr(std::min<unsigned int>(i+2, (unsigned int)longPath.size()));
 
   return std::make_tuple(ns, shortPath);
 }


### PR DESCRIPTION
Mentioning the function explicitly as `std::min<unsigned int>`.