### PR TITLE
Fixed zim::writer::Cluster::addContent()

### DIFF
--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -233,7 +233,7 @@ void Cluster::addContent(std::unique_ptr<ContentProvider> provider)
   _size += size;
   blobOffsets.push_back(offset_t(_size.v));
   m_count++;
-  isExtended |= (size>UINT32_MAX);
+  isExtended |= (_size.v>UINT32_MAX);
   if (size == 0)
     return;
 

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -226,8 +226,9 @@ TEST(ClusterTest, read_write_extended_cluster)
   std::string blob0("123456789012345678901234567890");
   std::string blob1("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
   std::string blob2("abcdefghijklmnopqrstuvwxyz");
-  zim::size_type bigger_than_4g = 1024LL*1024LL*1024LL*4LL+1024LL;
-  auto bigProvider = std::unique_ptr<zim::writer::ContentProvider>(new FakeProvider(bigger_than_4g));
+  const uint64_t FOUR_GIB = 4LL * 1024LL*1024LL*1024LL;
+  zim::size_type almost_4g = FOUR_GIB - 16;
+  auto bigProvider = std::unique_ptr<zim::writer::ContentProvider>(new FakeProvider(almost_4g));
 
   zim::writer::Cluster cluster(zim::zimcompNone);
   cluster.addContent(blob0);
@@ -235,6 +236,7 @@ TEST(ClusterTest, read_write_extended_cluster)
   cluster.addContent(blob2);
   cluster.addContent(std::move(bigProvider));
 
+  ASSERT_GT(cluster.size().v, FOUR_GIB);
   ASSERT_EQ(cluster.is_extended(), true);
 
   auto buffer = write_to_buffer(cluster);
@@ -248,7 +250,7 @@ TEST(ClusterTest, read_write_extended_cluster)
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(0)).v, blob0.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(2)).v, blob2.size());
-  ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(3)).v, bigger_than_4g);
+  ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(3)).v, almost_4g);
   ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
   ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
   ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -229,12 +229,14 @@ TEST(ClusterTest, read_write_extended_cluster)
   const uint64_t FOUR_GIB = 4LL * 1024LL*1024LL*1024LL;
   zim::size_type almost_4g = FOUR_GIB - 16;
   auto bigProvider = std::unique_ptr<zim::writer::ContentProvider>(new FakeProvider(almost_4g));
+  std::string blob4("zyxwvutsrqponmlkjihgfedcba");
 
   zim::writer::Cluster cluster(zim::zimcompNone);
   cluster.addContent(blob0);
   cluster.addContent(blob1);
   cluster.addContent(blob2);
   cluster.addContent(std::move(bigProvider));
+  cluster.addContent(blob4);
 
   ASSERT_GT(cluster.size().v, FOUR_GIB);
   ASSERT_EQ(cluster.is_extended(), true);
@@ -245,7 +247,7 @@ TEST(ClusterTest, read_write_extended_cluster)
   const auto cluster2shptr = zim::Cluster::read(zim::BufferReader(buffer), zim::offset_t(0));
   zim::Cluster& cluster2 = *cluster2shptr;
   ASSERT_EQ(cluster2.isExtended, true);
-  ASSERT_EQ(cluster2.count().v, 4U);
+  ASSERT_EQ(cluster2.count().v, 5U);
   ASSERT_EQ(cluster2.getCompression(), zim::zimcompNone);
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(0)).v, blob0.size());
   ASSERT_EQ(cluster2.getBlobSize(zim::blob_index_t(1)).v, blob1.size());
@@ -254,6 +256,7 @@ TEST(ClusterTest, read_write_extended_cluster)
   ASSERT_EQ(blob0, std::string(cluster2.getBlob(zim::blob_index_t(0))));
   ASSERT_EQ(blob1, std::string(cluster2.getBlob(zim::blob_index_t(1))));
   ASSERT_EQ(blob2, std::string(cluster2.getBlob(zim::blob_index_t(2))));
+  ASSERT_EQ(blob4, std::string(cluster2.getBlob(zim::blob_index_t(4))));
 }
 
 

--- a/test/tools.h
+++ b/test/tools.h
@@ -34,6 +34,7 @@
 #endif
 
 #include "../src/buffer.h"
+#include <limits.h>
 
 namespace zim
 {
@@ -109,8 +110,15 @@ zim::Buffer write_to_buffer(const T& object)
 
   auto buf = zim::Buffer::makeBuffer(zim::zsize_t(size));
   LSEEK(tmp_fd, 0, SEEK_SET);
-  if (read(tmp_fd, const_cast<char*>(buf.data()), size) == -1)
-    throw std::runtime_error("Cannot read");
+  char* p = const_cast<char*>(buf.data());
+  while ( size != 0 ) {
+    const auto size_to_read = std::min(size_type(size), size_type(INT_MAX));
+    const auto n = read(tmp_fd, p, size_to_read);
+    if ( n == -1)
+      throw std::runtime_error("Cannot read");
+    p += n;
+    size -= n;
+  }
   return buf;
 }
 


### PR DESCRIPTION
Should fix #551 (though this is speculative, since the change wasn't validated on the ZIM file of that crash report).

1. The `ClusterTest.read_write_extended_cluster` unit-test was modified to demonstrate the alleged problem causing the crash reported in #551.
2. Then the problem was fixed.
3. However the modified unit-test revealed a Windows-only bug in the `zim::unittests::write_to_buffer()` function. That bug was always triggered by the test, however its effects went unnoticed because the test wasn't elaborate enough. This bug was fixed too.
4. The `ClusterTest.read_write_extended_cluster` unit-test was further improved, so that it can catch similar bugs in the future.