### PR TITLE
Fix zim file creation on Windows.

### DIFF
--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -30,8 +30,7 @@
 # include "io.h"
 #else
 # include "unistd.h"
-# define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
-{throw std::runtime_error("Error writing");}
+# define _write(fd, addr, size) ::write((fd), (addr), (size))
 #endif
 
 log_define("zim.file.header")
@@ -61,7 +60,13 @@ namespace zim
     toLittleEndian(getLayoutPage(), header + 68);
     toLittleEndian(getChecksumPos(), header + 72);
 
-    _write(out_fd, header, Fileheader::size);
+    auto ret = _write(out_fd, header, Fileheader::size);
+    if (ret != Fileheader::size) {
+      std::cerr << "Error Writing" << std::endl;
+      std::cerr << "Ret is " << ret << std::endl;
+      perror("Error writing");
+      throw std::runtime_error("Error writing");
+    }
   }
 
   void Fileheader::read(const Reader& reader)

--- a/src/fs_windows.cpp
+++ b/src/fs_windows.cpp
@@ -172,7 +172,12 @@ bool FS::makeDirectory(path_t path)
 
 void FS::rename(path_t old_path, path_t new_path)
 {
-  MoveFileW(toWideChar(old_path).get(), toWideChar(new_path).get());
+  auto ret = MoveFileExW(toWideChar(old_path).get(), toWideChar(new_path).get(), MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH);
+  if (!ret) {
+    std::ostringstream oss;
+    oss << "Cannot move file " << old_path << " to " << new_path;
+    throw std::runtime_error(oss.str());
+  }
 }
 
 std::string FS::join(path_t base, path_t name)

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -39,6 +39,7 @@
 
 #ifdef _WIN32
 # include <io.h>
+# include <fcntl.h>
 #else
 # include <unistd.h>
 # define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
@@ -409,11 +410,13 @@ namespace zim
         tmpFileName(fname + ".tmp")
     {
 #ifdef _WIN32
-int mode =  _S_IREAD | _S_IWRITE;
+      int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
+      int mode =  _S_IREAD | _S_IWRITE;
 #else
+      int flag = O_RDWR | O_CREAT | O_TRUNC;
       mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 #endif
-      out_fd = open(tmpFileName.c_str(), O_RDWR|O_CREAT|O_TRUNC, mode);
+      out_fd = open(tmpFileName.c_str(), flag, mode);
       if (out_fd == -1){
         perror(nullptr);
         std::ostringstream ss;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -396,6 +396,8 @@ namespace zim
                                    CompressionType c)
       : mainPageDirent(nullptr),
         compression(c),
+        zimName(fname),
+        tmpFileName(fname + ".tmp"),
         withIndex(withIndex),
         indexingLanguage(language),
         verbose(verbose),
@@ -405,9 +407,7 @@ namespace zim
         nbClusters(0),
         nbCompClusters(0),
         nbUnCompClusters(0),
-        start_time(time(NULL)),
-        zimName(fname),
-        tmpFileName(fname + ".tmp")
+        start_time(time(NULL))
     {
 #ifdef _WIN32
       int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -97,7 +97,13 @@ TEST(ZimCreator, createEmptyZim)
 {
   unittests::TempFile temp("emptyzimfile");
   auto tempPath = temp.path();
+  zim::Uuid uuid;
+  // Force special char in the uuid to be sure they are not handled particularly.
+  uuid.data[5] = '\n';
+  uuid.data[10] = '\0';
+
   writer::Creator creator;
+  creator.setUuid(uuid);
   creator.startZimCreation(tempPath);
   creator.finishZimCreation();
 
@@ -172,7 +178,13 @@ TEST(ZimCreator, createZim)
 {
   unittests::TempFile temp("zimfile");
   auto tempPath = temp.path();
+  zim::Uuid uuid;
+  // Force special char in the uuid to be sure they are not handled particularly.
+  uuid.data[5] = '\n';
+  uuid.data[10] = '\0';
+
   writer::Creator creator;
+  creator.setUuid(uuid);
   creator.configIndexing(true, "eng");
   creator.startZimCreation(tempPath);
   auto item = std::make_shared<TestItem>("foo", "Foo", "FooContent");

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -47,7 +47,7 @@ using zim::unittests::write_to_buffer;
 TEST(HeaderTest, read_write_header)
 {
   zim::Fileheader header;
-  header.setUuid("1234567890abcdef");
+  header.setUuid("123456789\0abcd\nf");
   header.setArticleCount(4711);
   header.setUrlPtrPos(12345);
   header.setTitleIdxPos(23456);
@@ -57,7 +57,7 @@ TEST(HeaderTest, read_write_header)
   header.setLayoutPage(13);
   header.setMimeListPos(72);
 
-  ASSERT_EQ(header.getUuid(), "1234567890abcdef");
+  ASSERT_EQ(header.getUuid(), "123456789\0abcd\nf");
   ASSERT_EQ(header.getArticleCount(), 4711U);
   ASSERT_EQ(header.getUrlPtrPos(), 12345U);
   ASSERT_EQ(header.getTitleIdxPos(), 23456U);
@@ -71,7 +71,7 @@ TEST(HeaderTest, read_write_header)
   zim::Fileheader header2;
   header2.read(zim::BufferReader(buffer));
 
-  ASSERT_EQ(header2.getUuid(), "1234567890abcdef");
+  ASSERT_EQ(header2.getUuid(), "123456789\0abcd\nf");
   ASSERT_EQ(header2.getArticleCount(), 4711U);
   ASSERT_EQ(header2.getUrlPtrPos(), 12345U);
   ASSERT_EQ(header2.getTitleIdxPos(), 23456U);

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -24,6 +24,7 @@
 #include <codecvt>
 #include <windows.h>
 #include <fileapi.h>
+#include <io.h>
 #endif
 
 #include <fcntl.h>
@@ -69,7 +70,7 @@ int TempFile::fd()
 {
   if (fd_ == -1) {
 #ifdef _WIN32
-    fd_ = _wopen(wpath_, _O_RDWR);
+    fd_ = _wopen(wpath_, _O_RDWR | _O_BINARY);
 #else
     fd_ = open(path_.c_str(), O_RDWR);
 #endif


### PR DESCRIPTION
The bug comes from the fact that windows silently replaces `\n` by `\r\n` if we open the file "normally" (in text mode).

Fix #507

First commit is not necessary (windows replaces **silently**), but it is better to have it anyway.
(I've pushed the branch in two steps to have the CI run on the two last commits).