### PR TITLE
PPA: Temporarily disable Impish builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
           - debian-unstable
           - debian-bullseye
           - debian-buster
-          - ubuntu-impish
+          # - ubuntu-impish
           - ubuntu-hirsute
           - ubuntu-focal
           - ubuntu-bionic
@@ -58,13 +58,14 @@ jobs:
         with:
           args: --no-sign
 
-      - uses: legoktm/gh-action-build-deb@ubuntu-impish
-        if: matrix.distro == 'ubuntu-impish'
-        name: Build package for ubuntu-impish
-        id: build-ubuntu-impish
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
+      # Temporarily disabled, Impish keeps changing and breaking the build
+      #- uses: legoktm/gh-action-build-deb@ubuntu-impish
+      #  if: matrix.distro == 'ubuntu-impish'
+      #  name: Build package for ubuntu-impish
+      #  id: build-ubuntu-impish
+      #  with:
+      #    args: --no-sign
+      #    ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: legoktm/gh-action-build-deb@ubuntu-hirsute
         if: matrix.distro == 'ubuntu-hirsute'


### PR DESCRIPTION
Impish CI is broken (https://github.com/openzim/libzim/runs/3531529052?check_suite_focus=true) and following the PR on kiwix-desktop (https://github.com/kiwix/kiwix-desktop/pull/692) it is better for us to disable Impish builds for now.