### PR TITLE
Non-word symbol friendly suggestions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -137,7 +137,8 @@ Xapian::Query parse_query(Xapian::QueryParser* query_parser, std::string qs, int
 
     if (suggestion_mode && !query.empty()) {
       Xapian::Query subquery_phrase, subquery_anchored;
-      query_parser->set_default_op(Xapian::Query::op::OP_PHRASE);
+      query_parser->set_default_op(Xapian::Query::op::OP_OR);
+      query_parser->set_stemming_strategy(Xapian::QueryParser::STEM_NONE);
 
       subquery_phrase = query_parser->parse_query(qs);
       subquery_phrase = Xapian::Query(Xapian::Query::OP_PHRASE, subquery_phrase.get_terms_begin(), subquery_phrase.get_terms_end(), subquery_phrase.get_length());

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -87,6 +87,12 @@ namespace {
     return result;
   }
 
+#define EXPECT_SUGGESTION_RESULTS(archive, query, ...)          \
+  ASSERT_EQ(                                                    \
+      getSuggestions(archive, query, archive.getEntryCount()),  \
+      std::vector<std::string>({__VA_ARGS__})                   \
+  )
+
   TEST(Suggestion, emptyQuery) {
     std::vector<std::string> titles = {
                                         "fooland",
@@ -465,5 +471,28 @@ namespace {
 
     ASSERT_EQ(search.begin().get_path(), "testPath");
     ASSERT_EQ(search.begin().get_dbData().substr(0, 2), "C/");
+  }
+
+  TEST(Suggestion, nonWordCharacters) {
+    TempZimArchive tza("testZim");
+    {
+      const zim::Archive archive = tza.createZimFromTitles({
+        "Alice Bob",
+        "Bonnie + Clyde",
+        "Jack & Jill, on the hill"
+      });
+
+      EXPECT_SUGGESTION_RESULTS(archive, "Alice & Bob",
+        "Alice Bob"
+      );
+
+      EXPECT_SUGGESTION_RESULTS(archive, "Bonnie + Clyde",
+        "Bonnie + Clyde"
+      );
+
+      EXPECT_SUGGESTION_RESULTS(archive, "Jack & Jill",
+        "Jack & Jill, on the hill"
+      );
+    }
   }
 }


### PR DESCRIPTION
Fixes #537

> @maneeshpm This PR demonstrates a issue discovered during the work on kiwix/kiwix-lib#488 (for more details see commit https://github.com/kiwix/kiwix-lib/pull/488/commits/e5399be066c05b3f065d7d4542c48a0d4fa721e2). The workaround utilized in the said PR doesn't work for libzim out-of-the-box because it breaks some unit tests.
> 
> Would you mind taking over this PR and completing it?

Fixes #536 

The issue is Xapian queryparser does not work with `OP_PHRASE`/`OP_NEAR` as the default operator on certain kinds of queries. To fix this, we can change the default operator to `OP_OR` and bind the terms in a subquery that is created using query constructor with `OP_PHRASE` to handle the phrasing.

The changes included in this PR are:
- Add a unittest `nonWordCharacters` to suggestions.
- Switch default operator to `OP_OR` 