### PR TITLE
Fix `iterByTitle`.

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -239,7 +239,14 @@ namespace zim
 
   Archive::EntryRange<EntryOrder::titleOrder> Archive::iterByTitle() const
   {
-    return EntryRange<EntryOrder::titleOrder>(m_impl, m_impl->getStartUserEntry().v, m_impl->getEndUserEntry().v);
+    if (m_impl->hasFullTitleIndex()) {
+      // We don't have an index listing only front entry. We have to loop over user entry.
+      // (`C` namespace in new zim scheme, all namespace in old ones)
+      return EntryRange<EntryOrder::titleOrder>(m_impl, m_impl->getStartUserEntry().v, m_impl->getEndUserEntry().v);
+    } else {
+      // We have an index. We can "simply" loop over all front entries.
+      return EntryRange<EntryOrder::titleOrder>(m_impl, 0, m_impl->getFrontEntryCount().v);
+    }
   }
 
   Archive::EntryRange<EntryOrder::efficientOrder> Archive::iterEfficient() const

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -239,13 +239,13 @@ namespace zim
 
   Archive::EntryRange<EntryOrder::titleOrder> Archive::iterByTitle() const
   {
-    if (m_impl->hasFullTitleIndex()) {
+    if (m_impl->hasFrontArticlesIndex()) {
+      // We have a front articles index. We can "simply" loop over all front entries.
+      return EntryRange<EntryOrder::titleOrder>(m_impl, 0, m_impl->getFrontEntryCount().v);
+    } else  {
       // We don't have an index listing only front entry. We have to loop over user entry.
       // (`C` namespace in new zim scheme, all namespace in old ones)
       return EntryRange<EntryOrder::titleOrder>(m_impl, m_impl->getStartUserEntry().v, m_impl->getEndUserEntry().v);
-    } else {
-      // We have an index. We can "simply" loop over all front entries.
-      return EntryRange<EntryOrder::titleOrder>(m_impl, 0, m_impl->getFrontEntryCount().v);
     }
   }
 

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -108,6 +108,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       direntReader(new DirentReader(zimReader)),
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
       m_newNamespaceScheme(false),
+      m_hasFullTitleIndex(false),
       m_startUserEntry(0),
       m_endUserEntry(0)
   {
@@ -150,6 +151,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       offset_t titleOffset(header.getTitleIdxPos());
       zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
       mp_titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Title index table");
+      const_cast<bool&>(m_hasFullTitleIndex) = true;
     }
 
     readMimeTypes();

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -108,7 +108,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       direntReader(new DirentReader(zimReader)),
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
       m_newNamespaceScheme(false),
-      m_hasFullTitleIndex(false),
+      m_hasFrontArticlesIndex(true),
       m_startUserEntry(0),
       m_endUserEntry(0)
   {
@@ -151,7 +151,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       offset_t titleOffset(header.getTitleIdxPos());
       zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
       mp_titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Title index table");
-      const_cast<bool&>(m_hasFullTitleIndex) = true;
+      const_cast<bool&>(m_hasFrontArticlesIndex) = false;
     }
 
     readMimeTypes();

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -59,6 +59,7 @@ namespace zim
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
       const bool m_newNamespaceScheme;
+      const bool m_hasFullTitleIndex;
       const entry_index_t m_startUserEntry;
       const entry_index_t m_endUserEntry;
 
@@ -89,6 +90,7 @@ namespace zim
       const Fileheader& getFileheader() const  { return header; }
       zsize_t getFilesize() const;
       bool hasNewNamespaceScheme() const { return m_newNamespaceScheme; }
+      bool hasFullTitleIndex() const { return m_hasFullTitleIndex; }
 
       FileCompound::PartRange getFileParts(offset_t offset, zsize_t size);
       std::shared_ptr<const Dirent> getDirent(entry_index_t idx);

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -59,7 +59,7 @@ namespace zim
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
       const bool m_newNamespaceScheme;
-      const bool m_hasFullTitleIndex;
+      const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;
       const entry_index_t m_endUserEntry;
 
@@ -90,7 +90,7 @@ namespace zim
       const Fileheader& getFileheader() const  { return header; }
       zsize_t getFilesize() const;
       bool hasNewNamespaceScheme() const { return m_newNamespaceScheme; }
-      bool hasFullTitleIndex() const { return m_hasFullTitleIndex; }
+      bool hasFrontArticlesIndex() const { return m_hasFrontArticlesIndex; }
 
       FileCompound::PartRange getFileParts(offset_t offset, zsize_t size);
       std::shared_ptr<const Dirent> getDirent(entry_index_t idx);


### PR DESCRIPTION
If we have a specific title index, we must iterate on it.
We must not iterate on a (wrong) subset of the entries.

Related to #514
(This doesn't try to fix #514)