### PR TITLE
Introduce a generic dirent/item handler in the writer.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,8 @@ xapian_sources = [
     'xapian/htmlparse.cc',
     'xapian/myhtmlparse.cc',
     'writer/xapianIndexer.cpp',
-    'writer/xapianWorker.cpp'
+    'writer/xapianWorker.cpp',
+    'writer/xapianHandler.cpp'
 ]
 
 sources = common_sources

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,7 +32,8 @@ common_sources = [
     'writer/item.cpp',
     'writer/cluster.cpp',
     'writer/dirent.cpp',
-    'writer/workers.cpp'
+    'writer/workers.cpp',
+    'writer/clusterWorker.cpp'
 ]
 
 if host_machine.system() == 'windows'
@@ -47,7 +48,8 @@ xapian_sources = [
     'levenshtein.cpp',
     'xapian/htmlparse.cc',
     'xapian/myhtmlparse.cc',
-    'writer/xapianIndexer.cpp'
+    'writer/xapianIndexer.cpp',
+    'writer/xapianWorker.cpp'
 ]
 
 sources = common_sources

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -79,9 +79,10 @@ namespace zim
           : Dirent()
           { ns = ns_; path = path_; }
 
-        char getNamespace() const               { return ns; }
+        char getNamespace() const                { return ns; }
         void setNamespace(char ns_)              { ns = ns_; }
-        const std::string& getTitle() const     { return title.empty() ? path : title; }
+        const std::string& getTitle() const      { return title.empty() ? path : title; }
+        const std::string& getRealTitle() const  { return title; }
         void setTitle(const std::string& title_) { title = title_; }
         const std::string& getPath() const       { return path; }
         void setPath(const std::string& path_) {

--- a/src/writer/clusterWorker.cpp
+++ b/src/writer/clusterWorker.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "clusterWorker.h"
+
+#include "cluster.h"
+
+std::atomic<unsigned long> zim::writer::ClusterTask::waiting_task(0);
+
+namespace zim
+{
+  namespace writer
+  {
+
+    void ClusterTask::run(CreatorData* data) {
+      cluster->close();
+    };
+
+  }
+}

--- a/src/writer/clusterWorker.h
+++ b/src/writer/clusterWorker.h
@@ -30,7 +30,9 @@ class Cluster;
 
 class ClusterTask : public Task {
   public:
-    ClusterTask(Cluster* cluster) :
+    ClusterTask(const ClusterTask&) = delete;
+    ClusterTask& operator=(const ClusterTask&) = delete;
+    explicit ClusterTask(Cluster* cluster) :
       cluster(cluster)
     {
       ++waiting_task;

--- a/src/writer/clusterWorker.h
+++ b/src/writer/clusterWorker.h
@@ -17,26 +17,37 @@
  * MA 02110-1301, USA.
  */
 
-#ifndef OPENZIM_LIBZIM_WORKERS_H
-#define OPENZIM_LIBZIM_WORKERS_H
+#ifndef OPENZIM_LIBZIM_CLUSTER_WORKER_H
+#define OPENZIM_LIBZIM_CLUSTER_WORKER_H
+
+#include <atomic>
+#include "workers.h"
 
 namespace zim {
 namespace writer {
 
-class CreatorData;
+class Cluster;
 
-class Task {
+class ClusterTask : public Task {
   public:
-    Task() = default;
-    virtual ~Task() = default;
+    ClusterTask(Cluster* cluster) :
+      cluster(cluster)
+    {
+      ++waiting_task;
+    };
+    virtual ~ClusterTask()
+    {
+      --waiting_task;
+    }
 
-    virtual void run(CreatorData* data) = 0;
+    virtual void run(CreatorData* data);
+    static std::atomic<unsigned long> waiting_task;
+
+  private:
+    Cluster* cluster;
 };
 
-void* taskRunner(void* data);
-void* clusterWriter(void* data);
-
 }
 }
 
-#endif // OPENZIM_LIBZIM_WORKERS_H
+#endif // OPENZIM_LIBZIM_QUEUE_H

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -25,6 +25,7 @@
 #include "cluster.h"
 #include "debug.h"
 #include "workers.h"
+#include "clusterWorker.h"
 #include <zim/blob.h>
 #include <zim/writer/contentProvider.h>
 #include "../endian_tools.h"
@@ -33,7 +34,8 @@
 #include "../md5.h"
 
 #if defined(ENABLE_XAPIAN)
-  #include "xapianIndexer.h"
+# include "xapianIndexer.h"
+# include "xapianWorker.h"
 #endif
 
 #ifdef _WIN32

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -79,7 +79,6 @@ log_define("zim.writer.creator")
                   << "; RA:" << data->nbRedirectItems \
                   << "; CA:" << data->nbCompItems \
                   << "; UA:" << data->nbUnCompItems \
-                  << "; IA:" << data->nbIndexItems \
                   << "; C:" << data->nbClusters \
                   << "; CC:" << data->nbCompClusters \
                   << "; UC:" << data->nbUnCompClusters \
@@ -394,7 +393,6 @@ namespace zim
         nbRedirectItems(0),
         nbCompItems(0),
         nbUnCompItems(0),
-        nbIndexItems(0),
         nbClusters(0),
         nbCompClusters(0),
         nbUnCompClusters(0),

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -514,11 +514,6 @@ int mode =  _S_IREAD | _S_IWRITE;
 
     }
 
-    void CreatorData::addData(char ns, const std::string& path, const std::string& mimetype, std::unique_ptr<ContentProvider> provider, bool compressContent) {
-      auto dirent = createDirent(ns, path, mimetype, "");
-      addItemData(dirent, std::move(provider), compressContent);
-    }
-
     Dirent* CreatorData::createDirent(char ns, const std::string& path, const std::string& mimetype, const std::string& title)
     {
       auto dirent = pool.getDirent();

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -223,7 +223,7 @@ namespace zim
 
       for(auto& handler:data->m_direntHandlers) {
         // This silently create all the needed dirents
-        auto dirent = handler->getUniqueDirent();
+        auto dirent = handler->getDirent();
       }
 
       // Now we have all the dirents (but not the data), we must correctly set/fix the dirents
@@ -243,7 +243,7 @@ namespace zim
       // We can now stop the dirents, and get their content
       for(auto& handler:data->m_direntHandlers) {
         handler->stop();
-        auto dirent = handler->getUniqueDirent();
+        auto dirent = handler->getDirent();
         auto provider = handler->getContentProvider();
         auto providerSize = provider->getSize();
         data->addItemData(dirent, std::move(provider), false);

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -245,7 +245,6 @@ namespace zim
         handler->stop();
         auto dirent = handler->getDirent();
         auto provider = handler->getContentProvider();
-        auto providerSize = provider->getSize();
         data->addItemData(dirent, std::move(provider), false);
       }
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -221,7 +221,7 @@ namespace zim
       TPROGRESS();
 
 
-      for(auto& handler:data->m_handlers) {
+      for(auto& handler:data->m_direntHandlers) {
         // This silently create all the needed dirents
         auto dirent = handler->getUniqueDirent();
       }
@@ -241,7 +241,7 @@ namespace zim
       data->createTitleIndex();
 
       // We can now stop the dirents, and get their content
-      for(auto& handler:data->m_handlers) {
+      for(auto& handler:data->m_direntHandlers) {
         handler->stop();
         auto dirent = handler->getUniqueDirent();
         auto provider = handler->getContentProvider();
@@ -440,14 +440,14 @@ int mode =  _S_IREAD | _S_IWRITE;
 
 #if defined(ENABLE_XAPIAN)
       auto titleIndexer = std::make_shared<TitleXapianHandler>(this);
-      m_handlers.push_back(titleIndexer);
+      m_direntHandlers.push_back(titleIndexer);
       if (withIndex) {
         auto fulltextIndexer = std::make_shared<FullTextXapianHandler>(this);
-        m_handlers.push_back(fulltextIndexer);
+        m_direntHandlers.push_back(fulltextIndexer);
       }
 #endif
 
-      for(auto& handler:m_handlers) {
+      for(auto& handler:m_direntHandlers) {
         handler->start();
       }
     }

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -135,7 +135,6 @@ namespace zim
         entry_index_type nbRedirectItems;
         entry_index_type nbCompItems;
         entry_index_type nbUnCompItems;
-        entry_index_type nbIndexItems;
         cluster_index_type nbClusters;
         cluster_index_type nbCompClusters;
         cluster_index_type nbUnCompClusters;

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -129,10 +129,6 @@ namespace zim
             handler->handle(dirent, item);
           }
         }
-#if defined(ENABLE_XAPIAN)
-        XapianIndexer titleIndexer;
-        XapianIndexer* indexer = nullptr;
-#endif
 
         // Some stats
         bool verbose;

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -77,7 +77,6 @@ namespace zim
 
         void addDirent(Dirent* dirent);
         void addItemData(Dirent* dirent, std::unique_ptr<ContentProvider> provider, bool compressContent);
-        void addData(char ns, const std::string& path, const std::string& mimetype, std::unique_ptr<ContentProvider> provider, bool compressContent);
 
         Dirent* createDirent(char ns, const std::string& path, const std::string& mimetype, const std::string& title);
         Dirent* createItemDirent(const Item* item);

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -24,6 +24,7 @@
 #include "queue.h"
 #include "_dirent.h"
 #include "workers.h"
+#include "handler.h"
 #include <set>
 #include <vector>
 #include <map>
@@ -121,6 +122,13 @@ namespace zim
 
         bool withIndex;
         std::string indexingLanguage;
+
+        std::vector<std::shared_ptr<DirentHandler>> m_handlers;
+        void handle(Dirent* dirent, std::shared_ptr<Item> item = nullptr) {
+          for(auto& handler: m_handlers) {
+            handler->handle(dirent, item);
+          }
+        }
 #if defined(ENABLE_XAPIAN)
         XapianIndexer titleIndexer;
         XapianIndexer* indexer = nullptr;

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -122,9 +122,9 @@ namespace zim
         bool withIndex;
         std::string indexingLanguage;
 
-        std::vector<std::shared_ptr<DirentHandler>> m_handlers;
+        std::vector<std::shared_ptr<DirentHandler>> m_direntHandlers;
         void handle(Dirent* dirent, std::shared_ptr<Item> item = nullptr) {
-          for(auto& handler: m_handlers) {
+          for(auto& handler: m_direntHandlers) {
             handler->handle(dirent, item);
           }
         }

--- a/src/writer/handler.h
+++ b/src/writer/handler.h
@@ -53,7 +53,12 @@ class DirentHandler {
 
     virtual void start() = 0;
     virtual void stop() = 0;
-    virtual Dirent* getDirent() const = 0;
+    Dirent* getUniqueDirent() {
+      if (!mp_uniqueDirent) {
+        mp_uniqueDirent = getDirent();
+      }
+      return mp_uniqueDirent;
+    }
     virtual std::unique_ptr<ContentProvider> getContentProvider() const = 0;
 
     /*
@@ -64,7 +69,11 @@ class DirentHandler {
     virtual void handle(Dirent* dirent, std::shared_ptr<Item> item) = 0;
 
   protected:
+    virtual Dirent* getDirent() const = 0;
     DirentHandler() = default;
+
+  private:
+    Dirent* mp_uniqueDirent {0};
 };
 
 }

--- a/src/writer/handler.h
+++ b/src/writer/handler.h
@@ -49,9 +49,7 @@ class Item;
  * - Get the dirent associated to the handler using `createDirent()`.
  *   If a handler has to handle itself, it has to do it itself before (in start/stop, ...)
  *   The handlers will NOT have dirents of other hanlders passed.
- *   TitleListingHandler is a exception, it will receive ALL dirents, including its own.
  * - All dirents are correctly set (redirect resolved, index and mimetype set, ...)
- *   This step can mark dirents as removed (invalid redirect), handler may want to check that.
  * - Stop the handler with `stop()`.
  * - Content of the handler is taken using `getContentProvider`
  *

--- a/src/writer/handler.h
+++ b/src/writer/handler.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef OPENZIM_LIBZIM_WRITER_HANDLER_H
+#define OPENZIM_LIBZIM_WRITER_HANDLER_H
+
+#include <string>
+#include <memory>
+
+namespace zim {
+namespace writer {
+
+class CreatorData;
+class ContentProvider;
+class Dirent;
+class Item;
+
+/**
+ * DirentHandler is used to add "extra" handling on dirent/item.
+ *
+ * The main purpose of the handle is to "see" all dirents corresponding to user entries
+ * and generate it's own dirent/item.
+ *
+ * Classical use cases are :
+ *  - Generating a index of the item (xapianIndex)
+ *  - Generating a listing of the item (all item or "main" entries only)
+ *  - Count mimetypes
+ *  - ...
+ *
+ *  While it seems that DirentHandler is dynamically (de)activated by user it is not.
+ *  This is purelly a internal structur to simplify the internal architecture of the writer.
+ */
+class DirentHandler {
+  public:
+    explicit DirentHandler(CreatorData* data);
+    virtual ~DirentHandler() = default;
+
+    virtual void start() = 0;
+    virtual void stop() = 0;
+    virtual Dirent* getDirent() const = 0;
+    virtual std::unique_ptr<ContentProvider> getContentProvider() const = 0;
+
+    /*
+     * Handle a dirent/item.
+     *
+     * item may be nullptr (dirent is a redirect or in special case)
+     */
+    virtual void handle(Dirent* dirent, std::shared_ptr<Item> item) = 0;
+
+  protected:
+    DirentHandler() = default;
+};
+
+}
+}
+
+#endif // OPENZIM_LIBZIM_WRITER_HANDLER_H

--- a/src/writer/handler.h
+++ b/src/writer/handler.h
@@ -46,7 +46,7 @@ class Item;
  * The workflow is the following:
  * - Start the handler with `start()`.
  * - Pass dirents to handle using `handle()`.
- * - Get the dirent associated to the handler using `getDirent()`.
+ * - Get the dirent associated to the handler using `createDirent()`.
  *   If a handler has to handle itself, it has to do it itself before (in start/stop, ...)
  *   The handlers will NOT have dirents of other hanlders passed.
  *   TitleListingHandler is a exception, it will receive ALL dirents, including its own.
@@ -65,11 +65,11 @@ class DirentHandler {
 
     virtual void start() = 0;
     virtual void stop() = 0;
-    Dirent* getUniqueDirent() {
-      if (!mp_uniqueDirent) {
-        mp_uniqueDirent = getDirent();
+    Dirent* getDirent() {
+      if (!mp_dirent) {
+        mp_dirent = createDirent();
       }
-      return mp_uniqueDirent;
+      return mp_dirent;
     }
     virtual std::unique_ptr<ContentProvider> getContentProvider() const = 0;
 
@@ -81,11 +81,11 @@ class DirentHandler {
     virtual void handle(Dirent* dirent, std::shared_ptr<Item> item) = 0;
 
   protected:
-    virtual Dirent* getDirent() const = 0;
+    virtual Dirent* createDirent() const = 0;
     DirentHandler() = default;
 
   private:
-    Dirent* mp_uniqueDirent {0};
+    Dirent* mp_dirent {0};
 };
 
 }

--- a/src/writer/handler.h
+++ b/src/writer/handler.h
@@ -43,6 +43,18 @@ class Item;
  *  - Count mimetypes
  *  - ...
  *
+ * The workflow is the following:
+ * - Start the handler with `start()`.
+ * - Pass dirents to handle using `handle()`.
+ * - Get the dirent associated to the handler using `getDirent()`.
+ *   If a handler has to handle itself, it has to do it itself before (in start/stop, ...)
+ *   The handlers will NOT have dirents of other hanlders passed.
+ *   TitleListingHandler is a exception, it will receive ALL dirents, including its own.
+ * - All dirents are correctly set (redirect resolved, index and mimetype set, ...)
+ *   This step can mark dirents as removed (invalid redirect), handler may want to check that.
+ * - Stop the handler with `stop()`.
+ * - Content of the handler is taken using `getContentProvider`
+ *
  *  While it seems that DirentHandler is dynamically (de)activated by user it is not.
  *  This is purelly a internal structur to simplify the internal architecture of the writer.
  */

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -48,7 +48,7 @@ void FullTextXapianHandler::stop() {
   mp_indexer->indexingPostlude();
 }
 
-Dirent* FullTextXapianHandler::getDirent() const {
+Dirent* FullTextXapianHandler::createDirent() const {
   return mp_creatorData->createDirent('X', "fulltext/xapian", "application/octet-stream+xapian", "");
 }
 
@@ -82,7 +82,7 @@ void TitleXapianHandler::stop() {
   mp_indexer->indexingPostlude();
 }
 
-Dirent* TitleXapianHandler::getDirent() const {
+Dirent* TitleXapianHandler::createDirent() const {
   return mp_creatorData->createDirent('X', "title/xapian", "application/octet-stream+xapian", "");
 }
 

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -27,7 +27,7 @@
 using namespace zim::writer;
 
 FullTextXapianHandler::FullTextXapianHandler(CreatorData* data)
-  : mp_indexer(new XapianIndexer(data->basename+"_title.idx", data->indexingLanguage, IndexingMode::FULL, true)),
+  : mp_indexer(new XapianIndexer(data->basename+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true)),
     mp_creatorData(data)
 {}
 
@@ -68,7 +68,7 @@ void FullTextXapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
 }
 
 TitleXapianHandler::TitleXapianHandler(CreatorData* data)
-  : mp_indexer(new XapianIndexer(data->basename+"_fulltext.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
+  : mp_indexer(new XapianIndexer(data->basename+"_title.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
     mp_creatorData(data)
 {}
 

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "xapianHandler.h"
+#include "xapianIndexer.h"
+#include "xapianWorker.h"
+#include "creatordata.h"
+
+#include <zim/writer/contentProvider.h>
+
+using namespace zim::writer;
+
+FullTextXapianHandler::FullTextXapianHandler(CreatorData* data)
+  : mp_indexer(new XapianIndexer(data->basename+"_title.idx", data->indexingLanguage, IndexingMode::FULL, true)),
+    mp_creatorData(data)
+{}
+
+FullTextXapianHandler::~FullTextXapianHandler() = default;
+
+void FullTextXapianHandler::start() {
+  mp_indexer->indexingPrelude();
+}
+
+void FullTextXapianHandler::stop() {
+  // We need to wait that all indexation tasks have been done before closing the
+  // xapian database.
+  unsigned int wait = 0;
+  do {
+    microsleep(wait);
+    wait += 10;
+  } while (IndexTask::waiting_task.load() > 0);
+  mp_indexer->indexingPostlude();
+}
+
+Dirent* FullTextXapianHandler::getDirent() const {
+  return mp_creatorData->createDirent('X', "fulltext/xapian", "application/octet-stream+xapian", "");
+}
+
+std::unique_ptr<ContentProvider> FullTextXapianHandler::getContentProvider() const {
+  return std::unique_ptr<ContentProvider>(new FileProvider(mp_indexer->getIndexPath()));
+}
+
+void FullTextXapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
+{
+  if (dirent->getNamespace() != 'C') {
+    // We should always have namespace == 'C' but let's be careful.
+    return;
+  }
+  if (item) {
+    mp_creatorData->taskList.pushToQueue(new IndexTask(item, mp_indexer.get()));
+  }
+}
+
+TitleXapianHandler::TitleXapianHandler(CreatorData* data)
+  : mp_indexer(new XapianIndexer(data->basename+"_fulltext.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
+    mp_creatorData(data)
+{}
+
+TitleXapianHandler::~TitleXapianHandler() = default;
+
+void TitleXapianHandler::start() {
+  mp_indexer->indexingPrelude();
+}
+
+void TitleXapianHandler::stop() {
+  mp_indexer->indexingPostlude();
+}
+
+Dirent* TitleXapianHandler::getDirent() const {
+  return mp_creatorData->createDirent('X', "title/xapian", "application/octet-stream+xapian", "");
+}
+
+std::unique_ptr<ContentProvider> TitleXapianHandler::getContentProvider() const {
+  return std::unique_ptr<ContentProvider>(new FileProvider(mp_indexer->getIndexPath()));
+}
+
+void TitleXapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item) {
+  if (dirent->getNamespace() != 'C') {
+    // We should always have namespace == 'C' but let's be careful.
+    return;
+  }
+
+  auto title = dirent->getRealTitle();
+  if (title.empty()) {
+    return;
+  }
+  auto path = dirent->getPath();
+  mp_indexer->indexTitle(path, title);
+}
+

--- a/src/writer/xapianHandler.h
+++ b/src/writer/xapianHandler.h
@@ -38,7 +38,7 @@ class FullTextXapianHandler : public DirentHandler {
     void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
 
   protected:
-    Dirent* getDirent() const override;
+    Dirent* createDirent() const override;
 
   private:
     std::unique_ptr<XapianIndexer> mp_indexer;
@@ -56,7 +56,7 @@ class TitleXapianHandler : public DirentHandler {
     void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
 
   protected:
-    Dirent* getDirent() const override;
+    Dirent* createDirent() const override;
 
   private:
     std::unique_ptr<XapianIndexer> mp_indexer;

--- a/src/writer/xapianHandler.h
+++ b/src/writer/xapianHandler.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef OPENZIM_LIBZIM_XAPIAN_HANDLER_H
+#define OPENZIM_LIBZIM_XAPIAN_HANDLER_H
+
+#include "handler.h"
+
+namespace zim {
+namespace writer {
+
+class XapianIndexer;
+
+class FullTextXapianHandler : public DirentHandler {
+  public:
+    explicit FullTextXapianHandler(CreatorData* data);
+    virtual ~FullTextXapianHandler();
+
+    void start() override;
+    void stop() override;
+    Dirent* getDirent() const override;
+    std::unique_ptr<ContentProvider> getContentProvider() const override;
+    void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
+
+  private:
+    std::unique_ptr<XapianIndexer> mp_indexer;
+    CreatorData* mp_creatorData;
+};
+
+class TitleXapianHandler : public DirentHandler {
+  public:
+    explicit TitleXapianHandler(CreatorData* data);
+    virtual ~TitleXapianHandler();
+
+    void start() override;
+    void stop() override;
+    Dirent* getDirent() const override;
+    std::unique_ptr<ContentProvider> getContentProvider() const override;
+    void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
+
+  private:
+    std::unique_ptr<XapianIndexer> mp_indexer;
+    CreatorData* mp_creatorData;
+};
+
+}
+}
+
+#endif // OPENZIM_LIBZIM_XAPIAN_WORKER_H

--- a/src/writer/xapianHandler.h
+++ b/src/writer/xapianHandler.h
@@ -34,9 +34,11 @@ class FullTextXapianHandler : public DirentHandler {
 
     void start() override;
     void stop() override;
-    Dirent* getDirent() const override;
     std::unique_ptr<ContentProvider> getContentProvider() const override;
     void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
+
+  protected:
+    Dirent* getDirent() const override;
 
   private:
     std::unique_ptr<XapianIndexer> mp_indexer;
@@ -50,9 +52,11 @@ class TitleXapianHandler : public DirentHandler {
 
     void start() override;
     void stop() override;
-    Dirent* getDirent() const override;
     std::unique_ptr<ContentProvider> getContentProvider() const override;
     void handle(Dirent* dirent, std::shared_ptr<Item> item) override;
+
+  protected:
+    Dirent* getDirent() const override;
 
   private:
     std::unique_ptr<XapianIndexer> mp_indexer;

--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -26,9 +26,12 @@
 #include <stdexcept>
 #include <cassert>
 
+using namespace zim::writer;
+
 /* Constructor */
-XapianIndexer::XapianIndexer(const std::string& language, IndexingMode indexingMode, const bool verbose)
-    : language(language),
+XapianIndexer::XapianIndexer(const std::string& indexPath, const std::string& language, IndexingMode indexingMode, const bool verbose)
+    : indexPath(indexPath),
+      language(language),
       indexingMode(indexingMode)
 {
   /* Build ICU Local object to retrieve ISO-639 language code (from
@@ -62,9 +65,8 @@ XapianIndexer::~XapianIndexer()
   }
 }
 
-void XapianIndexer::indexingPrelude(const std::string indexPath_)
+void XapianIndexer::indexingPrelude()
 {
-  indexPath = indexPath_;
   writableDatabase = Xapian::WritableDatabase(indexPath + ".tmp", Xapian::DB_CREATE_OR_OVERWRITE);
   switch (indexingMode) {
     case IndexingMode::TITLE:

--- a/src/writer/xapianIndexer.h
+++ b/src/writer/xapianIndexer.h
@@ -28,10 +28,9 @@
 
 
 namespace zim {
-  namespace writer {
-    class IndexTask;
-  }
-}
+namespace writer {
+
+class IndexTask;
 
 enum class IndexingMode {
   TITLE,
@@ -41,10 +40,10 @@ enum class IndexingMode {
 class XapianIndexer
 {
  public:
-  XapianIndexer(const std::string& language, IndexingMode mode, bool verbose);
+  XapianIndexer(const std::string& indexPath, const std::string& language, IndexingMode mode, bool verbose);
   virtual ~XapianIndexer();
   std::string getIndexPath() { return indexPath; }
-  void indexingPrelude(const std::string indexPath);
+  void indexingPrelude();
   void flush();
   void indexingPostlude();
 
@@ -61,5 +60,8 @@ class XapianIndexer
 
  friend class zim::writer::IndexTask;
 };
+
+}
+}
 
 #endif  // LIBZIM_WRITER_XAPIANINDEXER_H

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -44,13 +44,13 @@ namespace zim
       Xapian::Stem stemmer;
       Xapian::TermGenerator indexer;
       try {
-        stemmer = Xapian::Stem(data->indexer->stemmer_language);
+        stemmer = Xapian::Stem(mp_indexer->stemmer_language);
         indexer.set_stemmer(stemmer);
         indexer.set_stemming_strategy(Xapian::TermGenerator::STEM_ALL);
       } catch (...) {
         // No stemming for language.
       }
-      indexer.set_stopper(&data->indexer->stopper);
+      indexer.set_stopper(&mp_indexer->stopper);
       indexer.set_stopper_strategy(Xapian::TermGenerator::STOP_ALL);
 
       auto indexData = mp_item->getIndexData();
@@ -96,7 +96,7 @@ namespace zim
       }
 
       std::lock_guard<std::mutex> l(s_dbaccessLock);
-      data->indexer->writableDatabase.add_document(document);
+      mp_indexer->writableDatabase.add_document(document);
     }
   }
 }

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -53,7 +53,7 @@ namespace zim
       indexer.set_stopper(&data->indexer->stopper);
       indexer.set_stopper_strategy(Xapian::TermGenerator::STOP_ALL);
 
-      auto indexData = p_item->getIndexData();
+      auto indexData = mp_item->getIndexData();
 
       if (!indexData->hasIndexData()) {
         return;
@@ -62,8 +62,8 @@ namespace zim
       Xapian::Document document;
       indexer.set_document(document);
 
-      document.set_data(p_item->getPath());
-      document.add_value(0, p_item->getTitle());
+      document.set_data(mp_item->getPath());
+      document.add_value(0, mp_item->getTitle());
 
       std::stringstream countWordStringStream;
       countWordStringStream << indexData->getWordCount();

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "xapianWorker.h"
+#include "creatordata.h"
+
+#include "xapianIndexer.h"
+
+#include <stdexcept>
+#include <sstream>
+#include <mutex>
+
+static std::mutex s_dbaccessLock;
+std::atomic<unsigned long> zim::writer::IndexTask::waiting_task(0);
+
+namespace zim
+{
+  namespace writer
+  {
+
+    const unsigned int keywordsBoostFactor = 3;
+    inline unsigned int getTitleBoostFactor(const unsigned int contentLength)
+    {
+      return contentLength / 500 + 1;
+    }
+
+    void IndexTask::run(CreatorData* data) {
+      Xapian::Stem stemmer;
+      Xapian::TermGenerator indexer;
+      try {
+        stemmer = Xapian::Stem(data->indexer->stemmer_language);
+        indexer.set_stemmer(stemmer);
+        indexer.set_stemming_strategy(Xapian::TermGenerator::STEM_ALL);
+      } catch (...) {
+        // No stemming for language.
+      }
+      indexer.set_stopper(&data->indexer->stopper);
+      indexer.set_stopper_strategy(Xapian::TermGenerator::STOP_ALL);
+
+      auto indexData = p_item->getIndexData();
+
+      if (!indexData->hasIndexData()) {
+        return;
+      }
+
+      Xapian::Document document;
+      indexer.set_document(document);
+
+      document.set_data(p_item->getPath());
+      document.add_value(0, p_item->getTitle());
+
+      std::stringstream countWordStringStream;
+      countWordStringStream << indexData->getWordCount();
+      document.add_value(1, countWordStringStream.str());
+
+      auto geoInfo = indexData->getGeoPosition();
+      if (std::get<0>(geoInfo)) {
+        auto geoPosition = Xapian::LatLongCoord(
+        std::get<1>(geoInfo), std::get<2>(geoInfo)).serialise();
+        document.add_value(2, geoPosition);
+      }
+
+      /* Index the content */
+      auto indexContent = indexData->getContent();
+      if (!indexContent.empty()) {
+        indexer.index_text_without_positions(indexContent);
+      }
+
+      /* Index the title */
+      auto indexTitle = indexData->getTitle();
+      if (!indexTitle.empty()) {
+        indexer.index_text_without_positions(
+          indexTitle, getTitleBoostFactor(indexContent.size()));
+      }
+
+      /* Index the keywords */
+      auto indexKeywords = indexData->getKeywords();
+      if (!indexKeywords.empty()) {
+        indexer.index_text_without_positions(indexKeywords, keywordsBoostFactor);
+      }
+
+      std::lock_guard<std::mutex> l(s_dbaccessLock);
+      data->indexer->writableDatabase.add_document(document);
+    }
+  }
+}

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -17,26 +17,38 @@
  * MA 02110-1301, USA.
  */
 
-#ifndef OPENZIM_LIBZIM_WORKERS_H
-#define OPENZIM_LIBZIM_WORKERS_H
+#ifndef OPENZIM_LIBZIM_XAPIAN_WORKER_H
+#define OPENZIM_LIBZIM_XAPIAN_WORKER_H
+
+#include <atomic>
+#include <memory>
+#include "workers.h"
 
 namespace zim {
 namespace writer {
 
-class CreatorData;
+class Item;
 
-class Task {
+class IndexTask : public Task {
   public:
-    Task() = default;
-    virtual ~Task() = default;
+    IndexTask(std::shared_ptr<Item> item) :
+      p_item(item)
+    {
+      ++waiting_task;
+    }
+    virtual ~IndexTask()
+    {
+      --waiting_task;
+    }
 
-    virtual void run(CreatorData* data) = 0;
+    virtual void run(CreatorData* data);
+    static std::atomic<unsigned long> waiting_task;
+
+  private:
+    std::shared_ptr<Item> p_item;
 };
 
-void* taskRunner(void* data);
-void* clusterWriter(void* data);
-
 }
 }
 
-#endif // OPENZIM_LIBZIM_WORKERS_H
+#endif // OPENZIM_LIBZIM_XAPIAN_WORKER_H

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -32,7 +32,7 @@ class Item;
 class IndexTask : public Task {
   public:
     IndexTask(std::shared_ptr<Item> item) :
-      p_item(item)
+      mp_item(item)
     {
       ++waiting_task;
     }
@@ -45,7 +45,7 @@ class IndexTask : public Task {
     static std::atomic<unsigned long> waiting_task;
 
   private:
-    std::shared_ptr<Item> p_item;
+    std::shared_ptr<Item> mp_item;
 };
 
 }

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -28,13 +28,15 @@ namespace zim {
 namespace writer {
 
 class Item;
+class XapianIndexer;
 
 class IndexTask : public Task {
   public:
     IndexTask(const IndexTask&) = delete;
     IndexTask& operator=(const IndexTask&) = delete;
-    explicit IndexTask(std::shared_ptr<Item> item) :
-      mp_item(item)
+    IndexTask(std::shared_ptr<Item> item, XapianIndexer* indexer) :
+      mp_item(item),
+      mp_indexer(indexer)
     {
       ++waiting_task;
     }
@@ -48,6 +50,7 @@ class IndexTask : public Task {
 
   private:
     std::shared_ptr<Item> mp_item;
+    XapianIndexer* mp_indexer;
 };
 
 }

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -31,7 +31,9 @@ class Item;
 
 class IndexTask : public Task {
   public:
-    IndexTask(std::shared_ptr<Item> item) :
+    IndexTask(const IndexTask&) = delete;
+    IndexTask& operator=(const IndexTask&) = delete;
+    explicit IndexTask(std::shared_ptr<Item> item) :
       mp_item(item)
     {
       ++waiting_task;

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -37,22 +37,53 @@ namespace
 
 using namespace zim;
 
-void test_article_dirent(std::shared_ptr<const Dirent> dirent, char ns, const std::string& url, const std::string title, uint16_t mimetype, cluster_index_t clusterNumber, blob_index_t blobNumber) {
+template<typename T>
+struct Filter{
+  Filter() : active(false) {};
+  Filter(T value) : active(true), value(value) {};
+  bool active;
+  T    value;
+};
+
+template<>
+struct Filter<const std::string> {
+  Filter() : active(false) {};
+  Filter(std::string value) : active(true), value(value) {};
+  Filter(const char* value) : active(true), value(value) {};
+  bool active;
+  std::string value;
+};
+
+void test_article_dirent(
+  std::shared_ptr<const Dirent> dirent,
+  Filter<char> ns,
+  Filter<const std::string> url,
+  Filter<const std::string> title,
+  Filter<uint16_t> mimetype,
+  Filter<cluster_index_t> clusterNumber,
+  Filter<blob_index_t> blobNumber)
+{
   ASSERT_TRUE(dirent->isArticle());
-  ASSERT_EQ(dirent->getNamespace(), ns);
-  ASSERT_EQ(dirent->getUrl(), url);
-  ASSERT_EQ(dirent->getTitle(), title);
-  ASSERT_EQ(dirent->getMimeType(), mimetype);
-  ASSERT_EQ(dirent->getClusterNumber(), clusterNumber);
-  ASSERT_EQ(dirent->getBlobNumber(), blobNumber);
+  if (ns.active) ASSERT_EQ(dirent->getNamespace(), ns.value);
+  if (url.active) ASSERT_EQ(dirent->getUrl(), url.value);
+  if (title.active) ASSERT_EQ(dirent->getTitle(), title.value);
+  if (mimetype.active) ASSERT_EQ(dirent->getMimeType(), mimetype.value);
+  if (clusterNumber.active) ASSERT_EQ(dirent->getClusterNumber(), clusterNumber.value);
+  if (blobNumber.active) ASSERT_EQ(dirent->getBlobNumber(), blobNumber.value);
 }
 
-void test_redirect_dirent(std::shared_ptr<const Dirent> dirent, char ns, const std::string& url, const std::string title, entry_index_t target) {
+void test_redirect_dirent(
+  std::shared_ptr<const Dirent> dirent,
+  Filter<char> ns,
+  Filter<const std::string> url,
+  Filter<const std::string> title,
+  Filter<entry_index_t> target)
+{
   ASSERT_TRUE(dirent->isRedirect());
-  ASSERT_EQ(dirent->getNamespace(), ns);
-  ASSERT_EQ(dirent->getUrl(), url);
-  ASSERT_EQ(dirent->getTitle(), title);
-  ASSERT_EQ(dirent->getRedirectIndex(), target);
+  if (ns.active) ASSERT_EQ(dirent->getNamespace(), ns.value);
+  if (url.active) ASSERT_EQ(dirent->getUrl(), url.value);
+  if (title.active) ASSERT_EQ(dirent->getTitle(), title.value);
+  if (target.active) ASSERT_EQ(dirent->getRedirectIndex(), target.value);
 }
 
 TEST(ZimCreator, createEmptyZim)

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <zim/zim.h>
+#include <zim/writer/creator.h>
+#include <zim/writer/item.h>
+#include <zim/writer/contentProvider.h>
+
+#include "tools.h"
+#include "../src/file_compound.h"
+#include "../src/file_reader.h"
+#include "../src/direntreader.h"
+#include "../src/fileheader.h"
+#include "../src/cluster.h"
+#include "../src/rawstreamreader.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+using namespace zim;
+
+void test_article_dirent(std::shared_ptr<const Dirent> dirent, char ns, const std::string& url, const std::string title, uint16_t mimetype, cluster_index_t clusterNumber, blob_index_t blobNumber) {
+  ASSERT_TRUE(dirent->isArticle());
+  ASSERT_EQ(dirent->getNamespace(), ns);
+  ASSERT_EQ(dirent->getUrl(), url);
+  ASSERT_EQ(dirent->getTitle(), title);
+  ASSERT_EQ(dirent->getMimeType(), mimetype);
+  ASSERT_EQ(dirent->getClusterNumber(), clusterNumber);
+  ASSERT_EQ(dirent->getBlobNumber(), blobNumber);
+}
+
+void test_redirect_dirent(std::shared_ptr<const Dirent> dirent, char ns, const std::string& url, const std::string title, entry_index_t target) {
+  ASSERT_TRUE(dirent->isRedirect());
+  ASSERT_EQ(dirent->getNamespace(), ns);
+  ASSERT_EQ(dirent->getUrl(), url);
+  ASSERT_EQ(dirent->getTitle(), title);
+  ASSERT_EQ(dirent->getRedirectIndex(), target);
+}
+
+TEST(ZimCreator, createEmptyZim)
+{
+  unittests::TempFile temp("emptyzimfile");
+  auto tempPath = temp.path() + ".zim";
+  writer::Creator creator;
+  creator.startZimCreation(tempPath);
+  creator.finishZimCreation();
+
+  // Do not use the high level Archive to test that zim file is correctly created but lower structure.
+  auto fd = DEFAULTFS::openFile(tempPath);
+  auto size = fd.getSize();
+  auto reader = std::make_shared<FileReader>(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size);
+  Fileheader header;
+  header.read(*reader);
+  ASSERT_FALSE(header.hasMainPage());
+#if defined(ENABLE_XAPIAN)
+  ASSERT_EQ(header.getArticleCount(), 1); // xapiantitleIndex
+
+  //Read the only one item existing.
+  auto urlPtrPos = offset_t(header.getUrlPtrPos());
+  auto direntOffset = offset_t(reader->read_uint<offset_type>(urlPtrPos));
+
+  DirentReader direntReader(reader);
+  auto dirent = direntReader.readDirent(direntOffset);
+  test_article_dirent(dirent, 'X', "title/xapian", "title/xapian", 0, cluster_index_t(0), blob_index_t(0));
+#else
+  ASSERT_EQ(header.getArticleCount(), 0);
+#endif
+}
+
+
+class TestItem : public writer::Item
+{
+  public:
+    TestItem()  { }
+    virtual ~TestItem() = default;
+
+    virtual std::string getPath() const { return "foo"; };
+    virtual std::string getTitle() const { return "Foo"; };
+    virtual std::string getMimeType() const { return "text/html"; };
+
+    virtual std::unique_ptr<writer::ContentProvider> getContentProvider() const {
+      return std::unique_ptr<writer::ContentProvider>(new writer::StringProvider("FooContent"));
+    }
+};
+
+TEST(ZimCreator, createZim)
+{
+  unittests::TempFile temp("zimfile");
+  auto tempPath = temp.path() + ".zim";
+  writer::Creator creator;
+  creator.startZimCreation(tempPath);
+  auto item = std::make_shared<TestItem>();
+  creator.addItem(item);
+  creator.addMetadata("Title", "This is a title");
+  creator.setMainPath("foo");
+  creator.finishZimCreation();
+
+  // Do not use the high level Archive to test that zim file is correctly created but lower structure.
+  auto fd = DEFAULTFS::openFile(tempPath);
+  auto size = fd.getSize();
+  auto reader = std::make_shared<FileReader>(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size);
+  Fileheader header;
+  header.read(*reader);
+  ASSERT_TRUE(header.hasMainPage());
+#if defined(ENABLE_XAPIAN)
+  ASSERT_EQ(header.getArticleCount(), 4); //xapiantitleIndex + foo + Title + mainPage
+  int xapian_mimetype = 0;
+  int html_mimetype = 1;
+  int plain_mimetype = 2;
+#else
+  ASSERT_EQ(header.getArticleCount(), 3); // foo + Title + mainPage
+  int html_mimetype = 0;
+  int plain_mimetype = 1;
+#endif
+
+
+  // Read dirent
+  DirentReader direntReader(reader);
+  auto urlPtrPos = header.getUrlPtrPos();
+  offset_t direntOffset;
+  std::shared_ptr<const Dirent> dirent;
+
+  direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos)));
+  dirent = direntReader.readDirent(direntOffset);
+  test_redirect_dirent(dirent, '-', "mainPage", "mainPage", entry_index_t(1));
+
+  direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos + 8)));
+  dirent = direntReader.readDirent(direntOffset);
+  test_article_dirent(dirent, 'C', "foo", "Foo", html_mimetype, cluster_index_t(0), blob_index_t(0));
+
+  direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos + 16)));
+  dirent = direntReader.readDirent(direntOffset);
+  test_article_dirent(dirent, 'M', "Title", "Title", plain_mimetype, cluster_index_t(0), blob_index_t(1));
+
+#if defined(ENABLE_XAPIAN)
+  direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos + 24)));
+  dirent = direntReader.readDirent(direntOffset);
+  test_article_dirent(dirent, 'X', "title/xapian", "title/xapian", xapian_mimetype, cluster_index_t(1), blob_index_t(0));
+#endif
+
+  auto clusterPtrPos = header.getClusterPtrPos();
+  auto clusterOffset = offset_t(reader->read_uint<offset_type>(offset_t(clusterPtrPos)));
+  auto cluster = Cluster::read(*reader, clusterOffset);
+  ASSERT_EQ(cluster->getCompression(), CompressionType::zimcompZstd);
+  ASSERT_EQ(cluster->count(), blob_index_t(2));
+  auto blob = cluster->getBlob(blob_index_t(0));
+  ASSERT_EQ(std::string(blob.data(), blob.size()), "FooContent");
+  blob = cluster->getBlob(blob_index_t(1));
+  ASSERT_EQ(std::string(blob.data(), blob.size()), "This is a title");
+}
+
+
+} // unnamed namespace

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -137,6 +137,7 @@ TEST(ZimCreator, createZim)
   unittests::TempFile temp("zimfile");
   auto tempPath = temp.path() + ".zim";
   writer::Creator creator;
+  creator.configIndexing(true, "eng");
   creator.startZimCreation(tempPath);
   auto item = std::make_shared<TestItem>();
   creator.addItem(item);
@@ -152,7 +153,7 @@ TEST(ZimCreator, createZim)
   header.read(*reader);
   ASSERT_TRUE(header.hasMainPage());
 #if defined(ENABLE_XAPIAN)
-  ASSERT_EQ(header.getArticleCount(), 4); //xapiantitleIndex + foo + Title + mainPage
+  ASSERT_EQ(header.getArticleCount(), 5); //xapiantitleIndex + xapianfulltextIndex + foo + Title + mainPage
   int xapian_mimetype = 0;
   int html_mimetype = 1;
   int plain_mimetype = 2;
@@ -184,7 +185,11 @@ TEST(ZimCreator, createZim)
 #if defined(ENABLE_XAPIAN)
   direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos + 24)));
   dirent = direntReader.readDirent(direntOffset);
-  test_article_dirent(dirent, 'X', "title/xapian", "title/xapian", xapian_mimetype, cluster_index_t(1), blob_index_t(0));
+  test_article_dirent(dirent, 'X', "fulltext/xapian", "fulltext/xapian", xapian_mimetype, cluster_index_t(1), Filter<blob_index_t>());
+
+  direntOffset = offset_t(reader->read_uint<offset_type>(offset_t(urlPtrPos + 32)));
+  dirent = direntReader.readDirent(direntOffset);
+  test_article_dirent(dirent, 'X', "title/xapian", "title/xapian", xapian_mimetype, cluster_index_t(1), Filter<blob_index_t>());
 #endif
 
   auto clusterPtrPos = header.getClusterPtrPos();

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,6 +3,7 @@ subdir('data')
 tests = [
     'lrucache',
     'cluster',
+    'creator',
     'dirent',
     'header',
     'uuid',


### PR DESCRIPTION
This is the second part of the split of the PR #486.

This PR concentrate on the writing part and introduce the direntHandler.

Comments in #486 has been answered (either as comment here or by a "fixup!" commit).