### PR TITLE
Introduce anchor term to titles index

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Maneesh P M <manu.pm55@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#define ANCHOR_TERM "0posanchor "

--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -21,6 +21,7 @@
 #include "libzim-resources.h"
 #include "fs.h"
 #include "tools.h"
+#include "../constants.h"
 #include <sstream>
 #include <fstream>
 #include <stdexcept>
@@ -132,7 +133,8 @@ void XapianIndexer::indexTitle(const std::string& path, const std::string& title
   }
 
   if (!unaccentedTitle.empty()) {
-    indexer.index_text(unaccentedTitle, 1);
+    std::string anchoredTitle = ANCHOR_TERM + unaccentedTitle;
+    indexer.index_text(anchoredTitle, 1);
   }
 
   /* add to the database */

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -139,9 +139,9 @@ namespace {
     std::vector<std::string> resultSet = getSuggestions(archive, "berlin", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
                                                 "berlin",
+                                                "berlin wall",
                                                 "hotel berlin, berlin",
                                                 "again berlin",
-                                                "berlin wall",
                                                 "not berlin"
                                               };
 
@@ -252,11 +252,11 @@ namespace {
     resultSet = getSuggestions(archive, "the", archive.getEntryCount());
     expectedResult = {
                        "The chocolate factory",
-                       "Hour of the wolf",
                        "The wolf among sheeps",
                        "The wolf of Shingashina",
                        "The wolf of Wall Street",
                        "The wolf of Wall Street Book",
+                       "Hour of the wolf",
                        "Terma termb the wolf of wall street termc"
                      };
 
@@ -265,11 +265,11 @@ namespace {
     // "the wolf"
     resultSet = getSuggestions(archive, "the wolf", archive.getEntryCount());
     expectedResult = {
-                       "Hour of the wolf",
                        "The wolf among sheeps",
                        "The wolf of Shingashina",
                        "The wolf of Wall Street",
                        "The wolf of Wall Street Book",
+                       "Hour of the wolf",
                        "Terma termb the wolf of wall street termc"
                      };
 
@@ -431,9 +431,9 @@ namespace {
 
     std::vector<std::string> resultSet = getSuggestions(archive, "This is a title", archive.getEntryCount());
     std::vector<std::string> expectedResult = {
+                                                "this is a title aterm bterm cterm",
                                                 "aterm bterm this is a title cterm",
-                                                "aterm this is a title bterm cterm",
-                                                "this is a title aterm bterm cterm"
+                                                "aterm this is a title bterm cterm"
                                               };
 
     ASSERT_EQ(expectedResult, resultSet);

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -417,4 +417,25 @@ namespace {
                                               };
     ASSERT_EQ(resultSet, expectedResult);
   }
+
+  // Titles which begins with the search string should have higher relevance
+  TEST(Suggestion, anchorQueryToBeginning) {
+    std::vector<std::string> titles = {
+                                        "aterm bterm this is a title cterm",
+                                        "this is a title aterm bterm cterm",
+                                        "aterm this is a title bterm cterm"
+                                      };
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    std::vector<std::string> resultSet = getSuggestions(archive, "This is a title", archive.getEntryCount());
+    std::vector<std::string> expectedResult = {
+                                                "aterm bterm this is a title cterm",
+                                                "aterm this is a title bterm cterm",
+                                                "this is a title aterm bterm cterm"
+                                              };
+
+    ASSERT_EQ(expectedResult, resultSet);
+  }
 }


### PR DESCRIPTION
Fixes #510 

The solution employed in this PR is different from what was discussed on the ticket. There are some fundamental issues when we tweak the behavior of Xapian::Query in order to achieve anchoring, these are:
- `OP_PHRASE` search becomes uncontrollably tight. The query then matches **only** those documents that begin at the 0th position of the title and hence, skips a lot of relevant search results that occur in the middle of the title.
- Any query made with operators that use the position of terms matches all the documents in the index. That is, even in case of an empty query, `OP_PHRASE` matches all the documents.

In this PR, we are forcing the documents to have an `ANCHOR_TERM` "0posanchor" at the beginning of titles. This offers much more flexibility and ease of implementation without bothering Xapain code. Now we can have a third subquery `subquery_anchored` with a querystring prefixed by `ANCHOR_TERM` ("0posanchor <querystring>") that matches only those documents that begin with the search string. The other two subquery `subquery_and` and `subquery_phrase` ensures that we do not miss out on other relevant results. The relevance score of each document becomes `A + B + C` (normalised out of 100) where `A`, `B` and `C` are relevance scores of that document for the individual subqueries `subquery_and`, `subquery_phrase` and `subquery_anchored` respectively.

Handling compatibility:
- indexes without `ANCHOR_TERM` 
For such indexes, the third subquery will be absent for all the documents and `C` will be 0, hence their relevance will be decided only by `A` and `B` as happens now.
- indexes with `ANCHOR_TERM` on older libzim
`subquery_phrase` and `subquery_and` does not mind to have an additional term in the title of the document. For `subquery_and` relevance of all the documents will be decreased by a similar small factor because of the decrease in wdf. Hence relative order is preserved. `subquery_phrase` is not disturbed at all because of a term at the beginning.
