### PR TITLE
Check decompression status in DecoderStreamReader.

### DIFF
--- a/src/compression.h
+++ b/src/compression.h
@@ -27,7 +27,6 @@ enum class CompStatus {
   OK,
   STREAM_END,
   BUF_ERROR,
-  OTHER
 };
 
 enum class RunnerStatus {
@@ -99,43 +98,49 @@ class Uncompressor
     RunnerStatus feed(char* data, size_t size, CompStep step = CompStep::STEP) {
       stream.next_in = (unsigned char*)data;
       stream.avail_in = size;
-      auto errcode = CompStatus::OTHER;
       while (true) {
-        errcode = INFO::stream_run_decode(&stream, step);
+        auto errcode = INFO::stream_run_decode(&stream, step);
         DEB((int)errcode)
-        if (errcode == CompStatus::BUF_ERROR) {
-          if (stream.avail_in == 0 && stream.avail_out != 0)  {
-            // End of input stream.
-            // compressor hasn't recognize the end of the input stream but there is
-            // no more input.
-            return RunnerStatus::NEED_MORE;
-          } else {
-            //Not enought output size
-            DEB("need memory " << data_size << " " << stream.avail_out << " " << stream.total_out)
-            data_size *= 2;
-            std::unique_ptr<char[]> new_ret_data(new char[data_size]);
-            memcpy(new_ret_data.get(), ret_data.get(), stream.total_out);
-            stream.next_out = (unsigned char*)(new_ret_data.get() + stream.total_out);
-            stream.avail_out = data_size - stream.total_out;
-            DEB(data_size << " " << stream.avail_out << " " << stream.avail_in)
-            ret_data = std::move(new_ret_data);
-            continue;
-          }
-        }
-        if (errcode == CompStatus::STREAM_END)
-          break;
-        // On first call where lzma cannot progress (no output size).
-        // Lzma return OK. If we return NEED_MORE, then we will try to compress
-        // with new input data, but we should not as current one is not processed.
-        // We must do a second step to have te BUF_ERROR and handle thing correctly.
-        if (errcode == CompStatus::OK) {
-          if (stream.avail_in == 0)
+        switch (errcode) {
+          case CompStatus::BUF_ERROR:
+            if (stream.avail_in == 0 && stream.avail_out != 0)  {
+              // End of input stream.
+              // compressor hasn't recognize the end of the input stream but there is
+              // no more input.
+              return RunnerStatus::NEED_MORE;
+            } else {
+              // Not enought output size.
+              // Allocate more memory and continue the loop.
+              DEB("need memory " << data_size << " " << stream.avail_out << " " << stream.total_out)
+              data_size *= 2;
+              std::unique_ptr<char[]> new_ret_data(new char[data_size]);
+              memcpy(new_ret_data.get(), ret_data.get(), stream.total_out);
+              stream.next_out = (unsigned char*)(new_ret_data.get() + stream.total_out);
+              stream.avail_out = data_size - stream.total_out;
+              DEB(data_size << " " << stream.avail_out << " " << stream.avail_in)
+              ret_data = std::move(new_ret_data);
+            }
             break;
-          continue;
+          case CompStatus::OK:
+            // On first call where lzma cannot progress (no output size).
+            // Lzma return OK. If we return NEED_MORE, then we will try to compress
+            // with new input data, but we should not as current one is not processed.
+            // We must do a second step to have te BUF_ERROR and handle thing correctly.
+            // If we have no more input, then we must ask for more.
+            if (stream.avail_in == 0) {
+              return RunnerStatus::NEED_MORE;
+            }
+            break;
+          case CompStatus::STREAM_END:
+            // End of compressed stream. Everything is ok.
+            return RunnerStatus::OK;
+          default:
+            // unreachable
+            return RunnerStatus::ERROR;
         }
-        return RunnerStatus::ERROR;
       };
-      return errcode==CompStatus::STREAM_END?RunnerStatus::OK:RunnerStatus::NEED_MORE;
+      // unreachable
+      return RunnerStatus::NEED_MORE;
     }
 
     std::unique_ptr<char[]> get_data(zim::zsize_t* size) {
@@ -216,16 +221,20 @@ class Compressor
     RunnerStatus feed(const char* data, size_t size, CompStep step=CompStep::STEP) {
       stream.next_in = (unsigned char*)data;
       stream.avail_in = size;
-      auto errcode = CompStatus::OTHER;
       while (true) {
-        errcode = INFO::stream_run_encode(&stream, step);
-        if (stream.avail_out == 0) {
-          if (errcode == CompStatus::OK) {
-            // lzma return a OK return status the first time it runs out of output memory.
-            // The BUF_ERROR is returned only the second time we call a lzma_code.
-            continue;
-          }
-          if (errcode == CompStatus::BUF_ERROR) {
+        auto errcode = INFO::stream_run_encode(&stream, step);
+        switch (errcode) {
+          case CompStatus::OK:
+            if (stream.avail_out == 0) {
+              // lzma return a OK return status the first time it runs out of output memory.
+              // The BUF_ERROR is returned only the second time we call a lzma_code.
+              continue;
+            } else {
+              return RunnerStatus::NEED_MORE;
+            }
+          case CompStatus::STREAM_END:
+            return RunnerStatus::NEED_MORE;
+          case CompStatus::BUF_ERROR: {
             //Not enought output size
             ret_size *= 2;
             std::unique_ptr<char[]> new_ret_data(new char[ret_size]);
@@ -235,13 +244,13 @@ class Compressor
             ret_data = std::move(new_ret_data);
             continue;
           }
-        }
-        if (errcode == CompStatus::STREAM_END || errcode == CompStatus::OK) {
-          // Everything ok, quit the loop
           break;
-        }
-        return RunnerStatus::ERROR;
+          default:
+            // unreachable
+            return RunnerStatus::ERROR;
+        };
       };
+      // urreachable
       return RunnerStatus::NEED_MORE;
     }
 

--- a/src/concurrent_cache.h
+++ b/src/concurrent_cache.h
@@ -66,7 +66,14 @@ public: // types
     const auto x = impl_.getOrPut(key, valuePromise.get_future().share());
     l.unlock();
     if ( x.miss() ) {
-      valuePromise.set_value(f());
+      try {
+        valuePromise.set_value(f());
+      } catch (std::exception& e) {
+        l.lock();
+        impl_.drop(key);
+        l.unlock();
+        throw;
+      }
     }
 
     return x.value().get();

--- a/src/decoderstreamreader.h
+++ b/src/decoderstreamreader.h
@@ -80,6 +80,10 @@ private: // functions
     m_decoderState.avail_out = nbytes.v;
     while ( m_decoderState.avail_out != 0 )
     {
+      // We don't car of the return code of decodeMoreBytes.
+      // We feed (or stop feeding) the decoder based on what
+      // we need to decode and the `avail_in`.
+      // If there is a error somehow, a exception will be thrown.
       decodeMoreBytes();
     }
   }

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -117,6 +117,17 @@ public: // functions
     }
   }
 
+  bool drop(const key_t& key) {
+    try {
+      auto list_it = _cache_items_map.at(key);
+      _cache_items_list.erase(list_it);
+      _cache_items_map.erase(key);
+      return true;
+    } catch (std::out_of_range& e) {
+      return false;
+    }
+  }
+
   bool exists(const key_t& key) const {
     return _cache_items_map.find(key) != _cache_items_map.end();
   }

--- a/subprojects/zstd.wrap
+++ b/subprojects/zstd.wrap
@@ -4,7 +4,7 @@ source_url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.
 source_filename = zstd-1.4.5.tar.gz
 source_hash = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
 
-patch_url = https://download.kiwix.org/dev/zstd-1.4.5-wrap.zip
+patch_url = https://mirror.download.kiwix.org/dev/zstd-1.4.5-wrap.zip
 patch_filename = zstd-1.4.5-wrap.zip
 patch_hash = 4462693b58939b61ab76c5e5597343ab156eb0681b60a77908d2b88e17dca7cc
 

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -60,6 +60,24 @@ TEST(CacheTest, MissingValue) {
     EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
 }
 
+TEST(CacheTest, DropValue) {
+    zim::lru_cache<int, int> cache_lru(3);
+    cache_lru.put(7, 777);
+    cache_lru.put(8, 888);
+    cache_lru.put(9, 999);
+    EXPECT_EQ(3, cache_lru.size());
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(777, cache_lru.get(7));
+
+    EXPECT_TRUE(cache_lru.drop(7));
+
+    EXPECT_EQ(2, cache_lru.size());
+    EXPECT_FALSE(cache_lru.exists(7));
+    EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
+
+    EXPECT_FALSE(cache_lru.drop(7));
+}
+
 TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
     zim::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
 

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "lrucache.h"
+#include "concurrent_cache.h"
 #include "gtest/gtest.h"
 
 const int NUM_OF_TEST1_RECORDS = 100;
@@ -96,4 +97,13 @@ TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
 
     size_t size = cache_lru.size();
     EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
+}
+
+TEST(ConcurrentCacheTest, handleException) {
+    zim::ConcurrentCache<int, int> cache(1);
+    auto val = cache.getOrPut(7, []() { return 777; });
+    EXPECT_EQ(val, 777);
+    EXPECT_THROW(cache.getOrPut(8, []() { throw std::runtime_error("oups"); return 0; }), std::runtime_error);
+    val = cache.getOrPut(8, []() { return 888; });
+    EXPECT_EQ(val, 888);
 }


### PR DESCRIPTION
If somehow `Decoder::stream_run_decode` fails,
`m_decoderState.avail_out` will never be updated and we are in a
infinite loop.

We must exit the loop at a moment.

Raising a exception may crash the user code if it doesn't catch it.

For kiwix-serve, we will return a 500 error code but we will still be
running.

See kiwix/libkiwix#515