### PR TITLE
Fix default html parsing.

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -78,16 +78,20 @@ std::string zim::removeAccents(const std::string& text)
 
 uint32_t zim::countWords(const std::string& text)
 {
-  unsigned int numWords = 1;
+  unsigned int numWords = 0;
   unsigned int length = text.size();
+  unsigned int i = 0;
 
-  for (unsigned int i = 0; i < length;) {
-    while (i < length && text[i] != ' ') {
-      i++;
-    }
+  // Find first word
+  while ( i < length && std::isspace(text[i]) ) i++;
+
+  while ( i < length ) {
+    // Find end of word
+    while ( i < length && !std::isspace(text[i]) ) i++;
     numWords++;
-      i++;
-    }
+    // Find start of next word
+    while ( i < length && std::isspace(text[i]) ) i++;
+  }
   return numWords;
 }
 

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -72,7 +72,7 @@ namespace zim
           try {
             htmlParser.parse_html(ss.str(), "UTF-8", true);
           } catch(...) {}
-          m_hasIndexData = (htmlParser.dump.find("NOINDEX") == std::string::npos);
+          m_hasIndexData = !htmlParser.dump.empty() && htmlParser.indexing_allowed && (htmlParser.dump.find("NOINDEX") == std::string::npos);
           m_content = zim::removeAccents(htmlParser.dump);
           m_keywords = zim::removeAccents(htmlParser.keywords);
           m_wordCount = countWords(htmlParser.dump);

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -60,25 +60,25 @@ namespace zim
             return;
           }
 #if defined(ENABLE_XAPIAN)
+          std::ostringstream ss;
+          while (true) {
+            auto blob = mp_contentProvider->feed();
+            if(blob.size() == 0) {
+              break;
+            }
+            ss << blob;
+          }
+          MyHtmlParser htmlParser;
           try {
-            std::ostringstream ss;
-            while (true) {
-              auto blob = mp_contentProvider->feed();
-              if(blob.size() == 0) {
-                break;
-              }
-              ss << blob;
-            }
-            MyHtmlParser htmlParser;
             htmlParser.parse_html(ss.str(), "UTF-8", true);
-            m_hasIndexData = (htmlParser.dump.find("NOINDEX") == std::string::npos);
-            m_content = zim::removeAccents(htmlParser.dump);
-            m_keywords = zim::removeAccents(htmlParser.keywords);
-            m_wordCount = countWords(htmlParser.dump);
-            if(htmlParser.has_geoPosition) {
-              m_geoPosition = std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
-            }
           } catch(...) {}
+          m_hasIndexData = (htmlParser.dump.find("NOINDEX") == std::string::npos);
+          m_content = zim::removeAccents(htmlParser.dump);
+          m_keywords = zim::removeAccents(htmlParser.keywords);
+          m_wordCount = countWords(htmlParser.dump);
+          if(htmlParser.has_geoPosition) {
+            m_geoPosition = std::make_tuple(true, htmlParser.latitude, htmlParser.longitude);
+          }
 #endif
           m_initialized = true;
         }

--- a/test/defaultIndexdata.cpp
+++ b/test/defaultIndexdata.cpp
@@ -53,6 +53,28 @@ namespace {
     ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
   }
 
+  TEST(DefaultIndexdata, noindexhead) {
+    auto indexData = index_data(R"(<html><head><meta name="robots" content="noindex"></head><body>Some <b>bold</b> words</body><html>)", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), false);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "");
+    ASSERT_EQ(indexData->getKeywords(), "");
+    ASSERT_EQ(indexData->getWordCount(), 0);
+    ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
+  }
+
+  TEST(DefaultIndexdata, noindexnone) {
+    auto indexData = index_data(R"(<html><head><meta name="robots" content="none"></head><body>Some <b>bold</b> words</body><html>)", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), false);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "");
+    ASSERT_EQ(indexData->getKeywords(), "");
+    ASSERT_EQ(indexData->getWordCount(), 0);
+    ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
+  }
+
  TEST(DefaultIndexdata, noindexbody) {
     auto indexData = index_data("<html><body>NOINDEXSome <b>bold</b> words</body><html>", "A Title");
 

--- a/test/defaultIndexdata.cpp
+++ b/test/defaultIndexdata.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+
+#include <zim/writer/contentProvider.h>
+
+#include "../src/writer/defaultIndexData.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+  std::unique_ptr<zim::writer::IndexData> index_data(const std::string& content, const std::string& title)
+  {
+    std::unique_ptr<zim::writer::ContentProvider> contentProvider(new zim::writer::StringProvider(content));
+    return std::unique_ptr<zim::writer::IndexData>(new zim::writer::DefaultIndexData(std::move(contentProvider), title));
+  }
+
+  TEST(DefaultIndexdata, empty) {
+    auto indexData = index_data("", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), false);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "");
+    ASSERT_EQ(indexData->getKeywords(), "");
+    ASSERT_EQ(indexData->getWordCount(), 0);
+    ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
+  }
+
+  TEST(DefaultIndexdata, simple) {
+    auto indexData = index_data("<html><body>Some <b>bold</b> words</body><html>", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), true);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "some bold words");
+    ASSERT_EQ(indexData->getKeywords(), "");
+    ASSERT_EQ(indexData->getWordCount(), 3);
+    ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
+  }
+
+ TEST(DefaultIndexdata, noindexbody) {
+    auto indexData = index_data("<html><body>NOINDEXSome <b>bold</b> words</body><html>", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), false);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "noindexsome bold words");
+    ASSERT_EQ(indexData->getKeywords(), "");
+    ASSERT_EQ(indexData->getWordCount(), 3);
+    ASSERT_EQ(indexData->getGeoPosition(), std::make_tuple(false, 0, 0));
+  }
+
+  TEST(DefaultIndexdata, full) {
+    auto indexData = index_data(R"(<html><head><meta name="keywords" content="some keyword important"><meta name="geo.position" content="45.005;10.100"></head><body>Some <b>bold</b> words</body><html>)", "A Title");
+
+    ASSERT_EQ(indexData->hasIndexData(), true);
+    ASSERT_EQ(indexData->getTitle(), "a title");
+    ASSERT_EQ(indexData->getContent(), "some bold words");
+    ASSERT_EQ(indexData->getKeywords(), "some keyword important");
+    ASSERT_EQ(indexData->getWordCount(), 3);
+    auto geoPos = indexData->getGeoPosition();
+    ASSERT_TRUE(std::get<0>(geoPos));
+    ASSERT_TRUE(std::abs(std::get<1>(geoPos)-45.005) < 0.00001);
+    ASSERT_TRUE(std::abs(std::get<2>(geoPos)-10.1) < 0.00001);
+  }
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -19,7 +19,8 @@ tests = [
     'rawstreamreader',
     'bufferstreamer',
     'parseLongPath',
-    'random'
+    'random',
+    'tooltesting',
 ]
 
 if xapian_dep.found()

--- a/test/meson.build
+++ b/test/meson.build
@@ -20,12 +20,11 @@ tests = [
     'bufferstreamer',
     'parseLongPath',
     'random',
-    'defaultIndexdata',
     'tooltesting',
 ]
 
 if xapian_dep.found()
-    tests += ['search', 'suggestion']
+    tests += ['search', 'suggestion', 'defaultIndexdata']
 endif
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/meson.build
+++ b/test/meson.build
@@ -20,6 +20,7 @@ tests = [
     'bufferstreamer',
     'parseLongPath',
     'random',
+    'defaultIndexdata',
     'tooltesting',
 ]
 

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -38,7 +38,7 @@ namespace {
         : BasicItem(path, mimetype, title) {}
 
       virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
-        return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(""));
+        return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider("foo"));
       }
   };
 

--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "../src/tools.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+  TEST(Tools, wordCount) {
+    ASSERT_EQ(zim::countWords(""), 0);
+    ASSERT_EQ(zim::countWords("   "), 0);
+    ASSERT_EQ(zim::countWords("One"), 1);
+    ASSERT_EQ(zim::countWords("One Two Three"), 3);
+    ASSERT_EQ(zim::countWords("  One  "), 1);
+    ASSERT_EQ(zim::countWords("One    Two Three   "), 3);
+    ASSERT_EQ(zim::countWords("One.Two\tThree"), 2);
+  }
+
+}


### PR DESCRIPTION
`countWord` was returning 1 for empty string.

This is a simple way to count word. But it is only use for statistic
about document. Actual count doesn't have to be exact.