### PR TITLE
Better clusterSize configuration.

### DIFF
--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -74,15 +74,23 @@ namespace zim
         Creator& configCompression(CompressionType comptype);
 
         /**
-         * Set the minimum size of the cluster.
+         * Set the size of the created clusters.
          *
-         * Creator will try to create cluster with this minimum size
-         * (uncompressed size).
+         * The creator will try to create cluster with (uncompressed) size
+         * as close as possible to targetSize without exceeding that limit.
+         * If not possible, the only such case being an item larger than targetSize,
+         * a separated cluster will be allocated for that oversized item.
          *
-         * @param size The minimum size of a cluster.
+         * Be carefull with this value.
+         * Bigger value means more content put together, so a better compression ratio.
+         * But it means also that more decompression has to be made when reading a blob.
+         * If you don't know which value to put, don't use this method and let libzim
+         * use the default value.
+         *
+         * @param targetSize The target size of a cluster (in byte).
          * @return a reference to itself.
          */
-        Creator& configMinClusterSize(zim::size_type size);
+        Creator& configClusterSize(zim::size_type targetSize);
 
         /**
          * Configure the fulltext indexing feature.
@@ -183,7 +191,7 @@ namespace zim
         bool m_verbose = false;
         CompressionType m_compression = zimcompZstd;
         bool m_withIndex = false;
-        size_t m_minClusterSize = 1024-64;
+        size_t m_clusterSize;
         std::string m_indexingLanguage;
         unsigned m_nbWorkers = 4;
 

--- a/src/compression.h
+++ b/src/compression.h
@@ -13,6 +13,7 @@
 #include <zstd.h>
 
 #include "zim_types.h"
+#include "constants.h"
 
 //#define DEB(X) std::cerr << __func__ << " " << X << std::endl ;
 #define DEB(X)
@@ -83,7 +84,7 @@ template<typename INFO>
 class Uncompressor
 {
   public:
-    Uncompressor(size_t initial_size=1024*1024) :
+    Uncompressor(size_t initial_size) :
       ret_data(new char[initial_size]),
       data_size(initial_size)
     {}
@@ -164,8 +165,8 @@ std::unique_ptr<char[]> uncompress(const zim::Reader* reader, zim::offset_t star
   // Use a compressor to compress the data.
   // As we don't know the result size, neither the compressed size,
   // we have to do chunk by chunk until decompressor is happy.
-  // Let's assume it will be something like the minChunkSize used at creation
-  Uncompressor<INFO> runner(1024*1024);
+  // Let's assume it will be something like the default clusterSize used at creation
+  Uncompressor<INFO> runner(DEFAULT_CLUSTER_SIZE);
   // The input is a buffer of CHUNCK_SIZE char max. It may be less if the last chunk
   // is at the end of the reader and the reader size is not a multiple of CHUNCK_SIZE.
   std::vector<char> raw_data(CHUNCK_SIZE);

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,3 +18,5 @@
  */
 
 #define ANCHOR_TERM "0posanchor "
+
+#define DEFAULT_CLUSTER_SIZE 1024*1024

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -61,7 +61,8 @@ namespace zim
 
         CreatorData(const std::string& fname, bool verbose,
                        bool withIndex, std::string language,
-                       CompressionType compression);
+                       CompressionType compression,
+                       size_t clusterSize);
         virtual ~CreatorData();
 
         void addDirent(Dirent* dirent);
@@ -79,7 +80,6 @@ namespace zim
         uint16_t getMimeTypeIdx(const std::string& mimeType);
         const std::string& getMimeType(uint16_t mimeTypeIdx) const;
 
-        size_t minChunkSize = 1024-64;
 
         DirentPool  pool;
 
@@ -101,7 +101,7 @@ namespace zim
         std::string zimName;
         std::string tmpFileName;
         bool isEmpty = true;
-        zsize_t clustersSize;
+        size_t clusterSize;
         Cluster *compCluster = nullptr;
         Cluster *uncompCluster = nullptr;
         int out_fd;
@@ -140,9 +140,6 @@ namespace zim
 
         entry_index_t itemCount() const
         { return entry_index_t(dirents.size()); }
-
-        size_t getMinChunkSize()    { return minChunkSize; }
-        void setMinChunkSize(size_t s)   { minChunkSize = s; }
     };
 
   }


### PR DESCRIPTION
- Rename minChunkSize/minClusterSize to clusterSize.
- Better doc string
- Change default value.
- Set the `creatorData::clusterSize` in the constructor.
  . No need for setter/getter
  . No need to have another default value.
- The already existing `creatorData::clusterSize` was not used,
  let's use it instead of `minChunkSize`.

Fix #553 