### PR TITLE
Add support of `M/Illustration` metadata in zim file.

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <memory>
 #include <bitset>
+#include <set>
 
 
 namespace zim
@@ -149,6 +150,16 @@ namespace zim
        *  @exception EntryNotFound If no illustration item can be found.
        */
       Item getIllustrationItem(unsigned int size=48) const;
+
+      /** Return a list of available size for the illustations in the archive.
+       *
+       * Illustration is a icon for the archive that can be used in catalog and so to illustrate the archive.
+       * An Archive may contains several illustration with different size.
+       * This method allow to know which illustration (size) is in the archive.
+       *
+       * @return A set of size.
+       */
+      std::set<unsigned int> getIllustrationSizes() const;
 
 
       /** Get an entry using its "path" index.

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -140,6 +140,17 @@ namespace zim
        */
       std::vector<std::string> getMetadataKeys() const;
 
+      /** Get the illustration item of the archive.
+       *
+       *  Illustration is a icon for the archive that can be used in catalog and so to illustrate the archive.
+       *
+       *  @param size The size (width and height) of the illustration to get. Default to 48 (48x48px icon)
+       *  @return The illustration item.
+       *  @exception EntryNotFound If no illustration item can be found.
+       */
+      Item getIllustrationItem(unsigned int size=48) const;
+
+
       /** Get an entry using its "path" index.
        *
        *  Use the index of the entry to get the idx'th entry
@@ -205,14 +216,6 @@ namespace zim
        */
       Entry getMainEntry() const;
 
-      /** Get the favicon entry of the archive.
-       *
-       *  @return The favicon entry.
-       *  @exception EntryNotFound If no favicon entry has been specified in the archive.
-       */
-      Entry getFaviconEntry() const;
-
-
       /** Get a random entry.
        *
        * The entry is picked randomly from the front artice list.
@@ -254,9 +257,11 @@ namespace zim
 
       /** Check if archive has a favicon entry
        *
-       * @return True if the archive has a favicon entry.
+       * @param size The size (width and height) of the illustration to check. Default to 48 (48x48px icon)
+       * @return True if the archive has a corresponding illustration entry.
+       *         (Always True if the archive has no illustration, but a favicon)
        */
-      bool hasFaviconEntry() const;
+      bool hasIllustration(unsigned int size=48) const;
 
       /** Check if the archive has a fulltext index.
        *

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -146,6 +146,21 @@ namespace zim
         void addMetadata(const std::string& name, std::unique_ptr<ContentProvider> provider, const std::string& mimetype);
 
         /**
+         * Add illustration to the archive.
+         *
+         * @param size the size (width and height) of the illustration.
+         * @param content the content of the illustration (must be a png content)
+         */
+        void addIllustration(unsigned int size, const std::string& content);
+        /**
+         * Add illustration to the archive.
+         *
+         * @param size the size (width and height) of the illustration.
+         * @param provider the provider of the content of the illustration (must be a png content)
+         */
+
+        void addIllustration(unsigned int size, std::unique_ptr<ContentProvider> provider);
+        /**
          * Add a redirection to the archive.
          *
          * @param path the path of the redirection.
@@ -171,13 +186,6 @@ namespace zim
         void setMainPath(const std::string& mainPath) { m_mainPath = mainPath; }
 
         /**
-         * Set the path of the favicon.
-         *
-         * @param faviconPath The path of the favicon.
-         */
-        void setFaviconPath(const std::string& faviconPath) { m_faviconPath = faviconPath; }
-
-        /**
          * Set the uuid of the the archive.
          *
          * @param uuid The uuid of the archive.
@@ -197,7 +205,6 @@ namespace zim
 
         // zim data
         std::string m_mainPath;
-        std::string m_faviconPath;
         Uuid m_uuid = Uuid::generate();
 
         void fillHeader(Fileheader* header) const;

--- a/scripts/download_test_data.py
+++ b/scripts/download_test_data.py
@@ -26,7 +26,7 @@ from urllib.error import *
 import tarfile
 import sys
 
-TEST_DATA_VERSION = "0.2"
+TEST_DATA_VERSION = "0.3"
 ARCHIVE_URL_TEMPL = "https://github.com/openzim/zim-testing-suite/releases/download/v{version}/zim-testing-suite-{version}.tar.gz"
 
 if __name__ == "__main__":

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -125,6 +125,29 @@ namespace zim
     throw EntryNotFound("Cannot find illustration item.");
   }
 
+  std::set<unsigned int> Archive::getIllustrationSizes() const {
+    std::set<unsigned int> ret;
+    for(auto r = m_impl->findx('M', "Illustration_").second;
+        /*No exit test*/;
+        r++
+       ) {
+      auto path = getEntryByPath(entry_index_type(r)).getPath();
+      if (path.find("Illustration_") != 0) {
+        break;
+      }
+      try {
+        ret.insert(parseIllustrationPathToSize(path));
+      } catch (...) {}
+    }
+    if (ret.find(48) == ret.end()) {
+      try {
+        auto r = findFavicon(*m_impl);
+        ret.insert(48);
+      } catch(EntryNotFound&) {}
+    }
+    return ret;
+  }
+
   bool Archive::hasIllustration(unsigned int size) const {
     try {
       getIllustrationItem(size);

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -86,6 +86,54 @@ namespace zim
     return ret;
   }
 
+  zim::FileImpl::FindxResult findFavicon(FileImpl& impl)
+  {
+    for(auto ns:{'-', 'I'}) {
+      for (auto& path:{"favicon", "favicon.png"}) {
+        auto r = impl.findx(ns, path);
+        if (r.first) {
+          return r;
+        }
+      }
+    }
+    throw EntryNotFound("No favicon found.");
+  }
+
+  Item Archive::getIllustrationItem(unsigned int size) const {
+    std::ostringstream ss;
+    ss  << "Illustration_" << size << "x" << size << "@" << 1;
+    auto r = m_impl->findx('M', ss.str());
+    if (r.first) {
+      return getEntryByPath(entry_index_type(r.second)).getItem();
+    }
+    // We haven't found the exact entry. Let's "search" for a illustration and
+    // use the first one we found.
+#if 0
+    // We have decided to not implement fallback in case of wrong resolution for now.
+    // We keep this code for reference.
+    r = m_impl->findx('M', "Illustration");
+    auto entry = getEntryByPath(entry_index_type(r.second));
+    if (entry.getPath().find("Illustration") == 0) {
+      return entry.getItem();
+    }
+#endif
+    // For 48x48 illustration, return favicon for older zims.
+    if (size == 48) {
+      auto r = findFavicon(*m_impl);
+      return getEntryByPath(entry_index_type(r.second)).getItem(true);
+    }
+    throw EntryNotFound("Cannot find illustration item.");
+  }
+
+  bool Archive::hasIllustration(unsigned int size) const {
+    try {
+      getIllustrationItem(size);
+      return true;
+    } catch (EntryNotFound& e) {
+      return false;
+    }
+  }
+
   Entry Archive::getEntryByPath(entry_index_type idx) const
   {
     if (idx >= entry_index_type(m_impl->getCountArticles()))
@@ -163,29 +211,6 @@ namespace zim
 
   bool Archive::hasMainEntry() const {
     return m_impl->getFileheader().hasMainPage();
-  }
-
-  Entry Archive::getFaviconEntry() const {
-    // `-/favicon` is the standard path for the favicon, but older zims may have it
-    // on other path.
-    for(auto ns:{'W', '-', 'I'}) {
-      for (auto& path:{"favicon", "favicon.png"}) {
-        auto r = m_impl->findx(ns, path);
-        if (r.first) {
-          return getEntryByPath(entry_index_type(r.second));
-        }
-      }
-    }
-    throw EntryNotFound("Cannot find favicon entry");
-  }
-
-  bool Archive::hasFaviconEntry() const {
-    try {
-      getFaviconEntry();
-      return true;
-    } catch (EntryNotFound& e) {
-      return false;
-    }
   }
 
   Entry Archive::getRandomEntry() const {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -121,6 +121,17 @@ std::tuple<char, std::string> zim::parseLongPath(const std::string& longPath)
   return std::make_tuple(ns, shortPath);
 }
 
+unsigned int zim::parseIllustrationPathToSize(const std::string& s)
+{
+  int nw(0), nh(0), nEnd(0);
+  long int w(-1), h(-1);
+  if ( sscanf(s.c_str(), "Illustration_%n%ldx%n%ld@1%n)", &nw, &w, &nh, &h, &nEnd) == 2
+     && nEnd == s.size() && !isspace(s[nw]) && !isspace(s[nh]) && w == h && w >= 0) {
+    return (unsigned int)w;
+  }
+  throw std::runtime_error("");
+}
+
 uint32_t zim::randomNumber(uint32_t max)
 {
   static std::default_random_engine random(

--- a/src/tools.h
+++ b/src/tools.h
@@ -35,6 +35,9 @@ namespace zim {
 
   std::tuple<char, std::string> parseLongPath(const std::string& longPath);
 
+  // Parse a illustration path ("Illustration_<width>x<height>@1") to a size.
+  unsigned int parseIllustrationPathToSize(const std::string& s);
+
   /** Return a random number from range [0, max]
    *
    * This function is threadsafe

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -196,6 +196,19 @@ namespace zim
       data->handle(dirent);
     }
 
+    void Creator::addIllustration(unsigned int size, const std::string& content)
+    {
+      auto provider = std::unique_ptr<ContentProvider>(new StringProvider(content));
+      addIllustration(size, std::move(provider));
+    }
+
+    void Creator::addIllustration(unsigned int size, std::unique_ptr<ContentProvider> provider)
+    {
+      std::stringstream ss;
+      ss << "Illustration_" << size << "x" << size << "@1";
+      addMetadata(ss.str(), std::move(provider), "image/png");
+    }
+
     void Creator::addRedirection(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
     {
       auto dirent = data->createRedirectDirent('C', path, title, 'C', targetPath);
@@ -208,12 +221,6 @@ namespace zim
 
     void Creator::finishZimCreation()
     {
-      // Create mandatory entries
-      if (!m_faviconPath.empty()) {
-        auto dirent = data->createRedirectDirent('W', "favicon", "", 'C', m_faviconPath);
-        data->handle(dirent);
-      }
-
       // Create a redirection for the mainPage.
       // We need to keep the created dirent to set the fileheader.
       // Dirent doesn't have to be deleted.

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -200,6 +200,7 @@ TEST(ZimArchive, illustration)
       } else {
         ASSERT_EQ(illustrationItem.getPath(), "I/favicon.png") << ctx;
       }
+      ASSERT_EQ(archive.getIllustrationSizes(), std::set<unsigned int>({48}));
     }
   }
 }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -181,6 +181,28 @@ TEST(ZimArchive, randomEntry)
     }
   }
 }
+
+TEST(ZimArchive, illustration)
+{
+  const char* const zimfiles[] = {
+    "small.zim",
+    "wikibooks_be_all_nopic_2017-02.zim"
+  };
+
+  for ( const std::string fname : zimfiles ) {
+    for (auto& testfile: getDataFilePath(fname)) {
+      const TestContext ctx{ {"path", testfile.path } };
+      const zim::Archive archive(testfile.path);
+      ASSERT_TRUE(archive.hasIllustration(48)) << ctx;
+      auto illustrationItem = archive.getIllustrationItem(48);
+      if(testfile.category == "nons") {
+        ASSERT_EQ(illustrationItem.getPath(), "Illustration_48x48@1") << ctx;
+      } else {
+        ASSERT_EQ(illustrationItem.getPath(), "I/favicon.png") << ctx;
+      }
+    }
+  }
+}
 #endif
 
 class CapturedStderr
@@ -316,7 +338,7 @@ TEST(ZimArchive, validate)
     if (testfile.category == "withns") {
       expected = "Entry M/Language has invalid MIME-type value 1234.\n";
     } else {
-      expected = "Entry M/Scraper has invalid MIME-type value 1234.\n";
+      expected = "Entry M/Publisher has invalid MIME-type value 1234.\n";
     }
     EXPECT_BROKEN_ZIMFILE(testfile.path, expected)
   }

--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -32,4 +32,26 @@ namespace {
     ASSERT_EQ(zim::countWords("One.Two\tThree"), 2);
   }
 
+
+  TEST(Tools, parseIllustrationPathToSize) {
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_0x0@1"), 0);
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_1x1@1"), 1);
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_01x01@1"), 1);
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_64x64@1"), 64);
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_128x128@1"), 128);
+    ASSERT_EQ(zim::parseIllustrationPathToSize("Illustration_1024x1024@1"), 1024);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illsration_64x64@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illstration_"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_64x@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_64x"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_64x64"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_64x64@1.5"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_128x64@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_-32x-32@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_ 64x64@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_64x 64@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_ 64x 64@1"), std::runtime_error);
+    ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_1 28x1 28@1"), std::runtime_error);
+  }
+
 }


### PR DESCRIPTION
Remove favicon API and replace it by illustration methods.

We have decided with @kelson42 to not implement resolution fallback for this PR. Has I had already implemented a small fallback algorithm, I've keep it commented as reference.
It is not to be reviewed as the exact algorithm will probably change.

We need new zim file with the correct illustration entry. I've made a prerealase of zim-testing-suite with them (https://github.com/openzim/zim-testing-suite/releases/tag/v0.3-alpha). v0.3-alpha is made using this branch and https://github.com/openzim/zim-tools/pull/241

codecov is a bit under 90% has we don't test the fallback if there is no illustration/favicon at all in the zim file.