### PR TITLE
Add to_str() method to Uuid

### DIFF
--- a/include/zim/uuid.h
+++ b/include/zim/uuid.h
@@ -47,6 +47,8 @@ namespace zim
       { return !(*this == other); }
     unsigned size() const  { return 16; }
 
+    explicit operator std::string() const;
+
     char data[16];
   };
 

--- a/src/uuid.cpp
+++ b/src/uuid.cpp
@@ -19,6 +19,7 @@
 
 #include <zim/uuid.h>
 #include <iostream>
+#include <sstream>
 #include <time.h>
 #include <zim/zim.h> // necessary to have the new types
 #include "log.h"
@@ -78,6 +79,13 @@ namespace zim
     log_debug("generated uuid: " << ret.data);
 
     return ret;
+  }
+
+  Uuid::operator std::string() const
+  {
+    std::ostringstream out;
+    zim::operator<<(out, *this);
+    return out.str();
   }
 
   std::ostream& operator<< (std::ostream& out, const Uuid& uuid)

--- a/test/uuid.cpp
+++ b/test/uuid.cpp
@@ -114,5 +114,6 @@ TEST(UuidTest, output)
   out << uuid;
   std::string s = out.str();
   ASSERT_EQ(s, "550e8400-e29b-41d4-a716-446655440000");
+  ASSERT_EQ((std::string)uuid, "550e8400-e29b-41d4-a716-446655440000");
 }
 };


### PR DESCRIPTION
Fixes #581 

This PR adds a method `Uuid::to_str()` to Uuid. It combines the existing methods and directly returns a string cast for the uuid.

Changes included in this PR:
- Add method `Uuid::to_str()`
- Add a unit test for `Uuid::to_str()`