### PR TITLE
Fix snippet highlighting for stemmed terms

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -157,8 +157,8 @@ InternalDataBase::InternalDataBase(const std::vector<Archive>& archives, bool su
                 icu::Locale languageLocale(language.c_str());
                 /* Configuring language base steemming */
                 try {
-                    Xapian::Stem stemmer = Xapian::Stem(languageLocale.getLanguage());
-                    m_queryParser.set_stemmer(stemmer);
+                    m_stemmer = Xapian::Stem(languageLocale.getLanguage());
+                    m_queryParser.set_stemmer(m_stemmer);
                     m_queryParser.set_stemming_strategy(
                     hasNewSuggestionFormat ? Xapian::QueryParser::STEM_SOME : Xapian::QueryParser::STEM_ALL);
                 } catch (...) {

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -65,6 +65,9 @@ class InternalDataBase {
 
     // The query parser corresponding to the database.
     Xapian::QueryParser m_queryParser;
+
+    // The stemmer used to parse queries
+    Xapian::Stem m_stemmer;
 };
 
 struct search_iterator::InternalData {

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -161,7 +161,7 @@ std::string search_iterator::get_snippet() const {
     if ( internal->mp_internalDb->m_suggestionMode )
     {
         try {
-            return internal->mp_mset->snippet(get_title(), 500);
+            return internal->mp_mset->snippet(get_title(), 500, internal->mp_internalDb->m_stemmer);
         } catch(...) {
             return "";
         }
@@ -191,7 +191,7 @@ std::string search_iterator::get_snippet() const {
         try {
           htmlParser.parse_html(content, "UTF-8", true);
         } catch (...) {}
-        return internal->mp_mset->snippet(htmlParser.dump, 500);
+        return internal->mp_mset->snippet(htmlParser.dump, 500, internal->mp_internalDb->m_stemmer);
     } catch (...) {
       return "";
     }

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -120,6 +120,33 @@ TEST(search_iterator, functions) {
   ASSERT_EQ(it.get_size(), -1);                 // Unimplemented
 }
 
+TEST(search_iterator, stemmedSearch) {
+  TempZimArchive tza("testZim");
+
+  // The following stemming occurs
+  // apple -> appl
+  // charlie -> charli
+  // chocolate -> chocol
+  // factory -> factori
+  zim::Archive archive = tza.createZimFromTitles({
+    "an apple a day, keeps the doctor away",
+    "charlie and the chocolate factory"
+  });
+
+  zim::Searcher searcher(archive);
+  zim::Query query;
+  query.setQuery("apples", true);
+  auto search = searcher.search(query);
+  auto result = search.getResults(0, 1);
+
+  ASSERT_EQ(result.begin().get_snippet(), "an <b>apple</b> a day, keeps the doctor away");
+
+  query.setQuery("chocolate factory", true);
+  search = searcher.search(query);
+  result = search.getResults(0, 1);
+  ASSERT_EQ(result.begin().get_snippet(), "charlie and the <b>chocolate</b> <b>factory</b>");
+}
+
 TEST(search_iterator, iteration) {
   TempZimArchive tza("testZim");
 


### PR DESCRIPTION
Fixes #86 

We address this issue by introducing a new member variable `m_stemmer` that stores the stemmer used for parsing queries by the `InternalDataBase::m_queryparser`. We use this stemmer as a parameter in `Xapian::MSet::snippet` which fixes this issue.

The changes included in this PR are:
- Adds a unit test `stemmedSearch` that demonstrates the expected behavior
- Introduce a member variable `m_stemmer`
- Use `m_stemmer` as a parameter while generating the snippet