### PR TITLE
Create Xapian::WritableDatabase with DB_NO_TERMLIST Flag

### DIFF
--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -82,7 +82,8 @@ XapianIndexer::~XapianIndexer()
 
 void XapianIndexer::indexingPrelude()
 {
-  writableDatabase = Xapian::WritableDatabase(indexPath + ".tmp", Xapian::DB_CREATE_OR_OVERWRITE);
+  writableDatabase = Xapian::WritableDatabase(indexPath + ".tmp", Xapian::DB_CREATE_OR_OVERWRITE | Xapian::DB_NO_TERMLIST);
+
   switch (indexingMode) {
     case IndexingMode::TITLE:
       writableDatabase.set_metadata("valuesmap", "title:0;targetPath:1");


### PR DESCRIPTION
Fixes #417 

We do not use any operation that requires the use of a xapian term list. Removing it makes our indexes a bit leaner. Refer discussion on the linked issue for more info.

Changes included in this PR:
- Use `Xapian::DB_NO_TERMLIST` flag along with `Xapian::DB_CREATE_OR_OVERWRITE` to create xapian database