### PR TITLE
Remove collapse based on title

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -396,10 +396,6 @@ Search::iterator Search::begin() const {
 
     enquire.set_query(query);
 
-    if (suggestion_mode && valuesmap.find("title") != valuesmap.end()) {
-      enquire.set_collapse_key(valuesmap["title"]);
-    }
-
     if (suggestion_mode && valuesmap.find("targetPath") != valuesmap.end()) {
       enquire.set_collapse_key(valuesmap["targetPath"]);
     }

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -391,4 +391,32 @@ namespace {
                                               };
     ASSERT_EQ(resultSet, expectedResult);
   }
+
+  // Different articles with same title should not be collapsed in suggestions
+  TEST(Suggestion, diffArticleSameTitle) {
+    TempZimArchive tza("testZim");
+    zim::writer::Creator creator;
+    creator.configIndexing(true, "en");
+    creator.startZimCreation(tza.getPath());
+
+    auto item1 = std::make_shared<TestItem>("testPath1", "text/html", "Test Article");
+    auto item2 = std::make_shared<TestItem>("testPath2", "text/html", "Test Article");
+    creator.addItem(item1);
+    creator.addItem(item2);
+
+    creator.addMetadata("Title", "Test zim");
+    creator.finishZimCreation();
+
+    zim::Archive archive(tza.getPath());
+    std::vector<std::string> resultSet = getSuggestions(archive, "Test Article", archive.getEntryCount());
+
+    // We should get two results
+    // We are getting two results before removing the collapse on title because
+    // it gets overridden by the collapse on targetPath.
+    std::vector<std::string> expectedResult = {
+                                                "Test Article",
+                                                "Test Article"
+                                              };
+    ASSERT_EQ(resultSet, expectedResult);
+  }
 }

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -411,8 +411,6 @@ namespace {
     std::vector<std::string> resultSet = getSuggestions(archive, "Test Article", archive.getEntryCount());
 
     // We should get two results
-    // We are getting two results before removing the collapse on title because
-    // it gets overridden by the collapse on targetPath.
     std::vector<std::string> expectedResult = {
                                                 "Test Article",
                                                 "Test Article"


### PR DESCRIPTION
Fixes #474 

We used to have collapse based on `title` value slot of documents in the suggestion search. This is a feature we do not want to keep. Though this is already not working after the merge of #515 (collapse on `targetPath` override this), the code is still there and should be removed. We only want to perform collapse based on `targetPath`. 

The changes included in this pr are
- Add unit tests that handle the case of different articles with the same title as mentioned in the ticket.
- Removes the unwanted title collapse on suggestion search.