### PR TITLE
Filter duplicates entries(redirections) in search suggestions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -400,6 +400,10 @@ Search::iterator Search::begin() const {
       enquire.set_collapse_key(valuesmap["title"]);
     }
 
+    if (suggestion_mode && valuesmap.find("targetPath") != valuesmap.end()) {
+      enquire.set_collapse_key(valuesmap["targetPath"]);
+    }
+
     internal->results = enquire.get_mset(this->range_start, this->range_end-this->range_start);
     search_started = true;
     estimated_matches_number = internal->results.get_matches_estimated();

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -107,7 +107,8 @@ void TitleXapianHandler::handle(Dirent* dirent, const Hints& hints)
     return;
   }
   auto path = dirent->getPath();
-  mp_indexer->indexTitle(path, title);
+  auto redirectPath = dirent->getRedirectPath();
+  mp_indexer->indexTitle(path, title, redirectPath);
 }
 
 void TitleXapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)

--- a/src/writer/xapianIndexer.h
+++ b/src/writer/xapianIndexer.h
@@ -47,7 +47,7 @@ class XapianIndexer
   void flush();
   void indexingPostlude();
 
-  void indexTitle(const std::string& path, const std::string& title);
+  void indexTitle(const std::string& path, const std::string& title, const std::string& targetPath = "");
 
  protected:
   Xapian::WritableDatabase writableDatabase;

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -63,6 +63,10 @@ namespace {
         creator.finishZimCreation();
         return zim::Archive(this->path());
       }
+
+      std::string getPath() {
+        return this->path();
+      }
   };
 
   std::vector<std::string> getSuggestions(const zim::Archive archive, std::string query, int range) {
@@ -319,7 +323,7 @@ namespace {
     std::vector<std::string> titles = {
                                         "she and the apple",
                                         "apple",
-                                        "she and the",
+                                        "she and the"
                                       };
 
     TempZimArchive tza("testZim");
@@ -329,8 +333,34 @@ namespace {
     // should be included in the result documents.
     std::vector<std::string> resultSet = getSuggestions(archive, "she and the apple", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
-                                                "she and the apple",
+                                                "she and the apple"
                                               };
     ASSERT_EQ(expectedResult, resultSet);
+  }
+
+  TEST(Suggestion, checkRedirectionCollapse) {
+    TempZimArchive tza("testZim");
+    zim::writer::Creator creator;
+    creator.configIndexing(true, "en");
+    creator.startZimCreation(tza.getPath());
+
+    auto item = std::make_shared<TestItem>("testPath", "text/html", "Article Target");
+    creator.addItem(item);
+    creator.addRedirection("redirectionPath1", "Article Redirect 1", "testPath");
+    creator.addRedirection("redirectionPath2", "Article Redirect 2", "testPath");
+
+    creator.addMetadata("Title", "Test zim");
+    creator.finishZimCreation();
+
+    zim::Archive archive(tza.getPath());
+    std::vector<std::string> resultSet = getSuggestions(archive, "Article", archive.getEntryCount());
+
+    // We should get only one result
+    std::vector<std::string> expectedResult = {
+                                                "Article Target",
+                                                "Article Redirect 1",
+                                                "Article Redirect 2"
+                                              };
+    ASSERT_EQ(resultSet, expectedResult);
   }
 }


### PR DESCRIPTION
Fixes #276 

The motive of this pr is to allow efficient collapsing of duplicate entries(redirects) and to index target paths for redirect entries. If we have three entries like:
1. `Article Target`, `testPath`
2. `Article Redirect 1`, `redirectionPath1`, redirect to Article Target
3. `Article Redirect 2`, `redirectionPath2`, redirect to Article Target

Then a suggestion query  "Article" should return {`Article Target`}. That is, articles with the same path are collapsed and the article that is left is the most relevant one.

The changes included in this pr are
- Creating a new value slot `targetPath` in the index to store path/redirectPath of the entries.
- Set `targetPath` as the collapse key if it is available in the index.
- Add unit tests supporting the changes and explaining behavior of chain redirects.

Since we have been storing the `path` as the `data` of the index, To implement this on older indexes afaik, each document in the index would have to be read individually to get the `data`, store it in a set to maintain uniqueness and then create a new `MSet` out of these selected documents. This is a bit tricky and affects the search performance. So I prefer to skip this entirely for older zims (which will be skipped since they don't have `targetPath` in valuesmap) and use it as a feature in the newer zim files. Open to suggestions here.

TODO:
- ~~Handle multiple redirects~~ Redirect chain seems like a super edgy case and the work needed to fix it is not proportionate to the value it brings. Skipping it for this pr.