### PR TITLE
Fixes #502 File name consistent with input provided

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -286,7 +286,7 @@ namespace zim
       ::close(data->out_fd);
 
       TINFO("rename tmpfile to final one.");
-      DEFAULTFS::rename(data->basename+".tmp", data->basename);
+      DEFAULTFS::rename(data->tmpFileName, data->zimName);
 
       TINFO("finish");
     }
@@ -405,19 +405,19 @@ namespace zim
         nbCompClusters(0),
         nbUnCompClusters(0),
         start_time(time(NULL)),
-        basename(fname)
+        zimName(fname),
+        tmpFileName(fname + ".tmp")
     {
-      auto zim_name = basename + ".tmp";
 #ifdef _WIN32
 int mode =  _S_IREAD | _S_IWRITE;
 #else
       mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 #endif
-      out_fd = open(zim_name.c_str(), O_RDWR|O_CREAT|O_TRUNC, mode);
+      out_fd = open(tmpFileName.c_str(), O_RDWR|O_CREAT|O_TRUNC, mode);
       if (out_fd == -1){
         perror(nullptr);
         std::ostringstream ss;
-        ss << "Cannot create file " << zim_name;
+        ss << "Cannot create file " << tmpFileName;
         throw std::runtime_error(ss.str());
       }
       if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -286,7 +286,7 @@ namespace zim
       ::close(data->out_fd);
 
       TINFO("rename tmpfile to final one.");
-      DEFAULTFS::rename(data->basename+".zim.tmp", data->basename+".zim");
+      DEFAULTFS::rename(data->basename+".tmp", data->basename);
 
       TINFO("finish");
     }
@@ -404,12 +404,10 @@ namespace zim
         nbClusters(0),
         nbCompClusters(0),
         nbUnCompClusters(0),
-        start_time(time(NULL))
+        start_time(time(NULL)),
+        basename(fname)
     {
-      basename =  (fname.size() > 4 && fname.compare(fname.size() - 4, 4, ".zim") == 0)
-                        ? fname.substr(0, fname.size() - 4)
-                        : fname;
-      auto zim_name = basename + ".zim.tmp";
+      auto zim_name = basename + ".tmp";
 #ifdef _WIN32
 int mode =  _S_IREAD | _S_IWRITE;
 #else

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -98,7 +98,8 @@ namespace zim
         ThreadList workerThreads;
         std::thread  writerThread;
         const CompressionType compression;
-        std::string basename;
+        std::string zimName;
+        std::string tmpFileName;
         bool isEmpty = true;
         bool isExtended = false;
         zsize_t clustersSize;

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -27,7 +27,7 @@
 using namespace zim::writer;
 
 FullTextXapianHandler::FullTextXapianHandler(CreatorData* data)
-  : mp_indexer(new XapianIndexer(data->basename+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true)),
+  : mp_indexer(new XapianIndexer(data->zimName+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true)),
     mp_creatorData(data)
 {}
 
@@ -71,7 +71,7 @@ void FullTextXapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
 }
 
 TitleXapianHandler::TitleXapianHandler(CreatorData* data)
-  : mp_indexer(new XapianIndexer(data->basename+"_title.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
+  : mp_indexer(new XapianIndexer(data->zimName+"_title.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
     mp_creatorData(data)
 {}
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -96,7 +96,7 @@ void test_redirect_dirent(
 TEST(ZimCreator, createEmptyZim)
 {
   unittests::TempFile temp("emptyzimfile");
-  auto tempPath = temp.path() + ".zim";
+  auto tempPath = temp.path();
   writer::Creator creator;
   creator.startZimCreation(tempPath);
   creator.finishZimCreation();
@@ -171,7 +171,7 @@ class TestItem : public writer::Item
 TEST(ZimCreator, createZim)
 {
   unittests::TempFile temp("zimfile");
-  auto tempPath = temp.path() + ".zim";
+  auto tempPath = temp.path();
   writer::Creator creator;
   creator.configIndexing(true, "eng");
   creator.startZimCreation(tempPath);


### PR DESCRIPTION
Fixes #502 

`".zim"` extension is not automatically added to the output file path if it is not provided by the user in the input.