### PR TITLE
Add zim files in the "new" format as testing data.

### DIFF
--- a/scripts/download_test_data.py
+++ b/scripts/download_test_data.py
@@ -26,7 +26,7 @@ from urllib.error import *
 import tarfile
 import sys
 
-TEST_DATA_VERSION = "0.1"
+TEST_DATA_VERSION = "0.2"
 ARCHIVE_URL_TEMPL = "https://github.com/openzim/zim-testing-suite/releases/download/v{version}/zim-testing-suite-{version}.tar.gz"
 
 if __name__ == "__main__":

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -239,7 +239,14 @@ namespace zim
 
   Archive::EntryRange<EntryOrder::titleOrder> Archive::iterByTitle() const
   {
-    return EntryRange<EntryOrder::titleOrder>(m_impl, m_impl->getStartUserEntry().v, m_impl->getEndUserEntry().v);
+    if (m_impl->hasFrontArticlesIndex()) {
+      // We have a front articles index. We can "simply" loop over all front entries.
+      return EntryRange<EntryOrder::titleOrder>(m_impl, 0, m_impl->getFrontEntryCount().v);
+    } else  {
+      // We don't have an index listing only front entry. We have to loop over user entry.
+      // (`C` namespace in new zim scheme, all namespace in old ones)
+      return EntryRange<EntryOrder::titleOrder>(m_impl, m_impl->getStartUserEntry().v, m_impl->getEndUserEntry().v);
+    }
   }
 
   Archive::EntryRange<EntryOrder::efficientOrder> Archive::iterEfficient() const

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -108,6 +108,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       direntReader(new DirentReader(zimReader)),
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
       m_newNamespaceScheme(false),
+      m_hasFrontArticlesIndex(true),
       m_startUserEntry(0),
       m_endUserEntry(0)
   {
@@ -150,6 +151,7 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
       offset_t titleOffset(header.getTitleIdxPos());
       zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
       mp_titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Title index table");
+      const_cast<bool&>(m_hasFrontArticlesIndex) = false;
     }
 
     readMimeTypes();

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -59,6 +59,7 @@ namespace zim
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
       const bool m_newNamespaceScheme;
+      const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;
       const entry_index_t m_endUserEntry;
 
@@ -89,6 +90,7 @@ namespace zim
       const Fileheader& getFileheader() const  { return header; }
       zsize_t getFilesize() const;
       bool hasNewNamespaceScheme() const { return m_newNamespaceScheme; }
+      bool hasFrontArticlesIndex() const { return m_hasFrontArticlesIndex; }
 
       FileCompound::PartRange getFileParts(offset_t offset, zsize_t size);
       std::shared_ptr<const Dirent> getDirent(entry_index_t idx);

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -360,18 +360,22 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
 #if defined(ENABLE_XAPIAN)
   if ( archive1.hasTitleIndex() )
   {
+    // Resolve any potential redirect.
+    auto mainItem = mainEntry.getItem(true);
     zim::Search search1(archive1);
     zim::Search search2(archive2);
     search1.set_suggestion_mode(true);
     search2.set_suggestion_mode(true);
-    search1.set_query(mainEntry.getTitle());
-    search2.set_query(mainEntry.getTitle());
+    search1.set_query(mainItem.getTitle());
+    search2.set_query(mainItem.getTitle());
     search1.set_range(0, archive1.getEntryCount());
     search2.set_range(0, archive2.getEntryCount());
     ASSERT_NE(0, search1.get_matches_estimated());
     ASSERT_EQ(search1.get_matches_estimated(), search2.get_matches_estimated());
-    ASSERT_EQ(mainEntry.getPath(), search1.begin().get_path());
-    ASSERT_EQ(mainEntry.getPath(), search2.begin().get_path());
+    auto firstSearchItem1 = search1.begin()->getItem(true);
+    auto firstSearchItem2 = search2.begin()->getItem(true);
+    ASSERT_EQ(mainItem.getPath(), firstSearchItem1.getPath());
+    ASSERT_EQ(mainItem.getPath(), firstSearchItem2.getPath());
     ASSERT_EQ(std::distance(search1.begin(), search1.end()),
               std::distance(search2.begin(), search2.end()));
   }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -33,6 +33,7 @@ namespace
 {
 
 using zim::unittests::makeTempFile;
+using zim::unittests::getDataFilePath;
 
 using TestContextImpl = std::vector<std::pair<std::string, std::string> >;
 struct TestContext : TestContextImpl {
@@ -145,7 +146,7 @@ TEST(ZimArchive, openRealZimArchive)
   };
 
   for ( const std::string fname : zimfiles ) {
-    const std::string path = zim::DEFAULTFS::join("data", fname);
+    const std::string path = getDataFilePath(fname);
     const TestContext ctx{ {"path", path } };
     std::unique_ptr<zim::Archive> archive;
     EXPECT_NO_THROW( archive.reset(new zim::Archive(path)) ) << ctx;
@@ -164,7 +165,7 @@ TEST(ZimArchive, randomEntry)
   };
 
   for ( const std::string fname : zimfiles ) {
-    const auto path = zim::DEFAULTFS::join("data", fname);
+    const auto path = getDataFilePath(fname);
     const TestContext ctx{ {"path", path } };
     const zim::Archive archive(path);
     try {
@@ -207,7 +208,7 @@ public:
     checksToRun.set();                                            \
     checksToRun.reset(size_t(zim::IntegrityCheck::CHECKSUM));     \
     CapturedStderr stderror;                                      \
-    EXPECT_FALSE(zim::validate(zimpath, checksToRun));            \
+    EXPECT_FALSE(zim::validate(getDataFilePath(zimpath), checksToRun));            \
     EXPECT_EQ(expected_stderror_text, std::string(stderror));     \
   }
 
@@ -217,82 +218,82 @@ TEST(ZimArchive, validate)
   zim::IntegrityCheckList all;
   all.set();
 
-  ASSERT_TRUE(zim::validate("./data/small.zim", all));
+  ASSERT_TRUE(zim::validate(getDataFilePath("small.zim"), all));
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.smaller_than_header.zim",
+    "invalid.smaller_than_header.zim",
     "zim-file is too small to contain a header\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_urlptrpos.zim",
+    "invalid.outofbounds_urlptrpos.zim",
     "Dirent pointer table outside (or not fully inside) ZIM file.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_titleptrpos.zim",
+    "invalid.outofbounds_titleptrpos.zim",
     "Title index table outside (or not fully inside) ZIM file.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_clusterptrpos.zim",
+    "invalid.outofbounds_clusterptrpos.zim",
     "Cluster pointer table outside (or not fully inside) ZIM file.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.invalid_mimelistpos.zim",
+    "invalid.invalid_mimelistpos.zim",
     "mimelistPos must be 80.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.invalid_checksumpos.zim",
+    "invalid.invalid_checksumpos.zim",
     "Checksum position is not valid\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_first_direntptr.zim",
+    "invalid.outofbounds_first_direntptr.zim",
     "Invalid dirent pointer\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_last_direntptr.zim",
+    "invalid.outofbounds_last_direntptr.zim",
     "Invalid dirent pointer\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_first_title_entry.zim",
+    "invalid.outofbounds_first_title_entry.zim",
     "Invalid title index entry.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_last_title_entry.zim",
+    "invalid.outofbounds_last_title_entry.zim",
     "Invalid title index entry.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.outofbounds_first_clusterptr.zim",
+    "invalid.outofbounds_first_clusterptr.zim",
     "Invalid cluster pointer\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.nonsorted_dirent_table.zim",
+    "invalid.nonsorted_dirent_table.zim",
     "Dirent table is not properly sorted:\n"
     "  #0: A/main.html\n"
     "  #1: -/favicon\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.nonsorted_title_index.zim",
+    "invalid.nonsorted_title_index.zim",
     "Title index is not properly sorted.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.bad_mimetype_list.zim",
+    "invalid.bad_mimetype_list.zim",
     "Error getting mimelists.\n"
   );
 
   EXPECT_BROKEN_ZIMFILE(
-    "./data/invalid.bad_mimetype_in_dirent.zim",
+    "invalid.bad_mimetype_in_dirent.zim",
     "Entry M/Language has invalid MIME-type value 1234.\n"
   );
 }
@@ -374,8 +375,8 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
 #if WITH_TEST_DATA
 TEST(ZimArchive, multipart)
 {
-  const zim::Archive archive1("./data/wikibooks_be_all_nopic_2017-02.zim");
-  const zim::Archive archive2("./data/wikibooks_be_all_nopic_2017-02_splitted.zim");
+  const zim::Archive archive1(getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+  const zim::Archive archive2(getDataFilePath("wikibooks_be_all_nopic_2017-02_splitted.zim"));
   ASSERT_FALSE(archive1.is_multiPart());
   ASSERT_TRUE (archive2.is_multiPart());
 
@@ -389,16 +390,16 @@ TEST(ZimArchive, multipart)
 #include <io.h>
 #undef min
 #undef max
-# define OPEN_READ_ONLY(path) _open(path, _O_RDONLY)
+# define OPEN_READ_ONLY(path) _open(path.c_str(), _O_RDONLY)
 #else
-# define OPEN_READ_ONLY(path) open(path, O_RDONLY)
+# define OPEN_READ_ONLY(path) open(path.c_str(), O_RDONLY)
 #endif
 
 #ifndef _WIN32
 TEST(ZimArchive, openByFD)
 {
-  const zim::Archive archive1("./data/small.zim");
-  const int fd = OPEN_READ_ONLY("./data/small.zim");
+  const zim::Archive archive1(getDataFilePath("small.zim"));
+  const int fd = OPEN_READ_ONLY(getDataFilePath("small.zim"));
   const zim::Archive archive2(fd);
 
   checkEquivalence(archive1, archive2);
@@ -406,8 +407,8 @@ TEST(ZimArchive, openByFD)
 
 TEST(ZimArchive, openZIMFileEmbeddedInAnotherFile)
 {
-  const zim::Archive archive1("./data/small.zim");
-  const int fd = OPEN_READ_ONLY("./data/small.zim.embedded");
+  const zim::Archive archive1(getDataFilePath("small.zim"));
+  const int fd = OPEN_READ_ONLY(getDataFilePath("small.zim.embedded"));
   const zim::Archive archive2(fd, 8, archive1.getFilesize());
 
   checkEquivalence(archive1, archive2);
@@ -426,7 +427,7 @@ zim::Blob readItemData(const zim::Item::DirectAccessInfo& dai, zim::size_type si
 #if WITH_TEST_DATA
 TEST(ZimArchive, getDirectAccessInformation)
 {
-  const zim::Archive archive("./data/small.zim");
+  const zim::Archive archive(getDataFilePath("small.zim"));
   zim::entry_index_type checkedItemCount = 0;
   for ( auto entry : archive.iterEfficient() ) {
     if (!entry.isRedirect()) {
@@ -445,7 +446,7 @@ TEST(ZimArchive, getDirectAccessInformation)
 #ifndef _WIN32
 TEST(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
 {
-  const int fd = OPEN_READ_ONLY("./data/small.zim");
+  const int fd = OPEN_READ_ONLY(getDataFilePath("small.zim"));
   const zim::Archive archive(fd);
   zim::entry_index_type checkedItemCount = 0;
   for ( auto entry : archive.iterEfficient() ) {
@@ -464,8 +465,8 @@ TEST(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
 
 TEST(ZimArchive, getDirectAccessInformationFromEmbeddedArchive)
 {
-  const int fd = OPEN_READ_ONLY("./data/small.zim.embedded");
-  const auto size = zim::DEFAULTFS::openFile("./data/small.zim").getSize();
+  const int fd = OPEN_READ_ONLY(getDataFilePath("small.zim.embedded"));
+  const auto size = zim::DEFAULTFS::openFile(getDataFilePath("small.zim")).getSize();
   const zim::Archive archive(fd, 8, size.v);
   zim::entry_index_type checkedItemCount = 0;
   for ( auto entry : archive.iterEfficient() ) {

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -93,19 +93,6 @@ TEST(FindTests, ByTitle)
     }
 }
 
-#if 0
-// By Path (compatibility)
-TEST(FindTests, ByPathNoNS)
-{
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
-
-    auto it1 = archive.findByPath("j/body.js");
-    auto it2 = archive.findByPath("m/115a35549794e50dcd03e60ef1a1ae24.png");
-    ASSERT_EQ(it1->getIndex(), 1);
-    ASSERT_EQ(it2->getIndex(), 76);
-}
-#endif
-
 // By Path
 TEST(FindTests, ByPath)
 {

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -36,8 +36,8 @@ using zim::unittests::getDataFilePath;
 #if WITH_TEST_DATA
 TEST(FindTests, NotFoundByTitle)
 {
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto range0 = archive.findByTitle("unkownTitle");
         auto range1 = archive.findByTitle("j/body.js");
@@ -49,8 +49,8 @@ TEST(FindTests, NotFoundByTitle)
 // By Path
 TEST(FindTests, NotFoundByPath)
 {
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto range0 = archive.findByPath("unkwonUrl");
         auto range1 = archive.findByPath("U/unkwonUrl");
@@ -70,8 +70,8 @@ TEST(FindTests, NotFoundByPath)
 // ByTitle
 TEST(FindTests, ByTitle)
 {
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto range0 = archive.findByTitle("Main Page");
         ASSERT_EQ(range0.begin()->getIndex(), 5);
@@ -114,8 +114,8 @@ TEST(FindTests, ByPathNoNS)
 // By Path
 TEST(FindTests, ByPath)
 {
-  for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-    zim::Archive archive (path);
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    zim::Archive archive (testfile.path);
 
     auto range0 = archive.findByPath("A/Main_Page.html");
     auto range1 = archive.findByPath("I/s/");

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -74,9 +74,6 @@ TEST(FindTests, ByTitle)
         zim::Archive archive (testfile.path);
 
         auto range0 = archive.findByTitle("Main Page");
-        ASSERT_EQ(range0.begin()->getIndex(), 5);
-        ASSERT_EQ(range0.end()->getIndex(), 7); // getIndex of an entry is always the path order.
-                                                // It happens that the 6th in title order is the 7th in path order.
 
         auto count = 0;
         for(auto& entry: range0) {
@@ -86,8 +83,6 @@ TEST(FindTests, ByTitle)
         ASSERT_EQ(count, 1);
 
         auto range1 = archive.findByTitle("Украінская");
-        ASSERT_EQ(range1.begin()->getIndex(), 53);
-        ASSERT_EQ(range1.end()->getIndex(), 58);
 
         count = 0;
         for(auto& entry: range1) {

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -36,29 +36,33 @@ using zim::unittests::getDataFilePath;
 #if WITH_TEST_DATA
 TEST(FindTests, NotFoundByTitle)
 {
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    auto range0 = archive.findByTitle("unkownTitle");
-    auto range1 = archive.findByTitle("j/body.js");
-    ASSERT_EQ(range0.begin(), range0.end());
-    ASSERT_EQ(range1.begin(), range1.end());
+        auto range0 = archive.findByTitle("unkownTitle");
+        auto range1 = archive.findByTitle("j/body.js");
+        ASSERT_EQ(range0.begin(), range0.end());
+        ASSERT_EQ(range1.begin(), range1.end());
+    }
 }
 
 // By Path
 TEST(FindTests, NotFoundByPath)
 {
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    auto range0 = archive.findByPath("unkwonUrl");
-    auto range1 = archive.findByPath("U/unkwonUrl");
-    auto range2 = archive.findByPath("A/unkwonUrl");
-    auto range3 = archive.findByPath("X");
-    auto range4 = archive.findByPath("X/");
-    ASSERT_EQ(range0.begin(), range0.end());
-    ASSERT_EQ(range1.begin(), range1.end());
-    ASSERT_EQ(range2.begin(), range2.end());
-    ASSERT_EQ(range3.begin(), range3.end());
-    ASSERT_EQ(range4.begin(), range4.end());
+        auto range0 = archive.findByPath("unkwonUrl");
+        auto range1 = archive.findByPath("U/unkwonUrl");
+        auto range2 = archive.findByPath("A/unkwonUrl");
+        auto range3 = archive.findByPath("X");
+        auto range4 = archive.findByPath("X/");
+        ASSERT_EQ(range0.begin(), range0.end());
+        ASSERT_EQ(range1.begin(), range1.end());
+        ASSERT_EQ(range2.begin(), range2.end());
+        ASSERT_EQ(range3.begin(), range3.end());
+        ASSERT_EQ(range4.begin(), range4.end());
+    }
 }
 
 // Found cases
@@ -66,30 +70,32 @@ TEST(FindTests, NotFoundByPath)
 // ByTitle
 TEST(FindTests, ByTitle)
 {
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    auto range0 = archive.findByTitle("Main Page");
-    ASSERT_EQ(range0.begin()->getIndex(), 5);
-    ASSERT_EQ(range0.end()->getIndex(), 7); // getIndex of an entry is always the path order.
-                                            // It happens that the 6th in title order is the 7th in path order.
+        auto range0 = archive.findByTitle("Main Page");
+        ASSERT_EQ(range0.begin()->getIndex(), 5);
+        ASSERT_EQ(range0.end()->getIndex(), 7); // getIndex of an entry is always the path order.
+                                                // It happens that the 6th in title order is the 7th in path order.
 
-    auto count = 0;
-    for(auto& entry: range0) {
-      count++;
-      ASSERT_EQ(entry.getTitle().find("Main Page"), 0);
+        auto count = 0;
+        for(auto& entry: range0) {
+          count++;
+          ASSERT_EQ(entry.getTitle().find("Main Page"), 0);
+        }
+        ASSERT_EQ(count, 1);
+
+        auto range1 = archive.findByTitle("Украінская");
+        ASSERT_EQ(range1.begin()->getIndex(), 53);
+        ASSERT_EQ(range1.end()->getIndex(), 58);
+
+        count = 0;
+        for(auto& entry: range1) {
+          count++;
+          ASSERT_EQ(entry.getTitle().find("Украінская"), 0);
+        }
+        ASSERT_EQ(count, 5);
     }
-    ASSERT_EQ(count, 1);
-
-    auto range1 = archive.findByTitle("Украінская");
-    ASSERT_EQ(range1.begin()->getIndex(), 53);
-    ASSERT_EQ(range1.end()->getIndex(), 58);
-
-    count = 0;
-    for(auto& entry: range1) {
-      count++;
-      ASSERT_EQ(entry.getTitle().find("Украінская"), 0);
-    }
-    ASSERT_EQ(count, 5);
 }
 
 #if 0
@@ -108,7 +114,8 @@ TEST(FindTests, ByPathNoNS)
 // By Path
 TEST(FindTests, ByPath)
 {
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+  for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    zim::Archive archive (path);
 
     auto range0 = archive.findByPath("A/Main_Page.html");
     auto range1 = archive.findByPath("I/s/");
@@ -174,6 +181,7 @@ TEST(FindTests, ByPath)
       count++;
     }
     ASSERT_EQ(count, 118);
+  }
 }
 #endif
 

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -73,12 +73,12 @@ TEST(FindTests, ByTitle)
     for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
         zim::Archive archive (testfile.path);
 
-        auto range0 = archive.findByTitle("Main Page");
+        auto range0 = archive.findByTitle("Першая старонка");
 
         auto count = 0;
         for(auto& entry: range0) {
           count++;
-          ASSERT_EQ(entry.getTitle().find("Main Page"), 0);
+          ASSERT_EQ(entry.getTitle().find("Першая старонка"), 0);
         }
         ASSERT_EQ(count, 1);
 

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -109,7 +109,7 @@ TEST(FindTests, ByPathNoNS)
 // By Path
 TEST(FindTests, ByPath)
 {
-  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
     zim::Archive archive (testfile.path);
 
     auto range0 = archive.findByPath("A/Main_Page.html");
@@ -176,6 +176,48 @@ TEST(FindTests, ByPath)
       count++;
     }
     ASSERT_EQ(count, 118);
+  }
+}
+
+// By Path
+TEST(FindTests, ByPathNons)
+{
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "nons")) {
+    zim::Archive archive (testfile.path);
+
+    auto range0 = archive.findByPath("Першая_старонка.html");
+    auto range1 = archive.findByPath("П");
+    auto range2 = archive.findByPath("");
+    auto range3 = archive.findByPath("/");
+
+    auto count = 0;
+    for(auto& entry: range0) {
+      count++;
+      ASSERT_EQ(entry.getPath().find("Першая_старонка.html"), 0);
+    }
+    ASSERT_EQ(count, 1);
+
+    count = 0;
+    for(auto& entry: range1) {
+      count++;
+      std::cout << entry.getPath() << std::endl;
+      ASSERT_EQ(entry.getPath().find("П"), 0);
+    }
+    ASSERT_EQ(count, 2);
+
+    count = 0;
+    for(auto& entry: range2) {
+      ASSERT_EQ(count, entry.getIndex());
+      count++;
+    }
+    ASSERT_EQ(count, 109);
+
+    count = 0;
+    for(auto& entry: range3) {
+      ASSERT_EQ(count, entry.getIndex());
+      count++;
+    }
+    ASSERT_EQ(count, 109);
   }
 }
 #endif

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -21,17 +21,22 @@
 #include <zim/archive.h>
 #include <zim/error.h>
 
+#include "tools.h"
+
 #include "gtest/gtest.h"
 
 namespace
 {
 // Not found cases
 
+
+using zim::unittests::getDataFilePath;
+
 // ByTitle
 #if WITH_TEST_DATA
 TEST(FindTests, NotFoundByTitle)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto range0 = archive.findByTitle("unkownTitle");
     auto range1 = archive.findByTitle("j/body.js");
@@ -42,7 +47,7 @@ TEST(FindTests, NotFoundByTitle)
 // By Path
 TEST(FindTests, NotFoundByPath)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto range0 = archive.findByPath("unkwonUrl");
     auto range1 = archive.findByPath("U/unkwonUrl");
@@ -61,7 +66,7 @@ TEST(FindTests, NotFoundByPath)
 // ByTitle
 TEST(FindTests, ByTitle)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto range0 = archive.findByTitle("Main Page");
     ASSERT_EQ(range0.begin()->getIndex(), 5);
@@ -91,7 +96,7 @@ TEST(FindTests, ByTitle)
 // By Path (compatibility)
 TEST(FindTests, ByPathNoNS)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto it1 = archive.findByPath("j/body.js");
     auto it2 = archive.findByPath("m/115a35549794e50dcd03e60ef1a1ae24.png");
@@ -103,7 +108,7 @@ TEST(FindTests, ByPathNoNS)
 // By Path
 TEST(FindTests, ByPath)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto range0 = archive.findByPath("A/Main_Page.html");
     auto range1 = archive.findByPath("I/s/");

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -40,8 +40,8 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
 
@@ -56,8 +56,8 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 
 TEST(getEntry, indexOutOfRange)
 {
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
 
@@ -83,8 +83,8 @@ TEST(IteratorTests, begin)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         int i = 0;
         for(auto& entry: archive.iterEfficient()) {
@@ -100,8 +100,8 @@ TEST(IteratorTests, beginByTitle)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10};
 
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto it = archive.iterByTitle().begin();
 
@@ -121,8 +121,8 @@ TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
-        zim::Archive archive (path);
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (testfile.path);
 
         auto it = archive.iterByPath().begin();
         int i = 0;

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -40,7 +40,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
         zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
@@ -56,7 +56,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 
 TEST(getEntry, indexOutOfRange)
 {
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
         zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
@@ -83,7 +83,7 @@ TEST(IteratorTests, begin)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
         zim::Archive archive (testfile.path);
 
         int i = 0;
@@ -100,7 +100,7 @@ TEST(IteratorTests, beginByTitle)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10};
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
         zim::Archive archive (testfile.path);
 
         auto it = archive.iterByTitle().begin();
@@ -121,7 +121,7 @@ TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
         zim::Archive archive (testfile.path);
 
         auto it = archive.iterByPath().begin();

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -21,10 +21,13 @@
 #include <zim/archive.h>
 #include <zim/error.h>
 
+#include "tools.h"
 #include "gtest/gtest.h"
 
 namespace
 {
+
+using zim::unittests::getDataFilePath;
 
 #if WITH_TEST_DATA
 TEST(ClusterIteratorTest, getEntryByClusterOrder)
@@ -37,7 +40,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto nbEntries = archive.getEntryCount();
 
@@ -51,7 +54,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 
 TEST(getEntry, indexOutOfRange)
 {
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto nbEntries = archive.getEntryCount();
 
@@ -76,7 +79,7 @@ TEST(IteratorTests, begin)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     int i = 0;
     for(auto& entry: archive.iterEfficient()) {
@@ -90,7 +93,7 @@ TEST(IteratorTests, begin)
 TEST(IteratorTests, beginByTitle)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10};
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto it = archive.iterByTitle().begin();
 
@@ -108,7 +111,7 @@ TEST(IteratorTests, beginByTitle)
 TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    zim::Archive archive ("./data/wikibooks_be_all_nopic_2017-02.zim");
+    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
     auto it = archive.iterByPath().begin();
     int i = 0;

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -40,31 +40,35 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    auto nbEntries = archive.getEntryCount();
+        auto nbEntries = archive.getEntryCount();
 
-    ASSERT_EQ(nbEntries, expected.size());
+        ASSERT_EQ(nbEntries, expected.size());
 
-    for (auto i = 0u; i < nbEntries; i++)
-    {
-        EXPECT_EQ(archive.getEntryByClusterOrder(i).getIndex(), expected[i]);
+        for (auto i = 0u; i < nbEntries; i++)
+        {
+            EXPECT_EQ(archive.getEntryByClusterOrder(i).getIndex(), expected[i]);
+        }
     }
 }
 
 TEST(getEntry, indexOutOfRange)
 {
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    auto nbEntries = archive.getEntryCount();
+        auto nbEntries = archive.getEntryCount();
 
-    try {
-        archive.getEntryByPath(nbEntries);
-        FAIL() << "Should throw exception\n";
-    }  catch (std::out_of_range& e) {
-        ASSERT_EQ(e.what(), std::string("entry index out of range"));
-    }  catch(...) {
-        FAIL() << "Should throw exception\n";
+        try {
+            archive.getEntryByPath(nbEntries);
+            FAIL() << "Should throw exception\n";
+        }  catch (std::out_of_range& e) {
+            ASSERT_EQ(e.what(), std::string("entry index out of range"));
+        }  catch(...) {
+            FAIL() << "Should throw exception\n";
+        }
     }
 }
 
@@ -79,12 +83,14 @@ TEST(IteratorTests, begin)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    int i = 0;
-    for(auto& entry: archive.iterEfficient()) {
-        EXPECT_EQ(entry.getIndex(), expected[i]);
-        i++;
+        int i = 0;
+        for(auto& entry: archive.iterEfficient()) {
+            EXPECT_EQ(entry.getIndex(), expected[i]);
+            i++;
+        }
     }
 }
 
@@ -93,17 +99,20 @@ TEST(IteratorTests, begin)
 TEST(IteratorTests, beginByTitle)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10};
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
-    auto it = archive.iterByTitle().begin();
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
 
-    int i = 0;
-    while (i < 10)
-    {
-        EXPECT_EQ(it->getIndex(), expected[i]);
-        it++; i++;
+        auto it = archive.iterByTitle().begin();
+
+        int i = 0;
+        while (i < 10)
+        {
+            EXPECT_EQ(it->getIndex(), expected[i]);
+            it++; i++;
+        }
+        std::cout << "\n";
     }
-    std::cout << "\n";
 }
 
 
@@ -111,14 +120,17 @@ TEST(IteratorTests, beginByTitle)
 TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    zim::Archive archive (getDataFilePath("wikibooks_be_all_nopic_2017-02.zim"));
 
-    auto it = archive.iterByPath().begin();
-    int i = 0;
-    while (i < 10)
-    {
-        EXPECT_EQ(it->getIndex(), expected[i]);
-        it++; i++;
+    for(auto& path:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+        zim::Archive archive (path);
+
+        auto it = archive.iterByPath().begin();
+        int i = 0;
+        while (i < 10)
+        {
+            EXPECT_EQ(it->getIndex(), expected[i]);
+            it++; i++;
+        }
     }
 }
 #endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -37,6 +37,9 @@ else
     run_target('download_test_data', command : [test_data_downloader, '--remove-top-dir', datadir])
 endif
 
+testenv = environment()
+testenv.set('ZIM_TEST_DATA_DIR', datadir)
+
 if gtest_dep.found() and not meson.is_cross_build()
     foreach test_name : tests
         test_exe = executable(test_name, [test_name+'.cpp', 'tools.cpp'],
@@ -47,7 +50,6 @@ if gtest_dep.found() and not meson.is_cross_build()
                               cpp_args: test_cpp_args,
                               dependencies: deps + [gtest_dep],
                               build_rpath: '$ORIGIN')
-        test(test_name, test_exe, timeout : 120,
-             workdir: meson.current_build_dir())
+        test(test_name, test_exe, timeout : 120, env: testenv)
     endforeach
 endif

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -69,8 +69,8 @@ class TempZimArchive : zim::unittests::TempFile
 #if WITH_TEST_DATA
 TEST(Search, searchByTitle)
 {
-  for(auto& path:getDataFilePath("small.zim")) {
-    const zim::Archive archive(path);
+  for(auto& testfile:getDataFilePath("small.zim")) {
+    const zim::Archive archive(testfile.path);
     ASSERT_TRUE(archive.hasTitleIndex());
     const zim::Entry mainEntry = archive.getMainEntry();
     zim::Search search(archive);

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -69,15 +69,17 @@ class TempZimArchive : zim::unittests::TempFile
 #if WITH_TEST_DATA
 TEST(Search, searchByTitle)
 {
-  const zim::Archive archive(getDataFilePath("small.zim"));
-  ASSERT_TRUE(archive.hasTitleIndex());
-  const zim::Entry mainEntry = archive.getMainEntry();
-  zim::Search search(archive);
-  search.set_suggestion_mode(true);
-  search.set_query(mainEntry.getTitle());
-  search.set_range(0, archive.getEntryCount());
-  ASSERT_NE(0, search.get_matches_estimated());
-  ASSERT_EQ(mainEntry.getPath(), search.begin().get_path());
+  for(auto& path:getDataFilePath("small.zim")) {
+    const zim::Archive archive(path);
+    ASSERT_TRUE(archive.hasTitleIndex());
+    const zim::Entry mainEntry = archive.getMainEntry();
+    zim::Search search(archive);
+    search.set_suggestion_mode(true);
+    search.set_query(mainEntry.getTitle());
+    search.set_range(0, archive.getEntryCount());
+    ASSERT_NE(0, search.get_matches_estimated());
+    ASSERT_EQ(mainEntry.getPath(), search.begin().get_path());
+  }
 }
 #endif
 

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -27,10 +27,13 @@
 
 #include "tools.h"
 
+#include "tools.h"
 #include "gtest/gtest.h"
 
 namespace
 {
+
+using zim::unittests::getDataFilePath;
 
 class TestItem : public zim::writer::Item
 {
@@ -66,7 +69,7 @@ class TempZimArchive : zim::unittests::TempFile
 #if WITH_TEST_DATA
 TEST(Search, searchByTitle)
 {
-  const zim::Archive archive("./data/small.zim");
+  const zim::Archive archive(getDataFilePath("small.zim"));
   ASSERT_TRUE(archive.hasTitleIndex());
   const zim::Entry mainEntry = archive.getMainEntry();
   zim::Search search(archive);

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -20,6 +20,7 @@
 
 #define ZIM_PRIVATE
 #include <zim/archive.h>
+#include <zim/item.h>
 #include <zim/search.h>
 #include <zim/writer/creator.h>
 #include <zim/writer/item.h>
@@ -72,13 +73,13 @@ TEST(Search, searchByTitle)
   for(auto& testfile:getDataFilePath("small.zim")) {
     const zim::Archive archive(testfile.path);
     ASSERT_TRUE(archive.hasTitleIndex());
-    const zim::Entry mainEntry = archive.getMainEntry();
+    const auto mainItem = archive.getMainEntry().getItem(true);
     zim::Search search(archive);
     search.set_suggestion_mode(true);
-    search.set_query(mainEntry.getTitle());
+    search.set_query(mainItem.getTitle());
     search.set_range(0, archive.getEntryCount());
     ASSERT_NE(0, search.get_matches_estimated());
-    ASSERT_EQ(mainEntry.getPath(), search.begin().get_path());
+    ASSERT_EQ(mainItem.getPath(), search.begin().get_path());
   }
 }
 #endif

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -31,6 +31,7 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
+#include "gtest/gtest.h"
 
 namespace zim
 {
@@ -97,9 +98,22 @@ makeTempFile(const char* name, const std::string& content)
   return p;
 }
 
+void setDataDir(std::string& dataDir)
+{
+  // FAIL must be used in a void function. So we need to use a out parameter.
+  const char* cDataDir = std::getenv("ZIM_TEST_DATA_DIR");
+  if (cDataDir == NULL) {
+    dataDir = "INVALID_DATA_DIR";
+    FAIL() << "ZIM_TEST_DATA_DIR is not defined. You must define it to the directory containing test zim files.";
+  }
+  dataDir = cDataDir;
+}
+
 const std::vector<std::string> getDataFilePath(const std::string& filename)
 {
-  auto path = zim::DEFAULTFS::join("data", filename);
+  std::string dataDir;
+  setDataDir(dataDir);
+  auto path = zim::DEFAULTFS::join(dataDir, filename);
   return { path };
 }
 

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -97,9 +97,10 @@ makeTempFile(const char* name, const std::string& content)
   return p;
 }
 
-std::string getDataFilePath(const std::string& filename)
+const std::vector<std::string> getDataFilePath(const std::string& filename)
 {
-  return zim::DEFAULTFS::join("data", filename);
+  auto path = zim::DEFAULTFS::join("data", filename);
+  return { path };
 }
 
 } // namespace unittests

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -27,6 +27,8 @@
 #include <io.h>
 #endif
 
+#include "../src/fs.h"
+
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -95,6 +97,10 @@ makeTempFile(const char* name, const std::string& content)
   return p;
 }
 
+std::string getDataFilePath(const std::string& filename)
+{
+  return zim::DEFAULTFS::join("data", filename);
+}
 
 } // namespace unittests
 

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -111,9 +111,16 @@ void setDataDir(std::string& dataDir)
   dataDir = cDataDir;
 }
 
-const std::vector<std::string> getDataFilePath(const std::string& filename)
+TestFile::TestFile(const std::string& dataDir, const std::string& category, const std::string& filename) :
+  filename(filename),
+  category(category),
+  path(zim::DEFAULTFS::join(zim::DEFAULTFS::join(dataDir, category), filename))
 {
-  std::vector<std::string> filePaths;
+}
+
+const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::string& category)
+{
+  std::vector<TestFile> filePaths;
   std::string dataDirPath;
   setDataDir(dataDirPath);
   auto dataDir = opendir(dataDirPath.c_str());
@@ -122,15 +129,20 @@ const std::vector<std::string> getDataFilePath(const std::string& filename)
     filePaths.emplace_back(dataDirPath, "NO_DATA_DIR", filename);
     return filePaths;
   }
-  struct dirent* current = NULL;
-  while(current = readdir(dataDir)) {
-    if (current->d_name[0] == '.' || current->d_name[0] == '_') {
-      continue;
-    }
-    filePaths.push_back(zim::DEFAULTFS::join(zim::DEFAULTFS::join(dataDirPath, current->d_name), filename));
-  }
 
-  closedir(dataDir);
+  if (!category.empty()) {
+      // We have asked for a particular category.
+      filePaths.emplace_back(dataDirPath, category, filename);
+  } else {
+    struct dirent* current = NULL;
+    while((current = readdir(dataDir))) {
+      if (current->d_name[0] == '.' || current->d_name[0] == '_') {
+        continue;
+      }
+      filePaths.emplace_back(dataDirPath, current->d_name, filename);
+    }
+    closedir(dataDir);
+  }
 
   return filePaths;
 }

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -123,17 +123,25 @@ const std::vector<TestFile> getDataFilePath(const std::string& filename, const s
   std::vector<TestFile> filePaths;
   std::string dataDirPath;
   setDataDir(dataDirPath);
-  auto dataDir = opendir(dataDirPath.c_str());
-
-  if (!dataDir) {
-    filePaths.emplace_back(dataDirPath, "NO_DATA_DIR", filename);
-    return filePaths;
-  }
 
   if (!category.empty()) {
       // We have asked for a particular category.
       filePaths.emplace_back(dataDirPath, category, filename);
   } else {
+#ifdef _WIN32
+    // We don't have dirent.h in windows.
+    // If we move to test data out of the repository, we will need a way to discover the data.
+    // Use a static list of categories for now.
+    for (auto& category: {"withns", "nons"}) {
+      filePaths.emplace_back(dataDirPath, category, filename);
+    }
+#else
+    auto dataDir = opendir(dataDirPath.c_str());
+
+    if (!dataDir) {
+      filePaths.emplace_back(dataDirPath, "NO_DATA_DIR", filename);
+      return filePaths;
+    }
     struct dirent* current = NULL;
     while((current = readdir(dataDir))) {
       if (current->d_name[0] == '.' || current->d_name[0] == '_') {
@@ -142,6 +150,7 @@ const std::vector<TestFile> getDataFilePath(const std::string& filename, const s
       filePaths.emplace_back(dataDirPath, current->d_name, filename);
     }
     closedir(dataDir);
+#endif
   }
 
   return filePaths;

--- a/test/tools.h
+++ b/test/tools.h
@@ -22,6 +22,7 @@
 
 
 #include <string>
+#include <vector>
 #include <sys/types.h>
 #ifdef _WIN32
 #include <windows.h>
@@ -113,7 +114,7 @@ zim::Buffer write_to_buffer(const T& object)
   return buf;
 }
 
-std::string getDataFilePath(const std::string& filename);
+const std::vector<std::string> getDataFilePath(const std::string& filename);
 
 } // namespace unittests
 

--- a/test/tools.h
+++ b/test/tools.h
@@ -114,7 +114,14 @@ zim::Buffer write_to_buffer(const T& object)
   return buf;
 }
 
-const std::vector<std::string> getDataFilePath(const std::string& filename);
+struct TestFile {
+  TestFile(const std::string& dataDir, const std::string& category, const std::string& filename);
+  const std::string filename;
+  const std::string category;
+  const std::string path;
+};
+
+const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::string& category = "");
 
 } // namespace unittests
 

--- a/test/tools.h
+++ b/test/tools.h
@@ -113,6 +113,8 @@ zim::Buffer write_to_buffer(const T& object)
   return buf;
 }
 
+std::string getDataFilePath(const std::string& filename);
+
 } // namespace unittests
 
 } // namespace zim


### PR DESCRIPTION
This PR somehow invalidate #531
(Moving the zim file in a different repository is still a open idea. But it can be done after this PR. Although it would be pretty useless. Adding the binary files to git will grow the total git repository size even if we remove them just after).

First commits prepare a bit the tests tools to be prepared to test several "same" test files.
After we add the new test files (which can be replaced by the download presented in #531)
Then we update the tests for the new test files.

It also "cherry-pick" #518 which now because obsolete.