### PR TITLE
Break reference loop in `Item`.

### DIFF
--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -133,9 +133,6 @@ namespace zim
          */
         virtual Hints getHints() const;
         virtual ~Item() = default;
-
-      private:
-        mutable std::shared_ptr<IndexData> mp_defaultIndexData;
     };
 
     /**

--- a/src/writer/item.cpp
+++ b/src/writer/item.cpp
@@ -27,16 +27,12 @@ namespace zim
   {
     std::shared_ptr<IndexData> Item::getIndexData() const
     {
-      if (mp_defaultIndexData) {
-        return mp_defaultIndexData;
-      }
       if (getMimeType().find("text/html")!=0) {
         return nullptr;
       }
 
       auto provider = getContentProvider();
-      mp_defaultIndexData = std::shared_ptr<IndexData>(new DefaultIndexData(std::move(provider), getTitle()));
-      return mp_defaultIndexData;
+      return std::make_shared<DefaultIndexData>(std::move(provider), getTitle());
     }
 
     Hints Item::getHints() const {


### PR DESCRIPTION
The basic idea was to store the created indexData's `shared_ptr` to
avoid creating it twice.

But the contentProvider may store a reference to the item, especially
when it reference content stored in the item (as it is the case for
`SharedStringContentProvider`.

This commit remove any storage of the created indexData.
This break the loop but at the cost of creating twice the indexData.

Will fix #618
The follow up of this PR will be the issue #620 