### PR TITLE
Restored Item::getClusterIndex()

### DIFF
--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -83,6 +83,10 @@ namespace zim
 
       entry_index_type getIndex() const   { return m_idx; }
 
+#ifdef ZIM_PRIVATE
+      cluster_index_type getClusterIndex() const;
+#endif
+
     private: // data
       std::shared_ptr<FileImpl> m_file;
       entry_index_type m_idx;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#define ZIM_PRIVATE
 #include <zim/item.h>
 #include "_dirent.h"
 #include "cluster.h"
@@ -95,4 +96,9 @@ std::pair<std::string, offset_type> Item::getDirectAccessInformation() const
   auto part = first_part->second;
   const offset_type local_offset(full_offset - range.min);
   return std::make_pair(part->filename(), local_offset);
+}
+
+cluster_index_type Item::getClusterIndex() const
+{
+  return m_dirent->getClusterNumber().v;
 }


### PR DESCRIPTION
Needed by openzim/zim-tools#194

`Article::getClusterNumber()` was removed by #454. The work on multithreading of zimcheck (that was already in progress then) relied on that functionality, in order to process items from the same cluster in the same thread. This PR restores the said functionality as ZIM_PRIVATE API.