### PR TITLE
Index data only if it is html by default and change how indexdata is created.

### DIFF
--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -98,6 +98,11 @@ namespace zim
          * The returned content provider must stay valid even after creator release
          * its reference to the item.
          *
+         * This method will be called once by libzim, in the main thread
+         * (but will be used in a different thread).
+         * The default IndexData will also call this method once (more)
+         * in the main thread (and use it in another thread).
+         *
          * @return the contentProvider of the item.
          */
         virtual std::unique_ptr<ContentProvider> getContentProvider() const = 0;
@@ -109,6 +114,12 @@ namespace zim
          * to store).
          * The returned index data must stay valid even after creator release
          * its reference to the item.
+         *
+         * This method will be called twice by libzim if it is compiled with xapian
+         * (and is configured to index data). You may return the same indexData.
+         * The default implementation will use a contentProvider to get the content to index.
+         * The contentProvider will be created in the main thread but the data reading and
+         * parsing will occur in a different thread.
          *
          * @return the indexData of the item.
          *         May return a nullptr if there is no indexData.

--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -178,7 +178,6 @@ namespace zim
         }
 
         std::unique_ptr<ContentProvider> getContentProvider() const;
-        std::unique_ptr<IndexData> getIndexData() const;
 
       protected:
         std::string content;

--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -110,6 +110,7 @@ namespace zim
          * its reference to the item.
          *
          * @return the indexData of the item.
+         *         May return a nullptr if there is no indexData.
          */
         virtual std::unique_ptr<IndexData> getIndexData() const;
 

--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -41,13 +41,14 @@ namespace zim
     class ContentProvider;
     class IndexData {
       public:
+        using GeoPosition = std::tuple<bool, double, double>;
         virtual ~IndexData() = default;
         virtual bool hasIndexData() const = 0;
         virtual std::string getTitle() const = 0;
         virtual std::string getContent() const = 0;
         virtual std::string getKeywords() const = 0;
         virtual uint32_t getWordCount() const = 0;
-        virtual std::tuple<bool, double, double> getGeoPosition() const = 0;
+        virtual GeoPosition getGeoPosition() const = 0;
     };
 
     /**

--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -113,7 +113,7 @@ namespace zim
          * @return the indexData of the item.
          *         May return a nullptr if there is no indexData.
          */
-        virtual std::unique_ptr<IndexData> getIndexData() const;
+        virtual std::shared_ptr<IndexData> getIndexData() const;
 
         /**
          * Hints to help the creator takes decision about the item.
@@ -122,6 +122,9 @@ namespace zim
          */
         virtual Hints getHints() const;
         virtual ~Item() = default;
+
+      private:
+        mutable std::shared_ptr<IndexData> mp_defaultIndexData;
     };
 
     /**

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_WRITER_DEFAULTINDEXDATA_H
+#define ZIM_WRITER_DEFAULTINDEXDATA_H
+
+#include <zim/writer/item.h>
+#include "xapian/myhtmlparse.h"
+#include "tools.h"
+
+namespace zim
+{
+  namespace writer
+  {
+    class DefaultIndexData : public IndexData {
+      public:
+        DefaultIndexData(const std::string& htmlData, const std::string& title)
+          : title(title)
+        {
+#if defined(ENABLE_XAPIAN)
+          try {
+            htmlParser.parse_html(htmlData, "UTF-8", true);
+          } catch(...) {}
+#endif
+        }
+
+        bool hasIndexData() const {
+#if defined(ENABLE_XAPIAN)
+          return (htmlParser.dump.find("NOINDEX") == std::string::npos);
+#else
+          return false;
+#endif
+        }
+
+        std::string getTitle() const {
+#if defined(ENABLE_XAPIAN)
+          return zim::removeAccents(title);
+#else
+          return "";
+#endif
+         }
+
+        std::string getContent() const {
+#if defined(ENABLE_XAPIAN)
+          return zim::removeAccents(htmlParser.dump);
+#else
+          return "";
+#endif
+        }
+
+        std::string getKeywords() const {
+#if defined(ENABLE_XAPIAN)
+          return zim::removeAccents(htmlParser.keywords);
+#else
+          return "";
+#endif
+        }
+
+        uint32_t getWordCount() const {
+#if defined(ENABLE_XAPIAN)
+          return countWords(htmlParser.dump);
+#else
+          return 0;
+#endif
+        }
+
+        std::tuple<bool, double, double> getGeoPosition() const
+        {
+#if defined(ENABLE_XAPIAN)
+          if(htmlParser.has_geoPosition) {
+            return std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
+          }
+#endif
+          return std::make_tuple(false, 0, 0);
+        }
+
+      private:
+#if defined(ENABLE_XAPIAN)
+        zim::MyHtmlParser htmlParser;
+#endif
+        std::string title;
+
+    };
+  }
+}
+
+#endif // ZIM_WRITER_DEFAULTINDEXDATA_H

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -24,78 +24,105 @@
 #include "xapian/myhtmlparse.h"
 #include "tools.h"
 
+#include <atomic>
+#include <mutex>
+#include <sstream>
+
 namespace zim
 {
   namespace writer
   {
     class DefaultIndexData : public IndexData {
       public:
-        DefaultIndexData(const std::string& htmlData, const std::string& title)
-          : title(title)
-        {
+        DefaultIndexData(std::unique_ptr<ContentProvider> contentProvider, const std::string& title)
+          : m_initialized(false),
+            mp_contentProvider(std::move(contentProvider)),
+#if defined(ENABLE_XAPIAN)
+            m_title(zim::removeAccents(title)),
+#else
+            m_title(""),
+#endif
+            m_hasIndexData(false),
+            m_content(""),
+            m_keywords(""),
+            m_wordCount(0),
+            m_geoPosition(std::make_tuple(false, 0, 0))
+        {}
+
+        void initialize() const {
+          if (m_initialized) {
+            return;
+          }
+          std::lock_guard<std::mutex> lock(m_initLock);
+          // We have to do a double check to be sure that two call on a un-initialized object
+          // will not be initiialized twice.
+          if (m_initialized) {
+            return;
+          }
 #if defined(ENABLE_XAPIAN)
           try {
-            htmlParser.parse_html(htmlData, "UTF-8", true);
+            std::ostringstream ss;
+            while (true) {
+              auto blob = mp_contentProvider->feed();
+              if(blob.size() == 0) {
+                break;
+              }
+              ss << blob;
+            }
+            MyHtmlParser htmlParser;
+            htmlParser.parse_html(ss.str(), "UTF-8", true);
+            m_hasIndexData = (htmlParser.dump.find("NOINDEX") == std::string::npos);
+            m_content = zim::removeAccents(htmlParser.dump);
+            m_keywords = zim::removeAccents(htmlParser.keywords);
+            m_wordCount = countWords(htmlParser.dump);
+            if(htmlParser.has_geoPosition) {
+              m_geoPosition = std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
+            }
           } catch(...) {}
 #endif
+          m_initialized = true;
         }
 
         bool hasIndexData() const {
-#if defined(ENABLE_XAPIAN)
-          return (htmlParser.dump.find("NOINDEX") == std::string::npos);
-#else
-          return false;
-#endif
+          initialize();
+          return m_hasIndexData;
         }
 
         std::string getTitle() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(title);
-#else
-          return "";
-#endif
+          return m_title;
          }
 
         std::string getContent() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(htmlParser.dump);
-#else
-          return "";
-#endif
+          initialize();
+          return m_content;
         }
 
         std::string getKeywords() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(htmlParser.keywords);
-#else
-          return "";
-#endif
+          initialize();
+          return m_keywords;
         }
 
         uint32_t getWordCount() const {
-#if defined(ENABLE_XAPIAN)
-          return countWords(htmlParser.dump);
-#else
-          return 0;
-#endif
+          initialize();
+          return m_wordCount;
         }
 
         GeoPosition getGeoPosition() const
         {
-#if defined(ENABLE_XAPIAN)
-          if(htmlParser.has_geoPosition) {
-            return std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
-          }
-#endif
-          return std::make_tuple(false, 0, 0);
+          initialize();
+          return m_geoPosition;
         }
 
       private:
-#if defined(ENABLE_XAPIAN)
-        zim::MyHtmlParser htmlParser;
-#endif
-        std::string title;
-
+        mutable std::atomic<bool> m_initialized;
+        mutable std::mutex m_initLock;
+        std::unique_ptr<ContentProvider> mp_contentProvider;
+        std::string m_title;
+        mutable bool m_hasIndexData;
+        mutable std::string m_content;
+        mutable std::string m_keywords;
+        mutable uint32_t m_wordCount;
+        mutable GeoPosition m_geoPosition;
     };
   }
 }

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -80,7 +80,7 @@ namespace zim
 #endif
         }
 
-        std::tuple<bool, double, double> getGeoPosition() const
+        GeoPosition getGeoPosition() const
         {
 #if defined(ENABLE_XAPIAN)
           if(htmlParser.has_geoPosition) {

--- a/src/writer/item.cpp
+++ b/src/writer/item.cpp
@@ -19,8 +19,7 @@
 
 #include <zim/writer/item.h>
 #include <zim/writer/contentProvider.h>
-#include "xapian/myhtmlparse.h"
-#include "tools.h"
+#include "defaultIndexData.h"
 
 #include <sstream>
 
@@ -28,77 +27,6 @@ namespace zim
 {
   namespace writer
   {
-    class DefaultIndexData : public IndexData {
-      public:
-        DefaultIndexData(const std::string& htmlData, const std::string& title)
-          : title(title)
-        {
-#if defined(ENABLE_XAPIAN)
-          try {
-            htmlParser.parse_html(htmlData, "UTF-8", true);
-          } catch(...) {}
-#endif
-        }
-
-        bool hasIndexData() const {
-#if defined(ENABLE_XAPIAN)
-          return (htmlParser.dump.find("NOINDEX") == std::string::npos);
-#else
-          return false;
-#endif
-        }
-
-        std::string getTitle() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(title);
-#else
-          return "";
-#endif
-         }
-
-        std::string getContent() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(htmlParser.dump);
-#else
-          return "";
-#endif
-        }
-
-        std::string getKeywords() const {
-#if defined(ENABLE_XAPIAN)
-          return zim::removeAccents(htmlParser.keywords);
-#else
-          return "";
-#endif
-        }
-
-        uint32_t getWordCount() const {
-#if defined(ENABLE_XAPIAN)
-          return countWords(htmlParser.dump);
-#else
-          return 0;
-#endif
-        }
-
-        std::tuple<bool, double, double> getGeoPosition() const
-        {
-#if defined(ENABLE_XAPIAN)
-          if(htmlParser.has_geoPosition) {
-            return std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
-          }
-#endif
-          return std::make_tuple(false, 0, 0);
-        }
-
-      private:
-#if defined(ENABLE_XAPIAN)
-        zim::MyHtmlParser htmlParser;
-#endif
-        std::string title;
-
-    };
-
-
     std::unique_ptr<IndexData> Item::getIndexData() const
     {
       auto provider = getContentProvider();

--- a/src/writer/item.cpp
+++ b/src/writer/item.cpp
@@ -54,15 +54,6 @@ namespace zim
       return std::unique_ptr<ContentProvider>(new SharedStringProvider(shared_string));
     }
 
-    std::unique_ptr<IndexData> StringItem::getIndexData() const
-    {
-      if (getMimeType().find("text/html")!=0) {
-        return nullptr;
-      }
-      return std::unique_ptr<IndexData>(new DefaultIndexData(content, title));
-    }
-
-
     std::unique_ptr<ContentProvider> FileItem::getContentProvider() const
     {
       return std::unique_ptr<ContentProvider>(new FileProvider(filepath));

--- a/src/writer/item.cpp
+++ b/src/writer/item.cpp
@@ -29,6 +29,9 @@ namespace zim
   {
     std::unique_ptr<IndexData> Item::getIndexData() const
     {
+      if (getMimeType().find("text/html")!=0) {
+        return nullptr;
+      }
       auto provider = getContentProvider();
       std::ostringstream ss;
       while (true) {
@@ -53,6 +56,9 @@ namespace zim
 
     std::unique_ptr<IndexData> StringItem::getIndexData() const
     {
+      if (getMimeType().find("text/html")!=0) {
+        return nullptr;
+      }
       return std::unique_ptr<IndexData>(new DefaultIndexData(content, title));
     }
 

--- a/src/writer/item.cpp
+++ b/src/writer/item.cpp
@@ -21,27 +21,22 @@
 #include <zim/writer/contentProvider.h>
 #include "defaultIndexData.h"
 
-#include <sstream>
-
 namespace zim
 {
   namespace writer
   {
-    std::unique_ptr<IndexData> Item::getIndexData() const
+    std::shared_ptr<IndexData> Item::getIndexData() const
     {
+      if (mp_defaultIndexData) {
+        return mp_defaultIndexData;
+      }
       if (getMimeType().find("text/html")!=0) {
         return nullptr;
       }
+
       auto provider = getContentProvider();
-      std::ostringstream ss;
-      while (true) {
-        auto blob = provider->feed();
-        if(blob.size() == 0) {
-          break;
-        }
-        ss << blob;
-      }
-      return std::unique_ptr<IndexData>(new DefaultIndexData(ss.str(), getTitle()));
+      mp_defaultIndexData = std::shared_ptr<IndexData>(new DefaultIndexData(std::move(provider), getTitle()));
+      return mp_defaultIndexData;
     }
 
     Hints Item::getHints() const {

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -55,7 +55,7 @@ namespace zim
 
       auto indexData = mp_item->getIndexData();
 
-      if (!indexData->hasIndexData()) {
+      if (!indexData || !indexData->hasIndexData()) {
         return;
       }
 

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -53,23 +53,21 @@ namespace zim
       indexer.set_stopper(&mp_indexer->stopper);
       indexer.set_stopper_strategy(Xapian::TermGenerator::STOP_ALL);
 
-      auto indexData = mp_item->getIndexData();
-
-      if (!indexData || !indexData->hasIndexData()) {
+      if (!mp_indexData || !mp_indexData->hasIndexData()) {
         return;
       }
 
       Xapian::Document document;
       indexer.set_document(document);
 
-      document.set_data(mp_item->getPath());
-      document.add_value(0, mp_item->getTitle());
+      document.set_data(m_path);
+      document.add_value(0, m_title);
 
       std::stringstream countWordStringStream;
-      countWordStringStream << indexData->getWordCount();
+      countWordStringStream << mp_indexData->getWordCount();
       document.add_value(1, countWordStringStream.str());
 
-      auto geoInfo = indexData->getGeoPosition();
+      auto geoInfo = mp_indexData->getGeoPosition();
       if (std::get<0>(geoInfo)) {
         auto geoPosition = Xapian::LatLongCoord(
         std::get<1>(geoInfo), std::get<2>(geoInfo)).serialise();
@@ -77,20 +75,20 @@ namespace zim
       }
 
       /* Index the content */
-      auto indexContent = indexData->getContent();
+      auto indexContent = mp_indexData->getContent();
       if (!indexContent.empty()) {
         indexer.index_text_without_positions(indexContent);
       }
 
       /* Index the title */
-      auto indexTitle = indexData->getTitle();
+      auto indexTitle = mp_indexData->getTitle();
       if (!indexTitle.empty()) {
         indexer.index_text_without_positions(
           indexTitle, getTitleBoostFactor(indexContent.size()));
       }
 
       /* Index the keywords */
-      auto indexKeywords = indexData->getKeywords();
+      auto indexKeywords = mp_indexData->getKeywords();
       if (!indexKeywords.empty()) {
         indexer.index_text_without_positions(indexKeywords, keywordsBoostFactor);
       }

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <memory>
 #include "workers.h"
+#include <zim/writer/item.h>
 
 namespace zim {
 namespace writer {
@@ -35,7 +36,9 @@ class IndexTask : public Task {
     IndexTask(const IndexTask&) = delete;
     IndexTask& operator=(const IndexTask&) = delete;
     IndexTask(std::shared_ptr<Item> item, XapianIndexer* indexer) :
-      mp_item(item),
+      mp_indexData(item->getIndexData()),
+      m_path(item->getPath()),
+      m_title(item->getTitle()),
       mp_indexer(indexer)
     {
       ++waiting_task;
@@ -49,7 +52,9 @@ class IndexTask : public Task {
     static std::atomic<unsigned long> waiting_task;
 
   private:
-    std::shared_ptr<Item> mp_item;
+    std::shared_ptr<IndexData> mp_indexData;
+    std::string m_path;
+    std::string m_title;
     XapianIndexer* mp_indexer;
 };
 

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -54,7 +54,7 @@ namespace {
         // add dummy items with given titles
         for (auto title : titles) {
           std::string path = "dummyPath" + title;
-          auto item = std::make_shared<TestItem>(path, "plain/text", title);
+          auto item = std::make_shared<TestItem>(path, "text/html", title);
           creator.addItem(item);
         }
         creator.addMetadata("Title", "This is a title");


### PR DESCRIPTION
Make the default indexer index data (content and title) only if it is html.

Change the way the indexData is created :

Before :
- We were creating a contentProvider (for the content) in main thread and read it in worker thread.
- We were creating a IndexData, initialize it (from a new contentProvider) in a worker thread
- To create the IndexData in the worker thread, we keep a reference to the item in the worker thread, so the item is used/destructed later.

Now:
- We are creating a contentProvider (for the content) in main thread and read it in worker thread.
- We are creating a IndexData (from a new contentProvider) in the main thread and we are initialize it (and read content from contentProvider) in a worker thread.
- We do not keep a reference to the item in worker thread. Once we return from `addItem` the item is not used anymore.
  User specialized `IndexData` or `ContentProvider` may keep a reference to the item, but it is not our problem.

Fix #500 