### PR TITLE
Add a new method search_iterator::get_zimId

### DIFF
--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <iterator>
 #include "entry.h"
+#include "uuid.h"
 
 namespace zim
 {
@@ -53,6 +54,7 @@ class search_iterator : public std::iterator<std::bidirectional_iterator_tag, En
         int get_wordCount() const;
         int get_size() const;
         int get_fileIndex() const;
+        Uuid get_zimId() const;
         reference operator*() const;
         pointer operator->() const;
 

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -238,6 +238,13 @@ int search_iterator::get_fileIndex() const {
     return 0;
 }
 
+Uuid search_iterator::get_zimId() const {
+    if (! internal ) {
+        throw std::runtime_error("Cannot get zimId from uninitialized iterator");
+    }
+    return internal->mp_internalDb->m_archives.at(get_fileIndex()).getUuid();
+}
+
 search_iterator::reference search_iterator::operator*() const {
     if (! internal ) {
         throw std::runtime_error("Cannot get a entry for a uninitialized iterator");

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -39,6 +39,7 @@ TEST(search_iterator, uninitialized) {
   ASSERT_EQ(it.get_fileIndex(), 0);
   ASSERT_EQ(it.get_wordCount(), -1);
   ASSERT_EQ(it.get_size(), -1);
+  ASSERT_THROW(it.get_zimId(), std::runtime_error);
   ASSERT_THROW(*it, std::runtime_error);
   ASSERT_THROW(it.operator->(), std::runtime_error);
 }
@@ -114,6 +115,7 @@ TEST(search_iterator, functions) {
   ASSERT_EQ(it.get_path(), "dummyPathitem a");
   ASSERT_EQ(it.get_score(), 100);
   ASSERT_EQ(it.get_fileIndex(), 0);
+  ASSERT_EQ(it.get_zimId(), archive.getUuid());
   ASSERT_EQ(it.get_wordCount(), -1);            // Unimplemented
   ASSERT_EQ(it.get_size(), -1);                 // Unimplemented
 }


### PR DESCRIPTION
Fixes #556 

Currently, users have to maintain a vector of Zim archives to track the archive from which a particular result is retrieved. Having a search iterator method `get_zimId` can let the user get the UUID of the archive from the search result itself.

Changes included in this PR:
- Adds the method `search_iterator::get_zimId()`
- Adds a test case to confirm this behavior