### PR TITLE
Fix documentation of getResults

### DIFF
--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -167,10 +167,10 @@ class Search
          *
          * @param start The begining of the range to get
          *              (offset of the first result).
-         * @param end   The end of the range to get
-         *              (offset of the result past the end of the range).
+         * @param maxResults The maximum number of results to return
+         *                   (offset of last result from the start of range).
          */
-        const SearchResultSet getResults(int start, int end) const;
+        const SearchResultSet getResults(int start, int maxResults) const;
 
         /** Get the number of estimated results for this search.
          *

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -357,10 +357,10 @@ int Search::getEstimatedMatches() const
     }
 }
 
-const SearchResultSet Search::getResults(int start, int end) const {
+const SearchResultSet Search::getResults(int start, int maxResults) const {
     try {
       auto enquire = getEnquire();
-      auto mset = enquire.get_mset(start, end);
+      auto mset = enquire.get_mset(start, maxResults);
       return SearchResultSet(mp_internalDb, std::move(mset));
     } catch(Xapian::QueryParserError& e) {
       return SearchResultSet(mp_internalDb);

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -172,8 +172,8 @@ TEST(Search, multiSearch)
   ASSERT_EQ(result2.size(), 3);
 
   // Check result retrieval in middle ranges
-  auto result3 = search0.getResults(2, 3);    // Should Return 1 result
-  ASSERT_EQ(result3.size(), 1);               // Fails!
+  auto result3 = search0.getResults(2, 3);    // Should Return 3 result
+  ASSERT_EQ(result3.size(), 3);
 
   // Be able to do a different search using the same searcher.
   query.setQuery("super", false);

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -167,6 +167,14 @@ TEST(Search, multiSearch)
   it1++;it1++;it1++;
   ASSERT_EQ(it1, result1.end());
 
+  // Check result retrieval in start ranges
+  auto result2 = search0.getResults(0, 3);    // Should return 3 results
+  ASSERT_EQ(result2.size(), 3);
+
+  // Check result retrieval in middle ranges
+  auto result3 = search0.getResults(2, 3);    // Should Return 1 result
+  ASSERT_EQ(result3.size(), 1);               // Fails!
+
   // Be able to do a different search using the same searcher.
   query.setQuery("super", false);
   auto search1 = searcher.search(query);


### PR DESCRIPTION
Fixes #596 

I propose we should follow the same convention as used by Xapian for consistency. That is, rather than keeping the second argument of `Search::getResults(start, end)` as `end` of range, we should use `maxResults` as the second argument. This way:
`getResult(start, maxResults)` will return results in the range `(start, start + maxResults)`

This makes use of API much easier and will require just a documentation fix. We need to fix the rest of the projects accordingly(even though they still work and won't break after this change) for which issues are being created.