### PR TITLE
Improve phrase search suggestions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -77,13 +77,14 @@ std::map<std::string, int> read_valuesmap(const std::string &s) {
 
 
 void
-setup_queryParser(Xapian::QueryParser* queryparser,
+setup_queryParser(Xapian::QueryParser* queryParser,
                   Xapian::Database& database,
                   const std::string& language,
                   const std::string& stopwords,
+                  bool suggestion_mode,
                   bool newSuggestionFormat) {
-    queryparser->set_default_op(Xapian::Query::op::OP_AND);
-    queryparser->set_database(database);
+    queryParser->set_default_op(Xapian::Query::op::OP_AND);
+    queryParser->set_database(database);
     if ( ! language.empty() )
     {
         /* Build ICU Local object to retrieve ISO-639 language code (from
@@ -93,15 +94,15 @@ setup_queryParser(Xapian::QueryParser* queryparser,
         /* Configuring language base steemming */
         try {
             Xapian::Stem stemmer = Xapian::Stem(languageLocale.getLanguage());
-            queryparser->set_stemmer(stemmer);
-            queryparser->set_stemming_strategy(
+            queryParser->set_stemmer(stemmer);
+            queryParser->set_stemming_strategy(
               newSuggestionFormat ? Xapian::QueryParser::STEM_SOME : Xapian::QueryParser::STEM_ALL);
         } catch (...) {
             std::cout << "No steemming for language '" << languageLocale.getLanguage() << "'" << std::endl;
         }
     }
 
-    if ( ! stopwords.empty() )
+    if ( ! stopwords.empty() && !suggestion_mode )
     {
         std::string stopWord;
         std::istringstream file(stopwords);
@@ -110,7 +111,7 @@ setup_queryParser(Xapian::QueryParser* queryparser,
             stopper->add(stopWord);
         }
         stopper->release();
-        queryparser->set_stopper(stopper);
+        queryParser->set_stopper(stopper);
     }
 }
 
@@ -314,7 +315,7 @@ Search::iterator Search::begin() const {
     if (verbose) {
       std::cout << "Setup queryparser using language " << language << std::endl;
     }
-    setup_queryParser(queryParser, internal->database, language, stopwords, hasNewSuggestionFormat);
+    setup_queryParser(queryParser, internal->database, language, stopwords, suggestion_mode, hasNewSuggestionFormat);
 
     std::string prefix = "";
     unsigned flags = Xapian::QueryParser::FLAG_DEFAULT;

--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -93,8 +93,6 @@ void XapianIndexer::indexTitle(const std::string& path, const std::string& title
     indexer.set_stemmer(stemmer);
     indexer.set_stemming_strategy(Xapian::TermGenerator::STEM_SOME);
   } catch (...) {}
-  indexer.set_stopper(&stopper);
-  indexer.set_stopper_strategy(Xapian::TermGenerator::STOP_ALL);
   Xapian::Document currentDocument;
   currentDocument.clear_values();
   currentDocument.set_data(path);

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -134,11 +134,11 @@ namespace {
 
     std::vector<std::string> resultSet = getSuggestions(archive, "berlin", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
-                                                "again berlin",
                                                 "berlin",
-                                                "not berlin",
                                                 "hotel berlin, berlin",
-                                                "berlin wall"
+                                                "again berlin",
+                                                "berlin wall",
+                                                "not berlin"
                                               };
 
     ASSERT_EQ(expectedResult , resultSet);
@@ -244,16 +244,23 @@ namespace {
 
     ASSERT_EQ(expectedResult, resultSet);
 
-    // "the" which is a stopword
+    // "the"
     resultSet = getSuggestions(archive, "the", archive.getEntryCount());
-    expectedResult = {};
+    expectedResult = {
+                       "The chocolate factory",
+                       "Hour of the wolf",
+                       "The wolf among sheeps",
+                       "The wolf of Shingashina",
+                       "The wolf of Wall Street",
+                       "The wolf of Wall Street Book",
+                       "Terma termb the wolf of wall street termc"
+                     };
 
     ASSERT_EQ(expectedResult, resultSet);
 
-    // "the wolf" translates to "wolf"
+    // "the wolf"
     resultSet = getSuggestions(archive, "the wolf", archive.getEntryCount());
     expectedResult = {
-                       "Wolf",
                        "Hour of the wolf",
                        "The wolf among sheeps",
                        "The wolf of Shingashina",
@@ -265,15 +272,18 @@ namespace {
     ASSERT_EQ(expectedResult, resultSet);
 
     // "the wolf of"
-    // this gives an empty result since the word "of" being a stopword is not
-    // included in the index, but being a partial search, it must be inluced as
-    // a `WILDCARD SYNONYM of` which is not present in the index.
     resultSet = getSuggestions(archive, "the wolf of", archive.getEntryCount());
-    expectedResult = {};
+    expectedResult = {
+                       "Hour of the wolf",
+                       "The wolf of Shingashina",
+                       "The wolf of Wall Street",
+                       "The wolf of Wall Street Book",
+                       "Terma termb the wolf of wall street termc"
+                     };
 
     ASSERT_EQ(expectedResult, resultSet);
 
-    // "the wolf of wall" translates to "wolf wall"
+    // "the wolf of wall"
     resultSet = getSuggestions(archive, "the wolf of wall", archive.getEntryCount());
     expectedResult = {
                        "The wolf of Wall Street",
@@ -315,10 +325,10 @@ namespace {
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
-    // "she", "and", "the" are stopwords, hence the query is resolved to just "apples"
+    // "she", "and", "the" are stopwords, If stopwords are properly handled, they
+    // should be included in the result documents.
     std::vector<std::string> resultSet = getSuggestions(archive, "she and the apple", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
-                                                "apple",
                                                 "she and the apple",
                                               };
     ASSERT_EQ(expectedResult, resultSet);

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -48,7 +48,7 @@ namespace {
 
       zim::Archive createZimFromTitles(std::vector<std::string> titles) {
         zim::writer::Creator creator;
-        creator.configIndexing(true, "eng");
+        creator.configIndexing(true, "en");
         creator.startZimCreation(this->path());
 
         // add dummy items with given titles
@@ -57,7 +57,9 @@ namespace {
           auto item = std::make_shared<TestItem>(path, "text/html", title);
           creator.addItem(item);
         }
+
         creator.addMetadata("Title", "This is a title");
+
         creator.finishZimCreation();
         return zim::Archive(this->path());
       }
@@ -87,15 +89,14 @@ namespace {
                                         "again berlin",
                                         "berlin",
                                         "not berlin"
-                                       };
-
-    std::vector<std::string> expectedResult = {};
-
+                                      };
 
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
     std::vector<std::string> resultSet = getSuggestions(archive, "", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {};
+
     ASSERT_EQ(resultSet, expectedResult);
   }
 
@@ -107,14 +108,14 @@ namespace {
                                         "again berlin",
                                         "berlin",
                                         "not berlin"
-                                       };
-
-    std::vector<std::string> expectedResult = {};
+                                      };
 
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
     std::vector<std::string> resultSet = getSuggestions(archive, "none", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {};
+
     ASSERT_EQ(resultSet, expectedResult);
   }
 
@@ -126,20 +127,20 @@ namespace {
                                         "again berlin",
                                         "berlin",
                                         "not berlin"
-                                       };
-
-    std::vector<std::string> expectedResult = {
-                                        "berlin",
-                                        "hotel berlin, berlin",
-                                        "again berlin",
-                                        "berlin wall",
-                                        "not berlin"
-                                       };
+                                      };
 
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
     std::vector<std::string> resultSet = getSuggestions(archive, "berlin", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "again berlin",
+                                                "berlin",
+                                                "not berlin",
+                                                "hotel berlin, berlin",
+                                                "berlin wall"
+                                              };
+
     ASSERT_EQ(expectedResult , resultSet);
   }
 
@@ -150,41 +151,176 @@ namespace {
                                         "foobar c",
                                         "foobar e",
                                         "foobar d"
-                                       };
+                                      };
 
-    std::vector<std::string> expectedResult = {
-                                        "foobar a",
-                                        "foobar b"
-                                       };
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
     std::vector<std::string> resultSet = getSuggestions(archive, "foobar", 2);
+    std::vector<std::string> expectedResult = {
+                                                "foobar a",
+                                                "foobar b"
+                                              };
+
+    ASSERT_EQ(expectedResult, resultSet);
+  }
+
+  TEST(Suggestion, partialQuery) {
+    std::vector<std::string> titles = {
+                                        "The chocolate factory",
+                                        "The wolf of Shingashina",
+                                        "The wolf of Wall Street",
+                                        "Hour of the wolf",
+                                        "Wolf",
+                                        "Terma termb the wolf of wall street termc"
+                                      };
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    // "wo"
+    std::vector<std::string> resultSet = getSuggestions(archive, "Wo", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "Wolf",
+                                                "Hour of the wolf",
+                                                "The wolf of Shingashina",
+                                                "The wolf of Wall Street",
+                                                "Terma termb the wolf of wall street termc"
+                                              };
+
     ASSERT_EQ(expectedResult, resultSet);
   }
 
   TEST(Suggestion, phraseOrder) {
     std::vector<std::string> titles = {
-                                        "Summer in Berlin",
-                                        "In Summer",
-                                        "Shivers in summer",
-                                        "Summer in Paradise",
-                                        "In mid Summer",
-                                        "In the winter"
-                                       };
-
-    std::vector<std::string> expectedResult = {
-                                        "In Summer",
-                                        "In mid Summer",
-                                        "Shivers in summer",
-                                        "Summer in Berlin",
-                                        "Summer in Paradise"
-                                       };
+                                        "summer winter autumn",
+                                        "winter autumn summer terma",
+                                        "autumn summer winter",
+                                        "control document",
+                                        "summer",
+                                      };
 
     TempZimArchive tza("testZim");
     const zim::Archive archive = tza.createZimFromTitles(titles);
 
-    std::vector<std::string> resultSet = getSuggestions(archive, "summer in", archive.getEntryCount());
+    std::vector<std::string> resultSet = getSuggestions(archive, "winter autumn summer", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "autumn summer winter",
+                                                "summer winter autumn",
+                                                "winter autumn summer terma",
+                                              };
+
+    ASSERT_EQ(expectedResult, resultSet);
+  }
+
+  TEST(Suggestion, incrementalSearch) {
+    std::vector<std::string> titles = {
+                                        "The chocolate factory",
+                                        "The wolf of Shingashina",
+                                        "The wolf of Wall Street",
+                                        "The wolf among sheeps",
+                                        "The wolf of Wall Street Book" ,
+                                        "Hour of the wolf",
+                                        "Wolf",
+                                        "Terma termb the wolf of wall street termc"
+                                      };
+
+    std::vector<std::string> resultSet, expectedResult;
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    // "wolf"
+    resultSet = getSuggestions(archive, "Wolf", archive.getEntryCount());
+    expectedResult = {
+                       "Wolf",
+                       "Hour of the wolf",
+                       "The wolf among sheeps",
+                       "The wolf of Shingashina",
+                       "The wolf of Wall Street",
+                       "The wolf of Wall Street Book",
+                       "Terma termb the wolf of wall street termc"
+                     };
+
+    ASSERT_EQ(expectedResult, resultSet);
+
+    // "the" which is a stopword
+    resultSet = getSuggestions(archive, "the", archive.getEntryCount());
+    expectedResult = {};
+
+    ASSERT_EQ(expectedResult, resultSet);
+
+    // "the wolf" translates to "wolf"
+    resultSet = getSuggestions(archive, "the wolf", archive.getEntryCount());
+    expectedResult = {
+                       "Wolf",
+                       "Hour of the wolf",
+                       "The wolf among sheeps",
+                       "The wolf of Shingashina",
+                       "The wolf of Wall Street",
+                       "The wolf of Wall Street Book",
+                       "Terma termb the wolf of wall street termc"
+                     };
+
+    ASSERT_EQ(expectedResult, resultSet);
+
+    // "the wolf of"
+    // this gives an empty result since the word "of" being a stopword is not
+    // included in the index, but being a partial search, it must be inluced as
+    // a `WILDCARD SYNONYM of` which is not present in the index.
+    resultSet = getSuggestions(archive, "the wolf of", archive.getEntryCount());
+    expectedResult = {};
+
+    ASSERT_EQ(expectedResult, resultSet);
+
+    // "the wolf of wall" translates to "wolf wall"
+    resultSet = getSuggestions(archive, "the wolf of wall", archive.getEntryCount());
+    expectedResult = {
+                       "The wolf of Wall Street",
+                       "The wolf of Wall Street Book",
+                       "Terma termb the wolf of wall street termc"
+                     };
+
+    ASSERT_EQ(expectedResult, resultSet);
+  }
+
+  TEST(Suggestion, phraseOutOfWindow) {
+    std::vector<std::string> titles = {
+                                        "This query",
+                                        "This is the dummy query phrase",
+                                        "the aterm bterm dummy cterm query",
+                                        "aterm the bterm dummy query cterm"
+                                      };
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    std::vector<std::string> resultSet = getSuggestions(archive, "the dummy query", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "This is the dummy query phrase",
+                                                "aterm the bterm dummy query cterm",
+                                                "the aterm bterm dummy cterm query"
+                                              };
+
+    ASSERT_EQ(expectedResult, resultSet);
+  }
+
+  TEST(Suggestion, checkStopword) {
+    std::vector<std::string> titles = {
+                                        "she and the apple",
+                                        "apple",
+                                        "she and the",
+                                      };
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    // "she", "and", "the" are stopwords, hence the query is resolved to just "apples"
+    std::vector<std::string> resultSet = getSuggestions(archive, "she and the apple", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "apple",
+                                                "she and the apple",
+                                              };
     ASSERT_EQ(expectedResult, resultSet);
   }
 }

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -205,9 +205,9 @@ namespace {
 
     std::vector<std::string> resultSet = getSuggestions(archive, "winter autumn summer", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
-                                                "autumn summer winter",
-                                                "summer winter autumn",
                                                 "winter autumn summer terma",
+                                                "autumn summer winter",
+                                                "summer winter autumn"
                                               };
 
     ASSERT_EQ(expectedResult, resultSet);
@@ -274,11 +274,11 @@ namespace {
     // "the wolf of"
     resultSet = getSuggestions(archive, "the wolf of", archive.getEntryCount());
     expectedResult = {
-                       "Hour of the wolf",
                        "The wolf of Shingashina",
                        "The wolf of Wall Street",
                        "The wolf of Wall Street Book",
-                       "Terma termb the wolf of wall street termc"
+                       "Terma termb the wolf of wall street termc",
+                       "Hour of the wolf"
                      };
 
     ASSERT_EQ(expectedResult, resultSet);


### PR DESCRIPTION
This pr is in continuation with #492
Fixes #509

Search with `OP_PHRASE` as the default operator
We are not providing higher weightage to `subquery_phrase`. The way this works is, suppose for a particular document, `subquery_and` gives a weightage `A` and `subquery_phrase` gives a weightage `B`. When we join these two queries with `OP_OR`, the net weight of this document becomes `A+B`. So this is why we are not losing any of the document which we used to get with only a single query. We are promoting the documents with terms in the correct order with the added weight of `subquery_phrase`. We have to do it because using only `subquery_phrase` makes the search too exclusive.

before:
```
$ kiwix-search -v --suggestion wikipedia_en_all_mini_2021-01.zim "the wolf of "
Performing suggestion query `the wolf of `
Setup queryparser using language eng
Mark query as 'partial'
Parsed query 'the wolf of ' to Query((Zthe@1 AND Zwolf@2 AND Zof@3))
Teen Wolf 3: The Return of The Wolf 100
The House of the Wolfings 93
The Mouth of the Wolf 93
The Lair of the Wolf 93
The Skin of the Wolf 93
The Cry of the Wolf 93
The House of the Wolf 93
The Wolf of the Sila 93
The Year of the Wolf 93
The Hour of the Wolf 93
```
After
```
▸ kiwix-search -v --suggestion wikipedia_en_all_mini_2021-01.zim "the wolf of "
Performing suggestion query `the wolf of `
Setup queryparser using language eng
Mark query as 'partial'
Parsed query 'the wolf of ' to Query(((the PHRASE 3 wolf PHRASE 3 of) OR (Zthe@1 AND Zwolf@2 AND Zof@3)))
The Wolf of Badenoch 100
The Wolf of Debt 100
The Wolf of Gubbio 100
The Wolf of Kabul 100
The Wolf of Rimini 100
The Wolf of Zhongshan 100
The Wolf of the Sila 99
The Wolf Of Wall Street 99
The Wolf of Snow Hollow 99
The Wolf of Wall Street 99
```