### PR TITLE
Use a bigger chunk size to write clusters.

### DIFF
--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -38,6 +38,8 @@
 # define _write(fd, addr, size) ::write((fd), (addr), (size))
 #endif
 
+const zim::size_type MAX_WRITE_SIZE(4UL*1024*1024*1024-1);
+
 namespace zim {
 namespace writer {
 
@@ -194,7 +196,7 @@ void Cluster::write(int out_fd) const
         size_type to_write = data.size();
         const char* src = data.data();
         while (to_write) {
-         size_type chunk_size = to_write > 4096 ? 4096 : to_write;
+         size_type chunk_size = std::min(MAX_WRITE_SIZE, to_write);
          auto ret = _write(out_fd, src, chunk_size);
          src += ret;
          to_write -= ret;


### PR DESCRIPTION
If the limit is 4Gb, it is better to set the max size to 4Gb.

I haven't made a real performance test but "cluster" unittest runs around 20% faster (from 6s to 4,7s)

Fix #455