### PR TITLE
Better methods to get number of entries in a zim archive.

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -113,11 +113,36 @@ namespace zim
        */
       size_type getFilesize() const;
 
-      /** Return the number of entry in the archive.
+      /** Return the number of entries in the archive.
        *
-       *  @return the number of entry in the archive.
+       * Return the total number of entries in the archive, including
+       * internal entries created by libzim itself, metadata, indexes, ...
+       *
+       *  @return the number of user entries in the archive.
+       */
+      entry_index_type getAllEntryCount() const;
+
+      /** Return the number of user entries in the archive.
+       *
+       * If the notion of "user entries" doesn't exist in the zim archive,
+       * returns `getAllEntryCount()`.
+       *
+       *  @return the number of user entries in the archive.
        */
       entry_index_type getEntryCount() const;
+
+      /** Return the number of articles in the archive.
+       *
+       *  The definition of "article" depends of the zim archive.
+       *  On recent archives, this correspond to all entries marked as "FRONT_ARTICLE"
+       *  at creaton time.
+       *  On old archives, this correspond to all entries in 'A' namespace.
+       *  Few archives may have been created without namespace but also withuut specific
+       *  article listing. In this case, articles are all user entries.
+       *
+       *  @return the number of articles in the archive.
+       */
+      entry_index_type getArticleCount() const;
 
       /** The uuid of the archive.
        *
@@ -289,7 +314,9 @@ namespace zim
 
       /** Get a "iterable" by path order.
        *
-       *  This method allow to iterate hover the entries in a path order
+       *  This method allow to iterate on all user entries using a path order.
+       *  If the notion of "user entries" doesn't exists (for old zim archive),
+       *  this iterate on all entries in the zim file.
        *
        *  ```
        *  for(auto& entry:archive.iterByPath()) {
@@ -303,7 +330,13 @@ namespace zim
 
       /** Get a "iterable" by title order.
        *
-       *  This method allow to iterate hover the entries in a title order
+       *  This method allow to iterate on all articles using a title order.
+       *  The definition of "article" depends of the zim archive.
+       *  On recent archives, this correspond to all entries marked as "FRONT_ARTICLE"
+       *  at creaton time.
+       *  On old archives, this correspond to all entries in 'A' namespace.
+       *  Few archives may have been created without namespace but also withuut specific
+       *  article listing. In this case, this iterate on all user entries.
        *
        *  ```
        *  for(auto& entry:archive.iterByTitle()) {
@@ -317,7 +350,9 @@ namespace zim
 
       /** Get a "iterable" by a efficient order.
        *
-       *  This method allow to iterate hover the entries in a efficient order
+       *  This method allow to iterate on all user entries using a effictient order.
+       *  If the notion of "user entries" doesn't exists (for old zim archive),
+       *  this iterate on all entries in the zim file.
        *
        *  ```
        *  for(auto& entry:archive.iterEfficient()) {

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -118,7 +118,7 @@ namespace zim
        * Return the total number of entries in the archive, including
        * internal entries created by libzim itself, metadata, indexes, ...
        *
-       *  @return the number of user entries in the archive.
+       *  @return the number of all entries in the archive.
        */
       entry_index_type getAllEntryCount() const;
 
@@ -137,7 +137,7 @@ namespace zim
        *  On recent archives, this correspond to all entries marked as "FRONT_ARTICLE"
        *  at creaton time.
        *  On old archives, this correspond to all entries in 'A' namespace.
-       *  Few archives may have been created without namespace but also withuut specific
+       *  Few archives may have been created without namespace but also without specific
        *  article listing. In this case, articles are all user entries.
        *
        *  @return the number of articles in the archive.
@@ -335,7 +335,7 @@ namespace zim
        *  On recent archives, this correspond to all entries marked as "FRONT_ARTICLE"
        *  at creaton time.
        *  On old archives, this correspond to all entries in 'A' namespace.
-       *  Few archives may have been created without namespace but also withuut specific
+       *  Few archives may have been created without namespace but also without specific
        *  article listing. In this case, this iterate on all user entries.
        *
        *  ```

--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -154,20 +154,23 @@ namespace zim
          * @param mimetype the mimetype of the item.
          * @param title the title of the item.
          */
-        BasicItem(const std::string& path, const std::string& mimetype, const std::string& title)
+        BasicItem(const std::string& path, const std::string& mimetype, const std::string& title, Hints hints)
           : path(path),
             mimetype(mimetype),
-            title(title)
+            title(title),
+            hints(hints)
         {}
 
         std::string getPath() const { return path; }
         std::string getTitle() const { return title; }
         std::string getMimeType() const { return mimetype; }
+        Hints       getHints() const { return hints; }
 
       protected:
         std::string path;
         std::string mimetype;
         std::string title;
+        Hints hints;
     };
 
     /**
@@ -198,8 +201,8 @@ namespace zim
 
       private:
         StringItem(const std::string& path, const std::string& mimetype,
-                   const std::string& title, const std::string& content)
-          : BasicItem(path, mimetype, title),
+                   const std::string& title, Hints hints, const std::string& content)
+          : BasicItem(path, mimetype, title, hints),
             content(content)
         {}
 
@@ -222,8 +225,8 @@ namespace zim
          * @param filepath the path of the file in the filesystem.
          */
         FileItem(const std::string& path, const std::string& mimetype,
-                 const std::string& title, const std::string& filepath)
-          : BasicItem(path, mimetype, title),
+                 const std::string& title, Hints hints, const std::string& filepath)
+          : BasicItem(path, mimetype, title, hints),
             filepath(filepath)
         {}
 

--- a/scripts/download_test_data.py
+++ b/scripts/download_test_data.py
@@ -27,7 +27,7 @@ import tarfile
 import sys
 
 TEST_DATA_VERSION = "0.3"
-ARCHIVE_URL_TEMPL = "https://github.com/openzim/zim-testing-suite/releases/download/v{version}/zim-testing-suite-{version}.tar.gz"
+ARCHIVE_URL_TEMPL = "https://github.com/openzim/zim-testing-suite/releases/download/v{version}-alpha/zim-testing-suite-{version}.tar.gz"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -110,6 +110,9 @@ namespace zim
 
       entry_index_t getNamespaceBeginOffset(char ch);
       entry_index_t getNamespaceEndOffset(char ch);
+      entry_index_t getNamespaceEntryCount(char ch) {
+        return getNamespaceEndOffset(ch) - getNamespaceBeginOffset(ch);
+      }
 
       entry_index_t getStartUserEntry() const { return m_startUserEntry; }
       entry_index_t getEndUserEntry() const { return m_endUserEntry; }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -153,10 +153,10 @@ TEST(ZimArchive, openCreatedArchive)
   creator.setUuid(uuid);
   creator.configIndexing(true, "eng");
   creator.startZimCreation(tempPath);
-  auto item = std::make_shared<TestItem>("foo", "text/html", "Foo", "FooContent");
+  auto item = std::make_shared<TestItem>("foo", "text/html", "Foo", "FooContent", true);
   creator.addItem(item);
   // Be sure that title order is not the same that url order
-  item = std::make_shared<TestItem>("foo2", "text/html", "AFoo", "Foo2Content");
+  item = std::make_shared<TestItem>("foo2", "text/html", "AFoo", "Foo2Content", false);
   creator.addItem(item);
   creator.addMetadata("Title", "This is a title");
   creator.addIllustration(48, "PNGBinaryContent48");
@@ -169,7 +169,7 @@ TEST(ZimArchive, openCreatedArchive)
   zim::Archive archive(tempPath);
   ASSERT_EQ(archive.getAllEntryCount(), 12);
   ASSERT_EQ(archive.getEntryCount(), 3);
-  ASSERT_EQ(archive.getArticleCount(), 0);
+  ASSERT_EQ(archive.getArticleCount(), 1);
   ASSERT_EQ(archive.getUuid(), uuid);
   ASSERT_EQ(archive.getMetadataKeys(), std::vector<std::string>({"Counter", "Illustration_48x48@1", "Illustration_96x96@1", "Title"}));
   ASSERT_EQ(archive.getIllustrationSizes(), std::set<unsigned int>({48, 96}));

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -167,7 +167,15 @@ TEST(ZimArchive, openCreatedArchive)
   creator.finishZimCreation();
 
   zim::Archive archive(tempPath);
-  ASSERT_EQ(archive.getAllEntryCount(), 12);
+#if !defined(ENABLE_XAPIAN)
+// 2*listingIndex + M/Counter + M/Title + mainpage + 2*Illustration + 2*Item + redirection
+#define ALL_ENTRY_COUNT 10
+#else
+// same as above + 2 xapian indexes.
+#define ALL_ENTRY_COUNT 12
+#endif
+  ASSERT_EQ(archive.getAllEntryCount(), ALL_ENTRY_COUNT);
+#undef ALL_ENTRY_COUNT
   ASSERT_EQ(archive.getEntryCount(), 3);
   ASSERT_EQ(archive.getArticleCount(), 1);
   ASSERT_EQ(archive.getUuid(), uuid);

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -167,7 +167,9 @@ TEST(ZimArchive, openCreatedArchive)
   creator.finishZimCreation();
 
   zim::Archive archive(tempPath);
+  ASSERT_EQ(archive.getAllEntryCount(), 12);
   ASSERT_EQ(archive.getEntryCount(), 3);
+  ASSERT_EQ(archive.getArticleCount(), 0);
   ASSERT_EQ(archive.getUuid(), uuid);
   ASSERT_EQ(archive.getMetadataKeys(), std::vector<std::string>({"Counter", "Illustration_48x48@1", "Illustration_96x96@1", "Title"}));
   ASSERT_EQ(archive.getIllustrationSizes(), std::set<unsigned int>({48, 96}));

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -273,6 +273,59 @@ TEST(ZimArchive, illustration)
     }
   }
 }
+
+TEST(ZimArchive, articleNumber)
+{
+  const char* const zimfiles[] = {
+    "small.zim",
+    "wikibooks_be_all_nopic_2017-02.zim",
+    "wikibooks_be_all_nopic_2017-02_splitted.zim",
+    "wikipedia_en_climate_change_nopic_2020-01.zim"
+  };
+
+  for ( const std::string fname : zimfiles ) {
+    for (auto& testfile: getDataFilePath(fname)) {
+      const TestContext ctx{ {"path", testfile.path } };
+      const zim::Archive archive(testfile.path);
+      if (testfile.filename == "small.zim") {
+        if (testfile.category == "withns") {
+          // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
+          EXPECT_EQ( archive.getAllEntryCount(), 17 ) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 17 ) << ctx;
+        } else {
+          EXPECT_EQ( archive.getAllEntryCount(), 16 ) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 2 ) << ctx;
+        }
+        // There is always 1 article, whatever the article is in 'A' namespace or in specific index.
+        EXPECT_EQ( archive.getArticleCount(), 1 ) << ctx;
+      } else if (testfile.filename == "wikipedia_en_climate_change_nopic_2020-01.zim") {
+        if (testfile.category == "withns") {
+          // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
+          EXPECT_EQ( archive.getAllEntryCount(), 7646 ) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 7646 ) << ctx;
+          // Only 7253 entry in 'A' namespace.
+          EXPECT_EQ( archive.getArticleCount(), 7253 ) << ctx;
+        } else {
+          EXPECT_EQ( archive.getAllEntryCount(), 7649 ) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 7633 ) << ctx;
+          EXPECT_EQ( archive.getArticleCount(), 1837 ) << ctx;
+        }
+      } else {
+        if (testfile.category == "withns") {
+          // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
+          EXPECT_EQ( archive.getAllEntryCount(), 118) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 118 ) << ctx;
+          // Only 70 entry in 'A' namespace.
+          EXPECT_EQ( archive.getArticleCount(), 70 ) << ctx;
+        } else {
+          EXPECT_EQ( archive.getAllEntryCount(), 123 ) << ctx;
+          EXPECT_EQ( archive.getEntryCount(), 109 ) << ctx;
+          EXPECT_EQ( archive.getArticleCount(), 66 ) << ctx;
+        }
+      }
+    }
+  }
+}
 #endif
 
 class CapturedStderr

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -98,10 +98,16 @@ TEST(IteratorTests, begin)
 // ByTitle
 TEST(IteratorTests, beginByTitle)
 {
-    std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 7, 8, 9, 10};
+    std::vector<zim::entry_index_type> expected = { 5, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
         zim::Archive archive (testfile.path);
+        std::vector<zim::entry_index_type> expected;
+        if (testfile.category == "withns") {
+          expected = { 5, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        } else {
+          expected = { 41, 42, 43, 44, 45, 46, 47, 48, 49, 50};
+        }
 
         auto it = archive.iterByTitle().begin();
 

--- a/test/tools.h
+++ b/test/tools.h
@@ -148,13 +148,29 @@ class TempZimArchive : zim::unittests::TempFile {
 
 class TestItem : public zim::writer::Item {
   public:
-    TestItem(const std::string& path, const std::string& mimetype = "text/html", const std::string& title = "Test Item", const std::string& content = "foo") :
-      path(path), title(title), content(content), mimetype(mimetype) {}
+    TestItem(
+        const std::string& path,
+        const std::string& mimetype = "text/html",
+        const std::string& title = "Test Item",
+        const std::string& content = "foo",
+        bool frontArticle = true) :
+      path(path),
+      title(title),
+      content(content),
+      mimetype(mimetype),
+      frontArticle(frontArticle)
+    {}
     virtual ~TestItem() = default;
 
     virtual std::string getPath() const { return path; };
     virtual std::string getTitle() const { return title; };
     virtual std::string getMimeType() const { return mimetype; };
+    virtual zim::writer::Hints getHints() const {
+      if (frontArticle) {
+        return zim::writer::Hints{{zim::writer::FRONT_ARTICLE, 1}};
+      }
+      return zim::writer::Hints();
+    }
 
     virtual std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const {
       return std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(content));
@@ -164,6 +180,7 @@ class TestItem : public zim::writer::Item {
   std::string title;
   std::string content;
   std::string mimetype;
+  bool frontArticle;
 };
 
 } // namespace unittests


### PR DESCRIPTION
Fix #514 

This PR is base on #540 mainly to reuse the test data and avoid two branch with parallel test data versions.
In consequence, of this PR, new test data is generated (to have correctly set front articles)
The corresponding PR on zim-tools side is https://github.com/openzim/zim-tools/pull/246 and zim-testing-suite v3.0 alpha has been updated.