### PR TITLE
Rethink search API to fix several issues.

### DIFF
--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -35,6 +35,7 @@ namespace zim
 
 class Archive;
 class InternalDataBase;
+class Query;
 class Search;
 class SearchResultSet;
 
@@ -58,7 +59,7 @@ class Searcher
 
     Searcher& add_archive(const Archive& archive);
 
-    Search search(bool suggestionMode);
+    Search search(const Query& query);
 
   private: // methods
     void initDatabase(bool suggestionMode);
@@ -67,6 +68,33 @@ class Searcher
     std::shared_ptr<InternalDataBase> mp_internalDb;
     std::shared_ptr<InternalDataBase> mp_internalSuggestionDb;
     std::vector<Archive> m_archives;
+};
+
+
+/**
+ * A Query represent a query.
+ *
+ * It describe what have to be searched and how.
+ * A Query is "database" independent.
+ */
+class Query
+{
+  public:
+    Query() = default;
+
+
+    Query& setVerbose(bool verbose);
+    Query& setQuery(const std::string& query, bool suggestionMode);
+    Query& setGeorange(float latitude, float longitude, float distance);
+
+    bool m_verbose { false };
+    std::string m_query { "" };
+    bool m_suggestionMode { false };
+
+    bool m_geoquery { false };
+    float m_latitude { 0 };
+    float m_longitude { 0 };
+    float m_distance { 0 } ;
 };
 
 
@@ -86,29 +114,17 @@ class Search
         Search& operator=(Search&& s);
         ~Search();
 
-        Search& setVerbose(bool verbose);
-        Search& setQuery(const std::string& query);
-        Search& setGeorange(float latitude, float longitude, float distance);
-
         const SearchResultSet getResults(int start, int end) const;
         int getEstimatedMatches() const;
 
     private: // methods
-        Search(std::shared_ptr<InternalDataBase> p_internalDb, bool suggestionMode);
+        Search(std::shared_ptr<InternalDataBase> p_internalDb, const Query& query);
         Xapian::Enquire& getEnquire() const;
 
     private: // data
          std::shared_ptr<InternalDataBase> mp_internalDb;
          mutable std::unique_ptr<Xapian::Enquire> mp_enquire;
-
-         bool m_verbose { false };
-         std::string m_query { "" };
-         bool m_suggestionMode { false };
-
-         bool m_geoquery { false };
-         float m_latitude { 0 };
-         float m_longitude { 0 };
-         float m_distance { 0 } ;
+         Query m_query;
 
   friend class Searcher;
 };

--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -61,11 +61,9 @@ class Search
 
     private: // data
          struct InternalData;
-         std::unique_ptr<InternalData> internal;
+         mutable std::shared_ptr<InternalData> internal;
          std::vector<Archive> m_archives;
 
-         mutable std::map<std::string, int> valuesmap;
-         mutable std::string prefixes;
          std::string query;
          float latitude;
          float longitude;
@@ -74,11 +72,7 @@ class Search
          int range_end;
          bool suggestion_mode;
          bool geo_query;
-         mutable bool hasNewSuggestionFormat;
-         mutable std::string language;
-         mutable std::string stopwords;
          mutable bool search_started;
-         mutable bool has_database;
          mutable bool verbose;
          mutable int estimated_matches_number;
 };

--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -56,7 +56,10 @@ class Search
         search_iterator end() const;
         int get_matches_estimated() const;
 
-    private:
+    private: // methods
+        void initDatabase() const;
+
+    private: // data
          struct InternalData;
          std::unique_ptr<InternalData> internal;
          std::vector<Archive> m_archives;
@@ -71,6 +74,9 @@ class Search
          int range_end;
          bool suggestion_mode;
          bool geo_query;
+         mutable bool hasNewSuggestionFormat;
+         mutable std::string language;
+         mutable std::string stopwords;
          mutable bool search_started;
          mutable bool has_database;
          mutable bool verbose;

--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -26,10 +26,10 @@
 
 namespace zim
 {
-class Search;
+class SearchResultSet;
 class search_iterator : public std::iterator<std::bidirectional_iterator_tag, Entry>
 {
-    friend class zim::Search;
+    friend class zim::SearchResultSet;
     public:
         search_iterator();
         search_iterator(const search_iterator& it);
@@ -68,6 +68,6 @@ class search_iterator : public std::iterator<std::bidirectional_iterator_tag, En
         bool is_end() const;
 };
 
-} // namespace ziç
+} // namespace zim
 
 #endif // ZIM_SEARCH_ITERATOR_H

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -257,15 +257,9 @@ Search& Search::set_suggestion_mode(const bool suggestion_mode) {
     return *this;
 }
 
-Search::iterator Search::begin() const {
-    if ( this->search_started ) {
-        return new search_iterator::InternalData(this, internal->results.begin());
-    }
-
+void Search::initDatabase() const {
     bool first = true;
-    bool hasNewSuggestionFormat = false;
-    std::string language;
-    std::string stopwords;
+    hasNewSuggestionFormat = false;
     for(auto& archive: m_archives)
     {
         auto impl = archive.getImpl();
@@ -341,6 +335,14 @@ Search::iterator Search::begin() const {
         internal->database.add_database(database);
         has_database = true;
     }
+}
+
+Search::iterator Search::begin() const {
+    if ( this->search_started ) {
+        return new search_iterator::InternalData(this, internal->results.begin());
+    }
+
+    initDatabase();
 
     if ( ! has_database ) {
         if (verbose) {

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -37,7 +37,7 @@ class InternalDataBase {
     bool hasValue(const std::string& valueName) const;
     int  valueSlot(const std::string&  valueName) const;
 
-    Xapian::QueryParser& getQueryParser();
+    Xapian::Query parseQuery(const Query& query);
 
   public: // data
     // The (main) database we will search on (wrapping other xapian databases).
@@ -52,15 +52,15 @@ class InternalDataBase {
     // The valuesmap associated with the database.
     std::map<std::string, int> m_valuesmap;
 
-    // The prefix stored in the database.
-    std::string m_prefixes;
+    // The prefix to search on.
+    std::string m_prefix;
+
+    // Flags to use to parse the query.
+    unsigned int m_flags;
 
     // If the database is open for suggestion.
     // True even if the dabase has no newSuggestionformat.
     bool m_suggestionMode;
-
-    // If the database is open for suggestion and has new suggestion format (title db).
-    bool m_hasNewSuggestionFormat;
 
     // The query parser corresponding to the database.
     Xapian::QueryParser m_queryParser;

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -93,7 +93,7 @@ struct search_iterator::InternalData {
         iterator = other.iterator;
         _document = other._document;
         document_fetched = other.document_fetched;
-        _entry.reset(new Entry(*other._entry.get()));
+        _entry.reset(other._entry ? new Entry(*other._entry) : nullptr);
       }
       return *this;
     }

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -24,10 +24,6 @@
 
 #include <zim/entry.h>
 
-namespace Xapian {
-  class QueryParser;
-};
-
 namespace zim {
 
 /**
@@ -41,7 +37,7 @@ class InternalDataBase {
     bool hasValue(const std::string& valueName) const;
     int  valueSlot(const std::string&  valueName) const;
 
-    void setupQueryparser(Xapian::QueryParser* queryParse, bool suggestionMode);
+    Xapian::QueryParser& getQueryParser();
 
   public: // data
     // The (main) database we will search on (wrapping other xapian databases).
@@ -66,11 +62,8 @@ class InternalDataBase {
     // If the database is open for suggestion and has new suggestion format (title db).
     bool m_hasNewSuggestionFormat;
 
-    // The language of the database.
-    std::string m_language;
-
-    // The stop words associated to the language of the database.
-    std::string m_stopwords;
+    // The query parser corresponding to the database.
+    Xapian::QueryParser m_queryParser;
 };
 
 struct search_iterator::InternalData {

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -23,6 +23,7 @@
 #include <xapian.h>
 
 #include <zim/entry.h>
+#include <zim/error.h>
 
 namespace zim {
 
@@ -106,9 +107,10 @@ struct search_iterator::InternalData {
 
     Xapian::Document get_document() {
         if ( !document_fetched ) {
-            if (iterator != mp_mset->end()) {
-                _document = iterator.get_document();
+            if (iterator == mp_mset->end()) {
+                throw std::runtime_error("Cannot get entry for end iterator");
             }
+            _document = iterator.get_document();
             document_fetched = true;
         }
         return _document;

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -246,10 +246,7 @@ search_iterator::reference search_iterator::operator*() const {
 }
 
 search_iterator::pointer search_iterator::operator->() const {
-    if (! internal ) {
-        throw std::runtime_error("Cannot get a entry for a uninitialized iterator");
-    }
-    return &internal->get_entry();
+    return &**this;
 }
 
 } // namespace zim

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -239,10 +239,16 @@ int search_iterator::get_fileIndex() const {
 }
 
 search_iterator::reference search_iterator::operator*() const {
+    if (! internal ) {
+        throw std::runtime_error("Cannot get a entry for a uninitialized iterator");
+    }
     return internal->get_entry();
 }
 
 search_iterator::pointer search_iterator::operator->() const {
+    if (! internal ) {
+        throw std::runtime_error("Cannot get a entry for a uninitialized iterator");
+    }
     return &internal->get_entry();
 }
 

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -59,7 +59,7 @@ bool search_iterator::operator==(const search_iterator& it) const {
         return true;
     if ( ! internal || ! it.internal)
         return false;
-    return (internal->search == it.internal->search
+    return (internal->searchData == it.internal->searchData
          && internal->iterator == it.internal->iterator);
 }
 
@@ -105,9 +105,9 @@ std::string search_iterator::get_path() const {
     }
 
     std::string path = internal->get_document().get_data();
-    bool hasNewNamespaceScheme = internal->search->m_archives.at(get_fileIndex()).hasNewNamespaceScheme();
+    bool hasNewNamespaceScheme = internal->searchData->m_internalDb.m_archives.at(get_fileIndex()).hasNewNamespaceScheme();
 
-    std::string dbDataType = internal->search->internal->database.get_metadata("data");
+    std::string dbDataType = internal->searchData->m_internalDb.m_database.get_metadata("data");
     if (dbDataType.empty()) {
         dbDataType = "fullPath";
     }
@@ -132,14 +132,14 @@ std::string search_iterator::get_title() const {
     if ( ! internal ) {
         return "";
     }
-    if ( internal->search->valuesmap.empty() )
+    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(0);
     }
-    else if ( internal->search->valuesmap.find("title") != internal->search->valuesmap.end() )
+    else if ( internal->searchData->m_internalDb.hasValue("title") )
     {
-        return internal->get_document().get_value(internal->search->valuesmap["title"]);
+        return internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("title"));
     }
     return "";
 }
@@ -157,17 +157,17 @@ std::string search_iterator::get_snippet() const {
     }
 
     // Generate title snippet for suggestion_mode
-    if ( internal->search->suggestion_mode )
+    if ( internal->searchData->m_internalDb.m_suggestionMode )
     {
         try {
-            return internal->search->internal->results.snippet(get_title(), 500);
+            return internal->searchData->results.snippet(get_title(), 500);
         } catch(...) {
             return "";
         }
     }
 
     // Generate full text snippet
-    if ( internal->search->valuesmap.empty() )
+    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         std::string stored_snippet = internal->get_document().get_value(1);
@@ -175,9 +175,9 @@ std::string search_iterator::get_snippet() const {
             return stored_snippet;
         /* Let's continue here, and see if we can genenate one */
     }
-    else if ( internal->search->valuesmap.find("snippet") != internal->search->valuesmap.end() )
+    else if ( internal->searchData->m_internalDb.hasValue("snippet") )
     {
-        return internal->get_document().get_value(internal->search->valuesmap["snippet"]);
+        return internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("snippet"));
     }
     /* No reader, no snippet */
     try {
@@ -190,7 +190,7 @@ std::string search_iterator::get_snippet() const {
         try {
           htmlParser.parse_html(content, "UTF-8", true);
         } catch (...) {}
-        return internal->search->internal->results.snippet(htmlParser.dump, 500);
+        return internal->searchData->results.snippet(htmlParser.dump, 500);
     } catch (...) {
       return "";
     }
@@ -200,14 +200,14 @@ int search_iterator::get_size() const {
     if ( ! internal ) {
         return -1;
     }
-    if ( internal->search->valuesmap.empty() )
+    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(2).empty() == true ? -1 : atoi(internal->get_document().get_value(2).c_str());
     }
-    else if ( internal->search->valuesmap.find("size") != internal->search->valuesmap.end() )
+    else if ( internal->searchData->m_internalDb.hasValue("size") )
     {
-        return atoi(internal->get_document().get_value(internal->search->valuesmap["size"]).c_str());
+        return atoi(internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("size")).c_str());
     }
     /* The size is never used. Do we really want to get the content and
        calculate the size ? */
@@ -218,14 +218,14 @@ int search_iterator::get_wordCount() const      {
     if ( ! internal ) {
         return -1;
     }
-    if ( internal->search->valuesmap.empty() )
+    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(3).empty() == true ? -1 : atoi(internal->get_document().get_value(3).c_str());
     }
-    else if ( internal->search->valuesmap.find("wordcount") != internal->search->valuesmap.end() )
+    else if ( internal->searchData->m_internalDb.hasValue("wordcount") )
     {
-        return atoi(internal->get_document().get_value(internal->search->valuesmap["wordcount"]).c_str());
+        return atoi(internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("wordcount")).c_str());
     }
     return -1;
 }

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -105,9 +105,9 @@ std::string search_iterator::get_path() const {
     }
 
     std::string path = internal->get_document().get_data();
-    bool hasNewNamespaceScheme = internal->searchData->m_internalDb.m_archives.at(get_fileIndex()).hasNewNamespaceScheme();
+    bool hasNewNamespaceScheme = internal->mp_internalDb->m_archives.at(get_fileIndex()).hasNewNamespaceScheme();
 
-    std::string dbDataType = internal->searchData->m_internalDb.m_database.get_metadata("data");
+    std::string dbDataType = internal->mp_internalDb->m_database.get_metadata("data");
     if (dbDataType.empty()) {
         dbDataType = "fullPath";
     }
@@ -132,14 +132,14 @@ std::string search_iterator::get_title() const {
     if ( ! internal ) {
         return "";
     }
-    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
+    if ( ! internal->mp_internalDb->hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(0);
     }
-    else if ( internal->searchData->m_internalDb.hasValue("title") )
+    else if ( internal->mp_internalDb->hasValue("title") )
     {
-        return internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("title"));
+        return internal->get_document().get_value(internal->mp_internalDb->valueSlot("title"));
     }
     return "";
 }
@@ -157,7 +157,7 @@ std::string search_iterator::get_snippet() const {
     }
 
     // Generate title snippet for suggestion_mode
-    if ( internal->searchData->m_internalDb.m_suggestionMode )
+    if ( internal->mp_internalDb->m_suggestionMode )
     {
         try {
             return internal->searchData->results.snippet(get_title(), 500);
@@ -167,7 +167,7 @@ std::string search_iterator::get_snippet() const {
     }
 
     // Generate full text snippet
-    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
+    if ( ! internal->mp_internalDb->hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         std::string stored_snippet = internal->get_document().get_value(1);
@@ -175,9 +175,9 @@ std::string search_iterator::get_snippet() const {
             return stored_snippet;
         /* Let's continue here, and see if we can genenate one */
     }
-    else if ( internal->searchData->m_internalDb.hasValue("snippet") )
+    else if ( internal->mp_internalDb->hasValue("snippet") )
     {
-        return internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("snippet"));
+        return internal->get_document().get_value(internal->mp_internalDb->valueSlot("snippet"));
     }
     /* No reader, no snippet */
     try {
@@ -200,14 +200,14 @@ int search_iterator::get_size() const {
     if ( ! internal ) {
         return -1;
     }
-    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
+    if ( ! internal->mp_internalDb->hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(2).empty() == true ? -1 : atoi(internal->get_document().get_value(2).c_str());
     }
-    else if ( internal->searchData->m_internalDb.hasValue("size") )
+    else if ( internal->mp_internalDb->hasValue("size") )
     {
-        return atoi(internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("size")).c_str());
+        return atoi(internal->get_document().get_value(internal->mp_internalDb->valueSlot("size")).c_str());
     }
     /* The size is never used. Do we really want to get the content and
        calculate the size ? */
@@ -218,14 +218,14 @@ int search_iterator::get_wordCount() const      {
     if ( ! internal ) {
         return -1;
     }
-    if ( ! internal->searchData->m_internalDb.hasValuesmap() )
+    if ( ! internal->mp_internalDb->hasValuesmap() )
     {
         /* This is the old legacy version. Guess and try */
         return internal->get_document().get_value(3).empty() == true ? -1 : atoi(internal->get_document().get_value(3).c_str());
     }
-    else if ( internal->searchData->m_internalDb.hasValue("wordcount") )
+    else if ( internal->mp_internalDb->hasValue("wordcount") )
     {
-        return atoi(internal->get_document().get_value(internal->searchData->m_internalDb.valueSlot("wordcount")).c_str());
+        return atoi(internal->get_document().get_value(internal->mp_internalDb->valueSlot("wordcount")).c_str());
     }
     return -1;
 }

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -55,12 +55,13 @@ search_iterator & search_iterator::operator=(const search_iterator& it) {
 }
 
 bool search_iterator::operator==(const search_iterator& it) const {
-    if ( ! internal && ! it.internal)
+    if ( ! internal && ! it.internal) {
         return true;
-    if ( ! internal || ! it.internal)
+    }
+    if ( ! internal || ! it.internal) {
         return false;
-    return (internal->searchData == it.internal->searchData
-         && internal->iterator == it.internal->iterator);
+    }
+    return (*internal == *it.internal);
 }
 
 bool search_iterator::operator!=(const search_iterator& it) const {
@@ -160,7 +161,7 @@ std::string search_iterator::get_snippet() const {
     if ( internal->mp_internalDb->m_suggestionMode )
     {
         try {
-            return internal->searchData->results.snippet(get_title(), 500);
+            return internal->mp_mset->snippet(get_title(), 500);
         } catch(...) {
             return "";
         }
@@ -190,7 +191,7 @@ std::string search_iterator::get_snippet() const {
         try {
           htmlParser.parse_html(content, "UTF-8", true);
         } catch (...) {}
-        return internal->searchData->results.snippet(htmlParser.dump, 500);
+        return internal->mp_mset->snippet(htmlParser.dump, 500);
     } catch (...) {
       return "";
     }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -382,10 +382,10 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
     auto mainItem = mainEntry.getItem(true);
     zim::Searcher searcher1(archive1);
     zim::Searcher searcher2(archive2);
-    auto search1 = searcher1.search(true);
-    auto search2 = searcher2.search(true);
-    search1.setQuery(mainItem.getTitle());
-    search2.setQuery(mainItem.getTitle());
+    zim::Query query;
+    query.setQuery(mainItem.getTitle(), true);
+    auto search1 = searcher1.search(query);
+    auto search2 = searcher2.search(query);
     ASSERT_NE(0, search1.getEstimatedMatches());
     ASSERT_EQ(search1.getEstimatedMatches(), search2.getEstimatedMatches());
 

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -380,10 +380,10 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
   {
     // Resolve any potential redirect.
     auto mainItem = mainEntry.getItem(true);
-    zim::Search search1(archive1);
-    zim::Search search2(archive2);
-    search1.set_suggestion_mode(true);
-    search2.set_suggestion_mode(true);
+    zim::Searcher searcher1(archive1);
+    zim::Searcher searcher2(archive2);
+    auto search1 = searcher1.search(true);
+    auto search2 = searcher2.search(true);
     search1.set_query(mainItem.getTitle());
     search2.set_query(mainItem.getTitle());
     search1.set_range(0, archive1.getEntryCount());

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -384,18 +384,19 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
     zim::Searcher searcher2(archive2);
     auto search1 = searcher1.search(true);
     auto search2 = searcher2.search(true);
-    search1.set_query(mainItem.getTitle());
-    search2.set_query(mainItem.getTitle());
-    search1.set_range(0, archive1.getEntryCount());
-    search2.set_range(0, archive2.getEntryCount());
-    ASSERT_NE(0, search1.get_matches_estimated());
-    ASSERT_EQ(search1.get_matches_estimated(), search2.get_matches_estimated());
-    auto firstSearchItem1 = search1.begin()->getItem(true);
-    auto firstSearchItem2 = search2.begin()->getItem(true);
+    search1.setQuery(mainItem.getTitle());
+    search2.setQuery(mainItem.getTitle());
+    ASSERT_NE(0, search1.getEstimatedMatches());
+    ASSERT_EQ(search1.getEstimatedMatches(), search2.getEstimatedMatches());
+
+    auto result1 = search1.getResults(0, archive1.getEntryCount());
+    auto result2 = search2.getResults(0, archive2.getEntryCount());
+    auto firstSearchItem1 = result1.begin()->getItem(true);
+    auto firstSearchItem2 = result2.begin()->getItem(true);
     ASSERT_EQ(mainItem.getPath(), firstSearchItem1.getPath());
     ASSERT_EQ(mainItem.getPath(), firstSearchItem2.getPath());
-    ASSERT_EQ(std::distance(search1.begin(), search1.end()),
-              std::distance(search2.begin(), search2.end()));
+    ASSERT_EQ(std::distance(result1.begin(), result1.end()),
+              std::distance(result2.begin(), result2.end()));
   }
 #endif
 }

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -38,12 +38,12 @@ using zim::unittests::TestItem;
 std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
   zim::Searcher searcher(archive);
   auto search = searcher.search(false);
-  search.set_query(query);
-  search.set_range(0, range);
-  search.set_verbose(true);
+  search.setQuery(query);
+  search.setVerbose(true);
+  auto result = search.getResults(0, range);
 
   std::vector<std::string> snippets;
-  for (auto entry = search.begin(); entry != search.end(); entry++) {
+  for (auto entry = result.begin(); entry != result.end(); entry++) {
     snippets.push_back(entry.get_snippet());
   }
   return snippets;
@@ -64,10 +64,10 @@ TEST(Search, searchByTitle)
     const auto mainItem = archive.getMainEntry().getItem(true);
     zim::Searcher searcher(archive);
     auto search = searcher.search(true);
-    search.set_query(mainItem.getTitle());
-    search.set_range(0, archive.getEntryCount());
-    ASSERT_NE(0, search.get_matches_estimated());
-    ASSERT_EQ(mainItem.getPath(), search.begin().get_path());
+    search.setQuery(mainItem.getTitle());
+    ASSERT_NE(0, search.getEstimatedMatches());
+    auto result = search.getResults(0, archive.getEntryCount());
+    ASSERT_EQ(mainItem.getPath(), result.begin().get_path());
   }
 }
 #endif
@@ -92,12 +92,12 @@ TEST(Search, indexFullPath)
 
   zim::Searcher searcher(archive);
   auto search = searcher.search(false);
-  search.set_query("test article");
-  search.set_range(0, archive.getEntryCount());
-  search.set_verbose(true);
+  search.setQuery("test article");
 
-  ASSERT_EQ(search.begin().get_path(), "testPath");
-  ASSERT_EQ(search.begin().get_dbData().substr(0, 2), "C/");
+  ASSERT_NE(0, search.getEstimatedMatches());
+  auto result = search.getResults(0, archive.getEntryCount());
+  ASSERT_EQ(result.begin().get_path(), "testPath");
+  ASSERT_EQ(result.begin().get_dbData().substr(0, 2), "C/");
 }
 
 TEST(Search, fulltextSnippet)

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -37,9 +37,9 @@ using zim::unittests::TestItem;
 
 std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
   zim::Searcher searcher(archive);
-  auto search = searcher.search(false);
-  search.setQuery(query);
-  search.setVerbose(true);
+  zim::Query _query;
+  _query.setQuery(query, false);
+  auto search = searcher.search(_query);
   auto result = search.getResults(0, range);
 
   std::vector<std::string> snippets;
@@ -63,8 +63,9 @@ TEST(Search, searchByTitle)
     ASSERT_TRUE(archive.hasTitleIndex());
     const auto mainItem = archive.getMainEntry().getItem(true);
     zim::Searcher searcher(archive);
-    auto search = searcher.search(true);
-    search.setQuery(mainItem.getTitle());
+    zim::Query query;
+    query.setQuery(mainItem.getTitle(), true);
+    auto search = searcher.search(query);
     ASSERT_NE(0, search.getEstimatedMatches());
     auto result = search.getResults(0, archive.getEntryCount());
     ASSERT_EQ(mainItem.getPath(), result.begin().get_path());
@@ -91,8 +92,9 @@ TEST(Search, indexFullPath)
   zim::Archive archive(tza.getPath());
 
   zim::Searcher searcher(archive);
-  auto search = searcher.search(false);
-  search.setQuery("test article");
+  zim::Query query;
+  query.setQuery("test article", false);
+  auto search = searcher.search(query);
 
   ASSERT_NE(0, search.getEstimatedMatches());
   auto result = search.getResults(0, archive.getEntryCount());

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -36,8 +36,8 @@ using zim::unittests::TempZimArchive;
 using zim::unittests::TestItem;
 
 std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
-  zim::Search search(archive);
-  search.set_suggestion_mode(false);
+  zim::Searcher searcher(archive);
+  auto search = searcher.search(false);
   search.set_query(query);
   search.set_range(0, range);
   search.set_verbose(true);
@@ -62,8 +62,8 @@ TEST(Search, searchByTitle)
     const zim::Archive archive(testfile.path);
     ASSERT_TRUE(archive.hasTitleIndex());
     const auto mainItem = archive.getMainEntry().getItem(true);
-    zim::Search search(archive);
-    search.set_suggestion_mode(true);
+    zim::Searcher searcher(archive);
+    auto search = searcher.search(true);
     search.set_query(mainItem.getTitle());
     search.set_range(0, archive.getEntryCount());
     ASSERT_NE(0, search.get_matches_estimated());
@@ -90,8 +90,8 @@ TEST(Search, indexFullPath)
 
   zim::Archive archive(tza.getPath());
 
-  zim::Search search(archive);
-  search.set_suggestion_mode(false);
+  zim::Searcher searcher(archive);
+  auto search = searcher.search(false);
   search.set_query("test article");
   search.set_range(0, archive.getEntryCount());
   search.set_verbose(true);

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -69,6 +69,31 @@ TEST(search_iterator, end) {
   ASSERT_THROW(it.operator->(), std::runtime_error);
 }
 
+TEST(search_iterator, copy) {
+  TempZimArchive tza("testZim");
+
+  zim::Archive archive = tza.createZimFromTitles({
+    "item a",
+  });
+
+  zim::Searcher searcher(archive);
+  zim::Query query;
+  query.setQuery("item", true);
+  auto search = searcher.search(query);
+  auto result = search.getResults(0, archive.getEntryCount());
+
+  auto it = result.begin();
+
+  auto it2 = it;
+  ASSERT_EQ(it.get_title(), it2.get_title());
+
+  it = result.end();
+  it2 = it;
+  ASSERT_EQ(it, it2);
+  ASSERT_THROW(it.get_title(), std::runtime_error);
+  ASSERT_THROW(it2.get_title(), std::runtime_error);
+}
+
 TEST(search_iterator, functions) {
   TempZimArchive tza("testZim");
 

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -37,9 +37,9 @@ TEST(search_iterator, functions) {
   });
 
   zim::Searcher searcher(archive);
-  auto search = searcher.search(true);
-  search.setQuery("item");
-  search.setVerbose(true);
+  zim::Query query;
+  query.setQuery("item", true);
+  auto search = searcher.search(query);
   auto result = search.getResults(0, archive.getEntryCount());
 
   auto it = result.begin();
@@ -62,9 +62,9 @@ TEST(search_iterator, iteration) {
   });
 
   zim::Searcher searcher(archive);
-  auto search = searcher.search(true);
-  search.setQuery("item");
-  search.setVerbose(true);
+  zim::Query query;
+  query.setQuery("item", true);
+  auto search = searcher.search(query);
   auto result = search.getResults(0, archive.getEntryCount());
 
   auto it = result.begin();

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -43,6 +43,32 @@ TEST(search_iterator, uninitialized) {
   ASSERT_THROW(it.operator->(), std::runtime_error);
 }
 
+TEST(search_iterator, end) {
+  TempZimArchive tza("testZim");
+
+  zim::Archive archive = tza.createZimFromTitles({
+    "item a",
+  });
+
+  zim::Searcher searcher(archive);
+  zim::Query query;
+  query.setQuery("item", true);
+  auto search = searcher.search(query);
+  auto result = search.getResults(0, archive.getEntryCount());
+
+  auto it = result.end();
+
+  ASSERT_THROW(it.get_title(), std::runtime_error);
+  ASSERT_THROW(it.get_path(), std::runtime_error);
+  ASSERT_EQ(it.get_snippet(), "");
+//  ASSERT_EQ(it.get_score(), 0); Unspecified, may be 0 or 1. To fix.
+  ASSERT_EQ(it.get_fileIndex(), 0);
+  ASSERT_EQ(it.get_wordCount(), -1);
+  ASSERT_EQ(it.get_size(), -1);
+  ASSERT_THROW(*it, std::runtime_error);
+  ASSERT_THROW(it.operator->(), std::runtime_error);
+}
+
 TEST(search_iterator, functions) {
   TempZimArchive tza("testZim");
 

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -21,6 +21,7 @@
 #include <zim/archive.h>
 #include <zim/search.h>
 #include <zim/search_iterator.h>
+#include <zim/error.h>
 #include "tools.h"
 
 #include "gtest/gtest.h"
@@ -28,6 +29,19 @@
 namespace {
 
 using zim::unittests::TempZimArchive;
+
+TEST(search_iterator, uninitialized) {
+  zim::SearchResultSet::iterator it;
+  ASSERT_EQ(it.get_title(), "");
+  ASSERT_EQ(it.get_path(), "");
+  ASSERT_EQ(it.get_snippet(), "");
+  ASSERT_EQ(it.get_score(), 0);
+  ASSERT_EQ(it.get_fileIndex(), 0);
+  ASSERT_EQ(it.get_wordCount(), -1);
+  ASSERT_EQ(it.get_size(), -1);
+  ASSERT_THROW(*it, std::runtime_error);
+  ASSERT_THROW(it.operator->(), std::runtime_error);
+}
 
 TEST(search_iterator, functions) {
   TempZimArchive tza("testZim");

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -36,8 +36,8 @@ TEST(search_iterator, functions) {
     "item a",
   });
 
-  zim::Search search(archive);
-  search.set_suggestion_mode(true);
+  zim::Searcher searcher(archive);
+  auto search = searcher.search(true);
   search.set_query("item");
   search.set_range(0, archive.getEntryCount());
   search.set_verbose(true);
@@ -61,8 +61,8 @@ TEST(search_iterator, iteration) {
     "item b"
   });
 
-  zim::Search search(archive);
-  search.set_suggestion_mode(true);
+  zim::Searcher searcher(archive);
+  auto search = searcher.search(true);
   search.set_query("item");
   search.set_range(0, archive.getEntryCount());
   search.set_verbose(true);

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -38,11 +38,11 @@ TEST(search_iterator, functions) {
 
   zim::Searcher searcher(archive);
   auto search = searcher.search(true);
-  search.set_query("item");
-  search.set_range(0, archive.getEntryCount());
-  search.set_verbose(true);
+  search.setQuery("item");
+  search.setVerbose(true);
+  auto result = search.getResults(0, archive.getEntryCount());
 
-  auto it = search.begin();
+  auto it = result.begin();
 
   // Test functions
   ASSERT_EQ(it.get_title(), "item a");
@@ -63,24 +63,24 @@ TEST(search_iterator, iteration) {
 
   zim::Searcher searcher(archive);
   auto search = searcher.search(true);
-  search.set_query("item");
-  search.set_range(0, archive.getEntryCount());
-  search.set_verbose(true);
+  search.setQuery("item");
+  search.setVerbose(true);
+  auto result = search.getResults(0, archive.getEntryCount());
 
-  auto it = search.begin();
-  ASSERT_EQ(it.get_title(), search.begin().get_title());
+  auto it = result.begin();
+  ASSERT_EQ(it.get_title(), result.begin().get_title());
 
   ASSERT_EQ(it.get_title(), "item a");
   it++;
   ASSERT_EQ(it.get_title(), "item b");
-  ASSERT_TRUE(it != search.begin());
+  ASSERT_TRUE(it != result.begin());
 
   it--;
   ASSERT_EQ(it.get_title(), "item a");
-  ASSERT_TRUE(search.begin() == it);
+  ASSERT_TRUE(result.begin() == it);
 
   it++; it++;
-  ASSERT_TRUE(it == search.end());
+  ASSERT_TRUE(it == result.end());
 }
 
 } // anonymous namespace

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -33,9 +33,9 @@ namespace {
 
   std::vector<std::string> getSuggestions(const zim::Archive archive, std::string query, int range) {
     zim::Searcher searcher(archive);
-    auto search = searcher.search(true);
-    search.setQuery(query);
-    search.setVerbose(true);
+    zim::Query _query;
+    _query.setQuery(query, true).setVerbose(true);
+    auto search = searcher.search(_query);
 
     auto searchResult = search.getResults(0, range);
 
@@ -50,9 +50,9 @@ namespace {
 
   std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
     zim::Searcher searcher(archive);
-    auto search = searcher.search(true);
-    search.setQuery(query);
-    search.setVerbose(true);
+    zim::Query _query;
+    _query.setQuery(query, true);
+    auto search = searcher.search(_query);
     auto result = search.getResults(0, range);
 
     std::vector<std::string> snippets;
@@ -445,10 +445,9 @@ namespace {
     zim::Archive archive(tza.getPath());
 
     zim::Searcher searcher(archive);
-    auto search = searcher.search(true);
-    search.setQuery("Test Article");
-    search.setVerbose(true);
-
+    zim::Query query;
+    query.setQuery("Test Article", true);
+    auto search = searcher.search(query);
     auto result = search.getResults(0, archive.getEntryCount());
 
     ASSERT_EQ(result.begin().get_path(), "testPath");

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -32,8 +32,8 @@ namespace {
   using zim::unittests::TestItem;
 
   std::vector<std::string> getSuggestions(const zim::Archive archive, std::string query, int range) {
-    zim::Search search(archive);
-    search.set_suggestion_mode(true);
+    zim::Searcher searcher(archive);
+    auto search = searcher.search(true);
     search.set_query(query);
     search.set_range(0, range);
     search.set_verbose(true);
@@ -48,8 +48,8 @@ namespace {
   }
 
   std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
-    zim::Search search(archive);
-    search.set_suggestion_mode(true);
+    zim::Searcher searcher(archive);
+    auto search = searcher.search(true);
     search.set_query(query);
     search.set_range(0, range);
     search.set_verbose(true);
@@ -443,8 +443,8 @@ namespace {
 
     zim::Archive archive(tza.getPath());
 
-    zim::Search search(archive);
-    search.set_suggestion_mode(true);
+    zim::Searcher searcher(archive);
+    auto search = searcher.search(true);
     search.set_query("Test Article");
     search.set_range(0, archive.getEntryCount());
     search.set_verbose(true);

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -34,12 +34,13 @@ namespace {
   std::vector<std::string> getSuggestions(const zim::Archive archive, std::string query, int range) {
     zim::Searcher searcher(archive);
     auto search = searcher.search(true);
-    search.set_query(query);
-    search.set_range(0, range);
-    search.set_verbose(true);
+    search.setQuery(query);
+    search.setVerbose(true);
+
+    auto searchResult = search.getResults(0, range);
 
     std::vector<std::string> result;
-    for (auto entry = search.begin();entry!=search.end();entry++) {
+    for (auto entry = searchResult.begin();entry!=searchResult.end();entry++) {
       std::cout<<(*entry).getTitle()<<entry.get_score()<<std::endl;
       result.push_back((*entry).getTitle());
     }
@@ -50,12 +51,12 @@ namespace {
   std::vector<std::string> getSnippet(const zim::Archive archive, std::string query, int range) {
     zim::Searcher searcher(archive);
     auto search = searcher.search(true);
-    search.set_query(query);
-    search.set_range(0, range);
-    search.set_verbose(true);
+    search.setQuery(query);
+    search.setVerbose(true);
+    auto result = search.getResults(0, range);
 
     std::vector<std::string> snippets;
-    for (auto entry = search.begin(); entry != search.end(); entry++) {
+    for (auto entry = result.begin(); entry != result.end(); entry++) {
       snippets.push_back(entry.get_snippet());
     }
     return snippets;
@@ -445,12 +446,13 @@ namespace {
 
     zim::Searcher searcher(archive);
     auto search = searcher.search(true);
-    search.set_query("Test Article");
-    search.set_range(0, archive.getEntryCount());
-    search.set_verbose(true);
+    search.setQuery("Test Article");
+    search.setVerbose(true);
 
-    ASSERT_EQ(search.begin().get_path(), "testPath");
-    ASSERT_EQ(search.begin().get_dbData().substr(0, 2), "C/");
+    auto result = search.getResults(0, archive.getEntryCount());
+
+    ASSERT_EQ(result.begin().get_path(), "testPath");
+    ASSERT_EQ(result.begin().get_dbData().substr(0, 2), "C/");
   }
 
   TEST(Suggestion, nonWordCharacters) {


### PR DESCRIPTION
Fix #463, #516, #471.
Related to https://github.com/kiwix/kiwix-tools/issues/97

First commits roughly change the API to have a correct public API (but somehow wrong internal structures).
Later commits fix the internal structures to have something correct.

The main idea is to have :
- A `Searcher`, wrapping a xapian database.
- A `Search`, wrapping a particular query on the xapian database.
- A `SearchResult`, a set of result (range) corresponding to the `Search`.

We keep the iterator, but now we iterate over the `SearchResult`
We also introduce a `Query` object, describing a query (from user point of view), not associated to any database.