### PR TITLE
Use full path as data of documents in the xapian index for compatibility of new zim files with older libzim

### DIFF
--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -46,7 +46,7 @@ class search_iterator : public std::iterator<std::bidirectional_iterator_tag, En
         search_iterator& operator--();
         search_iterator operator--(int);
 
-        std::string get_url() const;
+        std::string get_path() const;
         std::string get_title() const;
         int get_score() const;
         std::string get_snippet() const;

--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -56,6 +56,10 @@ class search_iterator : public std::iterator<std::bidirectional_iterator_tag, En
         reference operator*() const;
         pointer operator->() const;
 
+#ifdef ZIM_PRIVATE
+        std::string get_dbData() const;
+#endif
+
     private:
         struct InternalData;
         std::unique_ptr<InternalData> internal;

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -99,11 +99,25 @@ search_iterator search_iterator::operator--(int) {
     return it;
 }
 
-std::string search_iterator::get_url() const {
+std::string search_iterator::get_path() const {
     if ( ! internal ) {
         return "";
     }
-    return internal->get_document().get_data();
+
+    std::string path = internal->get_document().get_data();
+    bool hasNewNamespaceScheme = internal->search->m_archives.at(get_fileIndex()).hasNewNamespaceScheme();
+
+    std::string dbDataType = internal->search->internal->database.get_metadata("data");
+    if (dbDataType.empty()) {
+        dbDataType = "fullPath";
+    }
+
+    // If the archive has new namespace scheme and the type of its indexed data
+    // is `fullPath` we return only the `path` without namespace
+    if (hasNewNamespaceScheme && dbDataType == "fullPath") {
+        path = path.substr(2);
+    }
+    return path;
 }
 
 std::string search_iterator::get_dbData() const {

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#define ZIM_PRIVATE
+
 #include "xapian/myhtmlparse.h"
 #include <zim/search_iterator.h>
 #include <zim/search.h>
@@ -101,6 +103,14 @@ std::string search_iterator::get_url() const {
     if ( ! internal ) {
         return "";
     }
+    return internal->get_document().get_data();
+}
+
+std::string search_iterator::get_dbData() const {
+    if ( ! internal ) {
+        return "";
+    }
+
     return internal->get_document().get_data();
 }
 

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -60,7 +60,8 @@ namespace zim
       Xapian::Document document;
       indexer.set_document(document);
 
-      document.set_data(m_path);
+      std::string fullPath = "C/" + m_path;
+      document.set_data(fullPath);
       document.add_value(0, m_title);
 
       std::stringstream countWordStringStream;

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -359,8 +359,8 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
     search2.set_range(0, archive2.getEntryCount());
     ASSERT_NE(0, search1.get_matches_estimated());
     ASSERT_EQ(search1.get_matches_estimated(), search2.get_matches_estimated());
-    ASSERT_EQ(mainEntry.getPath(), search1.begin().get_url());
-    ASSERT_EQ(mainEntry.getPath(), search2.begin().get_url());
+    ASSERT_EQ(mainEntry.getPath(), search1.begin().get_path());
+    ASSERT_EQ(mainEntry.getPath(), search2.begin().get_path());
     ASSERT_EQ(std::distance(search1.begin(), search1.end()),
               std::distance(search2.begin(), search2.end()));
   }

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -73,7 +73,7 @@ TEST(Search, searchByTitle)
   search.set_query(mainEntry.getTitle());
   search.set_range(0, archive.getEntryCount());
   ASSERT_NE(0, search.get_matches_estimated());
-  ASSERT_EQ(mainEntry.getPath(), search.begin().get_url());
+  ASSERT_EQ(mainEntry.getPath(), search.begin().get_path());
 }
 
 // To secure compatibity of new zim files with older kiwixes, we need to index

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Veloman Yunkan
+ * Copyright (C) 2021 Maneesh P M <manu.pm55@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -20,11 +21,47 @@
 #define ZIM_PRIVATE
 #include <zim/archive.h>
 #include <zim/search.h>
+#include <zim/writer/creator.h>
+#include <zim/writer/item.h>
+#include <zim/writer/contentProvider.h>
+
+#include "tools.h"
 
 #include "gtest/gtest.h"
 
 namespace
 {
+
+class TestItem : public zim::writer::Item
+{
+  public:
+    TestItem(const std::string& path, const std::string& title, const std::string& content):
+     path(path), title(title), content(content)  { }
+    virtual ~TestItem() = default;
+
+    virtual std::string getPath() const { return path; };
+    virtual std::string getTitle() const { return title; };
+    virtual std::string getMimeType() const { return "text/html"; };
+
+    virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
+      return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(content));
+    }
+
+  std::string path;
+  std::string title;
+  std::string content;
+};
+
+// Helper class to create a temporary zim and remove it once the test is done
+class TempZimArchive : zim::unittests::TempFile
+{
+  public:
+    explicit TempZimArchive(const char* tempPath) : zim::unittests::TempFile {tempPath} {}
+
+    const std::string getPath() {
+      return this->path();
+    }
+};
 
 TEST(Search, searchByTitle)
 {
@@ -37,6 +74,34 @@ TEST(Search, searchByTitle)
   search.set_range(0, archive.getEntryCount());
   ASSERT_NE(0, search.get_matches_estimated());
   ASSERT_EQ(mainEntry.getPath(), search.begin().get_url());
+}
+
+// To secure compatibity of new zim files with older kiwixes, we need to index
+// full path of the entries as data of documents.
+TEST(Search, indexFullPath)
+{
+  TempZimArchive tza("testZim");
+  zim::writer::Creator creator;
+  creator.configIndexing(true, "en");
+  creator.startZimCreation(tza.getPath());
+
+  auto item = std::make_shared<TestItem>("testPath", "Test Article", "This is a test article");
+  creator.addItem(item);
+
+  creator.setMainPath("testPath");
+  creator.addMetadata("Title", "Test zim");
+  creator.finishZimCreation();
+
+  zim::Archive archive(tza.getPath());
+
+  zim::Search search(archive);
+  search.set_suggestion_mode(false);
+  search.set_query("test article");
+  search.set_range(0, archive.getEntryCount());
+  search.set_verbose(true);
+
+  ASSERT_EQ(search.begin().get_path(), "testPath");
+  ASSERT_EQ(search.begin().get_dbData().substr(0, 2), "C/");
 }
 
 } // unnamed namespace


### PR DESCRIPTION
Fixes #523 

There is a compatibility issue when reading new zim files with older libzim used by some kiwixes. Older libzim still uses the convention where the namespace is not hidden from the path. Hence it fails to load items from the paths stored in new zim file indexes. The solution is to index the `fullPath` with namespace as the data of documents in the xapian index. This will make older libzim happy. We already have a compatibility layer in newer libzim that handles the old path convention with namespace, we just modify search iterator `get_path`(formerly `get_url`) to do the same.

The changes included in this pr are:
- Index `fullPath` in xapian title index.
- Index `fullPath` in xapian ft index.
- Introduce a new database metadata `data` that signifies what is contained as "data" of documents in the index.
- Rename `search_iterator:;get_url` to `search_iterator::get_path` and handle new namespace scheme
- Add unit test to ensure proper indexing of data