### PR TITLE
Revert updation of stemming strategy

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -93,7 +93,7 @@ InternalDataBase::InternalDataBase(const std::vector<Archive>& archives, bool ve
                 try {
                     m_stemmer = Xapian::Stem(languageLocale.getLanguage());
                     m_queryParser.set_stemmer(m_stemmer);
-                    m_queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_ALL_Z);
+                    m_queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_ALL);
                 } catch (...) {
                     std::cout << "No stemming for language '" << languageLocale.getLanguage() << "'" << std::endl;
                 }

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -54,7 +54,7 @@ namespace zim
       try {
         stemmer = Xapian::Stem(mp_indexer->stemmer_language);
         indexer.set_stemmer(stemmer);
-        indexer.set_stemming_strategy(Xapian::TermGenerator::STEM_ALL_Z);
+        indexer.set_stemming_strategy(Xapian::TermGenerator::STEM_ALL);
       } catch (...) {
         // No stemming for language.
       }

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -128,33 +128,6 @@ TEST(search_iterator, functions) {
   ASSERT_EQ(it.getTitle(), "iTem ć");
 }
 
-TEST(search_iterator, stemmedSearch) {
-  TempZimArchive tza("testZim");
-
-  // The following stemming occurs
-  // apple -> appl
-  // charlie -> charli
-  // chocolate -> chocol
-  // factory -> factori
-  zim::Archive archive = tza.createZimFromContent({
-    {"article 1", "an apple a day, keeps the doctor away"},
-    {"article 2", "charlie and the chocolate factory"}
-  });
-
-  zim::Searcher searcher(archive);
-  zim::Query query;
-  query.setQuery("apples");
-  auto search = searcher.search(query);
-  auto result = search.getResults(0, 1);
-
-  ASSERT_EQ(result.begin().getSnippet(), "an <b>apple</b> a day, keeps the doctor away");
-
-  query.setQuery("chocolate factory");
-  search = searcher.search(query);
-  result = search.getResults(0, 1);
-  ASSERT_EQ(result.begin().getSnippet(), "charlie and the <b>chocolate</b> <b>factory</b>");
-}
-
 TEST(search_iterator, iteration) {
   TempZimArchive tza("testZim");
 

--- a/test/suggestion_iterator.cpp
+++ b/test/suggestion_iterator.cpp
@@ -169,4 +169,30 @@ TEST(suggestion_iterator, rangeBased) {
   ASSERT_EQ(it2->getTitle(), "random c");
 }
 
+#if defined(ENABLE_XAPIAN)
+TEST(search_iterator, stemmedSearch) {
+  TempZimArchive tza("testZim");
+
+  // The following stemming occurs
+  // apple -> appl
+  // charlie -> charli
+  // chocolate -> chocol
+  // factory -> factori
+  zim::Archive archive = tza.createZimFromTitles({
+    "an apple a day, keeps the doctor away",
+    "charlie and the chocolate factory"
+  });
+
+  zim::SuggestionSearcher searcher(archive);
+  auto search = searcher.suggest("apples");
+  auto result = search.getResults(0, 1);
+
+  ASSERT_EQ(result.begin()->getSnippet(), "an <b>apple</b> a day, keeps the doctor away");
+
+  search = searcher.suggest("chocolate factory");
+  result = search.getResults(0, 1);
+  ASSERT_EQ(result.begin()->getSnippet(), "charlie and the <b>chocolate</b> <b>factory</b>");
+}
+#endif  // ENABLE_XAPIAN
+
 } // anonymous namespace


### PR DESCRIPTION
Fixes #606 by reverting 3508e103072c4abcff9c721b88c1f9a9e12cbb3b
This was updated in order to "fix" stemming while building the add suggestion api pr. It is not required now since the api is completely built and we should revert the commit since it breaks back compatibility.