### PR TITLE
Add unit test for search iterator

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -18,11 +18,11 @@ tests = [
     'bufferstreamer',
     'parseLongPath',
     'random',
-    'tooltesting',
+    'tooltesting'
 ]
 
 if xapian_dep.found()
-    tests += ['search', 'suggestion', 'defaultIndexdata']
+    tests += ['search', 'suggestion', 'defaultIndexdata', 'search_iterator']
 endif
 
 datadir = get_option('test_data_dir')

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -22,9 +22,6 @@
 #include <zim/archive.h>
 #include <zim/item.h>
 #include <zim/search.h>
-#include <zim/writer/creator.h>
-#include <zim/writer/item.h>
-#include <zim/writer/contentProvider.h>
 
 #include "tools.h"
 
@@ -35,37 +32,8 @@ namespace
 {
 
 using zim::unittests::getDataFilePath;
-
-class TestItem : public zim::writer::Item
-{
-  public:
-    TestItem(const std::string& path, const std::string& title, const std::string& content):
-     path(path), title(title), content(content)  { }
-    virtual ~TestItem() = default;
-
-    virtual std::string getPath() const { return path; };
-    virtual std::string getTitle() const { return title; };
-    virtual std::string getMimeType() const { return "text/html"; };
-
-    virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
-      return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(content));
-    }
-
-  std::string path;
-  std::string title;
-  std::string content;
-};
-
-// Helper class to create a temporary zim and remove it once the test is done
-class TempZimArchive : zim::unittests::TempFile
-{
-  public:
-    explicit TempZimArchive(const char* tempPath) : zim::unittests::TempFile {tempPath} {}
-
-    const std::string getPath() {
-      return this->path();
-    }
-};
+using zim::unittests::TempZimArchive;
+using zim::unittests::TestItem;
 
 #if WITH_TEST_DATA
 TEST(Search, searchByTitle)
@@ -93,7 +61,7 @@ TEST(Search, indexFullPath)
   creator.configIndexing(true, "en");
   creator.startZimCreation(tza.getPath());
 
-  auto item = std::make_shared<TestItem>("testPath", "Test Article", "This is a test article");
+  auto item = std::make_shared<TestItem>("testPath", "text/html", "Test Article", "This is a test article");
   creator.addItem(item);
 
   creator.setMainPath("testPath");

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021 Maneesh P M <manu.pm55@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#define ZIM_PRIVATE
+#include <zim/archive.h>
+#include <zim/search.h>
+#include <zim/search_iterator.h>
+#include "tools.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+using zim::unittests::TempZimArchive;
+
+TEST(search_iterator, functions) {
+  TempZimArchive tza("testZim");
+
+  zim::Archive archive = tza.createZimFromTitles({
+    "item a",
+  });
+
+  zim::Search search(archive);
+  search.set_suggestion_mode(true);
+  search.set_query("item");
+  search.set_range(0, archive.getEntryCount());
+  search.set_verbose(true);
+
+  auto it = search.begin();
+
+  // Test functions
+  ASSERT_EQ(it.get_title(), "item a");
+  ASSERT_EQ(it.get_path(), "dummyPathitem a");
+  ASSERT_EQ(it.get_score(), 100);
+  ASSERT_EQ(it.get_fileIndex(), 0);
+  ASSERT_EQ(it.get_wordCount(), -1);            // Unimplemented
+  ASSERT_EQ(it.get_size(), -1);                 // Unimplemented
+}
+
+TEST(search_iterator, iteration) {
+  TempZimArchive tza("testZim");
+
+  zim::Archive archive = tza.createZimFromTitles({
+    "item a",
+    "item b"
+  });
+
+  zim::Search search(archive);
+  search.set_suggestion_mode(true);
+  search.set_query("item");
+  search.set_range(0, archive.getEntryCount());
+  search.set_verbose(true);
+
+  auto it = search.begin();
+  ASSERT_EQ(it.get_title(), search.begin().get_title());
+
+  ASSERT_EQ(it.get_title(), "item a");
+  it++;
+  ASSERT_EQ(it.get_title(), "item b");
+  ASSERT_TRUE(it != search.begin());
+
+  it--;
+  ASSERT_EQ(it.get_title(), "item a");
+  ASSERT_TRUE(search.begin() == it);
+
+  it++; it++;
+  ASSERT_TRUE(it == search.end());
+}
+
+} // anonymous namespace

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -19,12 +19,8 @@
 
 #define ZIM_PRIVATE
 
-#include <zim/zim.h>
 #include <zim/archive.h>
 #include <zim/search.h>
-#include <zim/writer/creator.h>
-#include <zim/writer/item.h>
-#include <zim/writer/contentProvider.h>
 
 #include "tools.h"
 
@@ -32,44 +28,8 @@
 
 namespace {
 
-  class TestItem : public zim::writer::BasicItem {
-      public:
-      TestItem(const std::string& path, const std::string& mimetype, const std::string& title)
-        : BasicItem(path, mimetype, title) {}
-
-      virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
-        return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider("foo"));
-      }
-  };
-
-  // Helper class to create a temporary zim from titles list
-  // Remove the temporary file once test is done.
-  class TempZimArchive : zim::unittests::TempFile {
-    public:
-      explicit TempZimArchive(const char* tempPath) : zim::unittests::TempFile {tempPath} {}
-
-      zim::Archive createZimFromTitles(std::vector<std::string> titles) {
-        zim::writer::Creator creator;
-        creator.configIndexing(true, "en");
-        creator.startZimCreation(this->path());
-
-        // add dummy items with given titles
-        for (auto title : titles) {
-          std::string path = "dummyPath" + title;
-          auto item = std::make_shared<TestItem>(path, "text/html", title);
-          creator.addItem(item);
-        }
-
-        creator.addMetadata("Title", "This is a title");
-
-        creator.finishZimCreation();
-        return zim::Archive(this->path());
-      }
-
-      const std::string getPath() {
-        return this->path();
-      }
-  };
+  using zim::unittests::TempZimArchive;
+  using zim::unittests::TestItem;
 
   std::vector<std::string> getSuggestions(const zim::Archive archive, std::string query, int range) {
     zim::Search search(archive);

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -156,6 +156,28 @@ const std::vector<TestFile> getDataFilePath(const std::string& filename, const s
   return filePaths;
 }
 
+zim::Archive TempZimArchive::createZimFromTitles(std::vector<std::string> titles) {
+  zim::writer::Creator creator;
+  creator.configIndexing(true, "en");
+  creator.startZimCreation(this->path());
+
+  // add dummy items with given titles
+  for (auto title : titles) {
+    std::string path = "dummyPath" + title;
+    auto item = std::make_shared<TestItem>(path, "text/html", title);
+    creator.addItem(item);
+  }
+
+  creator.addMetadata("Title", "This is a title");
+
+  creator.finishZimCreation();
+  return zim::Archive(this->path());
+}
+
+const std::string TempZimArchive::getPath() {
+  return this->path();
+}
+
 } // namespace unittests
 
 } // namespace zim

--- a/test/tools.h
+++ b/test/tools.h
@@ -36,6 +36,13 @@
 #include "../src/buffer.h"
 #include <limits.h>
 
+#define ZIM_PRIVATE
+#include <zim/archive.h>
+#include <zim/search.h>
+#include <zim/writer/creator.h>
+#include <zim/writer/item.h>
+#include <zim/writer/contentProvider.h>
+
 namespace zim
 {
 
@@ -130,6 +137,34 @@ struct TestFile {
 };
 
 const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::string& category = "");
+
+// Helper class to create temporary zim and remove it once the test is done
+class TempZimArchive : zim::unittests::TempFile {
+  public:
+    explicit TempZimArchive(const char* tempPath) : zim::unittests::TempFile {tempPath} {}
+    zim::Archive createZimFromTitles(std::vector<std::string> titles);
+    const std::string getPath();
+};
+
+class TestItem : public zim::writer::Item {
+  public:
+    TestItem(const std::string& path, const std::string& mimetype = "text/html", const std::string& title = "Test Item", const std::string& content = "foo") :
+      path(path), title(title), content(content), mimetype(mimetype) {}
+    virtual ~TestItem() = default;
+
+    virtual std::string getPath() const { return path; };
+    virtual std::string getTitle() const { return title; };
+    virtual std::string getMimeType() const { return mimetype; };
+
+    virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
+      return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(content));
+    }
+
+  std::string path;
+  std::string title;
+  std::string content;
+  std::string mimetype;
+};
 
 } // namespace unittests
 


### PR DESCRIPTION
Fixes #546 

Changes contained this PR:
- Move helper code `TempZimArchive` & `TestItem` to tools for better usability.
- Add some unit tests for the search iterator.