### PR TITLE
Remove `zim::windows::FD:FD(int fd)`

### DIFF
--- a/src/file_compound.cpp
+++ b/src/file_compound.cpp
@@ -69,12 +69,14 @@ FileCompound::FileCompound(const std::string& filename):
   }
 }
 
+#ifndef _WIN32
 FileCompound::FileCompound(int fd):
   _filename(),
   _fsize(0)
 {
   addPart(new FilePart(fd));
 }
+#endif
 
 FileCompound::~FileCompound() {
   for(auto it=begin(); it!=end(); it++) {

--- a/src/file_compound.h
+++ b/src/file_compound.h
@@ -56,7 +56,11 @@ class FileCompound : private std::map<Range, FilePart*, less_range> {
 
   public: // functions
     explicit FileCompound(const std::string& filename);
+
+#ifndef _WIN32
     explicit FileCompound(int fd);
+#endif
+
     ~FileCompound();
 
     using ImplType::begin;

--- a/src/file_part.h
+++ b/src/file_part.h
@@ -42,14 +42,12 @@ class FilePart {
         m_filename(filename),
         m_fhandle(std::make_shared<FS::FD>(FS::openFile(filename))),
         m_size(m_fhandle->getSize()) {}
-    FilePart(int fd) :
+
 #ifndef _WIN32
+    FilePart(int fd) :
         FilePart(getFilePathFromFD(fd)) {}
-#else
-        m_filename(""),
-        m_fhandle(std::make_shared<typename FS::FD>(fd)),
-        m_size(m_fhandle->getSize()) {}
 #endif
+
     ~FilePart() = default;
     const std::string& filename() const { return m_filename; };
     const FS::FD& fhandle() const { return *m_fhandle; };

--- a/src/fs_windows.cpp
+++ b/src/fs_windows.cpp
@@ -57,9 +57,6 @@ FD::FD() :
 FD::FD(fd_t handle) :
   mp_impl(new ImplFD(handle)) {}
 
-FD::FD(int fd):
-  mp_impl(new ImplFD(reinterpret_cast<HANDLE>(_get_osfhandle(fd)))) {}
-
 FD::FD(FD&& o) = default;
 FD& FD::operator=(FD&& o) = default;
 

--- a/src/fs_windows.h
+++ b/src/fs_windows.h
@@ -44,7 +44,6 @@ class FD {
   public:
     FD();
     FD(fd_t handle);
-    FD(int fd);
     FD(const FD& o) = delete;
     FD(FD&& o);
     FD& operator=(FD&& o);

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -263,8 +263,8 @@ TEST(ClusterTest, read_extended_cluster)
     return;
   }
 
-  std::FILE* tmpfile = std::tmpfile();
-  int fd = fileno(tmpfile);
+  TempFile tmpfile("extended_cluster");
+  int fd = tmpfile.fd();
   ssize_t bytes_written;
 
   std::string blob0("123456789012345678901234567890");
@@ -318,9 +318,9 @@ TEST(ClusterTest, read_extended_cluster)
 //  std::fseek(tmpfile, bigger_than_4g-1, SEEK_CUR);
   a = '\0';
   bytes_written = write(fd, &a, 1);
-  fflush(tmpfile);
+  tmpfile.close();
 
-  auto fileCompound = std::make_shared<zim::FileCompound>(fd);
+  auto fileCompound = std::make_shared<zim::FileCompound>(tmpfile.path());
   const auto cluster2shptr = zim::Cluster::read(zim::MultiPartFileReader(fileCompound), zim::offset_t(0));
   zim::Cluster& cluster2 = *cluster2shptr;
   ASSERT_EQ(cluster2.isExtended, true);
@@ -343,8 +343,6 @@ TEST(ClusterTest, read_extended_cluster)
   } else {
     ASSERT_EQ(b.size(), bigger_than_4g);
   }
-
-  fclose(tmpfile);
 }
 
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -100,9 +100,8 @@ TEST(ZimCreator, createEmptyZim)
   creator.finishZimCreation();
 
   // Do not use the high level Archive to test that zim file is correctly created but lower structure.
-  auto fd = DEFAULTFS::openFile(tempPath);
-  auto size = fd.getSize();
-  auto reader = std::make_shared<FileReader>(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size);
+  auto fileCompound = std::make_shared<FileCompound>(tempPath);
+  auto reader = std::make_shared<MultiPartFileReader>(fileCompound);
   Fileheader header;
   header.read(*reader);
   ASSERT_FALSE(header.hasMainPage());
@@ -151,9 +150,8 @@ TEST(ZimCreator, createZim)
   creator.finishZimCreation();
 
   // Do not use the high level Archive to test that zim file is correctly created but lower structure.
-  auto fd = DEFAULTFS::openFile(tempPath);
-  auto size = fd.getSize();
-  auto reader = std::make_shared<FileReader>(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size);
+  auto fileCompound = std::make_shared<FileCompound>(tempPath);
+  auto reader = std::make_shared<MultiPartFileReader>(fileCompound);
   Fileheader header;
   header.read(*reader);
   ASSERT_TRUE(header.hasMainPage());

--- a/test/reader.cpp
+++ b/test/reader.cpp
@@ -38,7 +38,7 @@ using zim::unittests::makeTempFile;
 std::unique_ptr<Reader> createFileReader(const char* data, zsize_t size) {
   const auto tmpfile = makeTempFile("data", data);
   auto fd = DEFAULTFS::openFile(tmpfile->path());
-  return std::unique_ptr<Reader>(new FileReader(std::make_shared<typename DEFAULTFS::FD>(fd.release()), offset_t(0), size));
+  return std::unique_ptr<Reader>(new FileReader(std::make_shared<typename DEFAULTFS::FD>(std::move(fd)), offset_t(0), size));
 }
 
 std::unique_ptr<Reader> createMultiFileReader(const char* data, zsize_t size) {


### PR DESCRIPTION
This constructor is buggy as it create a FD that should be destructed
differently that a FD created from a `HANDLE`.

We use it only in cluster's test so we can remove it.

Fix #478