### PR TITLE
Fix getTitle to return the actual title

### DIFF
--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -133,16 +133,7 @@ std::string SearchIterator::getTitle() const {
     if ( ! internal ) {
         return "";
     }
-    if ( ! internal->mp_internalDb->hasValuesmap() )
-    {
-        /* This is the old legacy version. Guess and try */
-        return internal->get_document().get_value(0);
-    }
-    else if ( internal->mp_internalDb->hasValue("title") )
-    {
-        return internal->get_document().get_value(internal->mp_internalDb->valueSlot("title"));
-    }
-    return "";
+    return internal->get_entry().getTitle();
 }
 
 int SearchIterator::getScore() const {

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -100,6 +100,8 @@ TEST(search_iterator, functions) {
 
   zim::Archive archive = tza.createZimFromTitles({
     "item a",
+    "Item B",
+    "iTem ć"
   });
 
   zim::Searcher searcher(archive);
@@ -118,6 +120,12 @@ TEST(search_iterator, functions) {
   ASSERT_EQ(it.getZimId(), archive.getUuid());
   ASSERT_EQ(it.getWordCount(), -1);            // Unimplemented
   ASSERT_EQ(it.getSize(), -1);                 // Unimplemented
+
+  // Check getTitle for accents/cased text
+  it++;
+  ASSERT_EQ(it.getTitle(), "Item B");
+  it++;
+  ASSERT_EQ(it.getTitle(), "iTem ć");
 }
 
 TEST(search_iterator, stemmedSearch) {


### PR DESCRIPTION
Fixes #584 
SearchIterator::getTitle() should return the actual title of the entry rather than returning it from the valuesmap which is unaccented.