### PR TITLE
Lower zstd compression level.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ endif
 
 cpp = meson.get_compiler('cpp')
 sizeof_off_t = cpp.sizeof('off_t')
+sizeof_size_t = cpp.sizeof('size_t')
 
 private_conf = configuration_data()
 public_conf = configuration_data()
@@ -20,6 +21,8 @@ private_conf.set('DIRENT_LOOKUP_CACHE_SIZE', get_option('DIRENT_LOOKUP_CACHE_SIZ
 private_conf.set('CLUSTER_CACHE_SIZE', get_option('CLUSTER_CACHE_SIZE'))
 private_conf.set('LZMA_MEMORY_SIZE', get_option('LZMA_MEMORY_SIZE'))
 private_conf.set10('MMAP_SUPPORT_64', sizeof_off_t==8)
+private_conf.set10('ENV64BIT', sizeof_size_t==8)
+private_conf.set10('ENV32BIT', sizeof_size_t==4)
 if target_machine.system() == 'windows'
     private_conf.set('ENABLE_USE_MMAP', false)
     add_project_arguments('-DNOMINMAX', language: 'cpp')

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -94,7 +94,7 @@ void ZSTD_INFO::init_stream_decoder(stream_t* stream, char* raw_data)
 void ZSTD_INFO::init_stream_encoder(stream_t* stream, char* raw_data)
 {
   stream->encoder_stream = ::ZSTD_createCStream();
-  auto ret = ::ZSTD_initCStream(stream->encoder_stream, ::ZSTD_maxCLevel());
+  auto ret = ::ZSTD_initCStream(stream->encoder_stream, 19);
   if (::ZSTD_isError(ret)) {
     throw std::runtime_error("Failed to initialize Zstd compression");
   }

--- a/src/concurrent_cache.h
+++ b/src/concurrent_cache.h
@@ -69,14 +69,18 @@ public: // types
       try {
         valuePromise.set_value(f());
       } catch (std::exception& e) {
-        l.lock();
-        impl_.drop(key);
-        l.unlock();
+        drop(key);
         throw;
       }
     }
 
     return x.value().get();
+  }
+
+  bool drop(const Key& key)
+  {
+    std::unique_lock<std::mutex> l(lock_);
+    return impl_.drop(key);
   }
 
 private: // data

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -16,3 +16,7 @@
 #mesondefine ENABLE_USE_BUFFER_HEADER
 
 #mesondefine MMAP_SUPPORT_64
+
+#mesondefine ENV64BIT
+
+#mesondefine ENV32BIT


### PR DESCRIPTION
The max level (22) set a huge windowSize (128Mb).
It if far too much and we don't even need it (most of our compressed
content is about 1Mb).

By setting a level of 19, the windowSize is 8Mb and
the compression ratio is relativly equivalent.
From lzbench https://github.com/inikep/lzbench the ratio is
24.88 for level 22 and 25.33 for level 18.

See kiwix/libkiwix#515