### PR TITLE
Do not build packages for groovy distribution (20.10)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,6 @@ jobs:
           - debian-buster
           - ubuntu-impish
           - ubuntu-hirsute
-          - ubuntu-groovy
           - ubuntu-focal
           - ubuntu-bionic
     steps:
@@ -71,14 +70,6 @@ jobs:
         if: matrix.distro == 'ubuntu-hirsute'
         name: Build package for ubuntu-hirsute
         id: build-ubuntu-hirsute
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
-
-      - uses: legoktm/gh-action-build-deb@ubuntu-groovy
-        if: matrix.distro == 'ubuntu-groovy'
-        name: Build package for ubuntu-groovy
-        id: build-ubuntu-groovy
         with:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}


### PR DESCRIPTION
Groovy reaches its end of life.

Failing CI is https://github.com/openzim/libzim/actions/runs/1071601511

@legoktm please confirm we can remove groovy packages.