### PR TITLE
For xapian to check 10 documents when asking for empty mset.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -239,9 +239,9 @@ int Search::getEstimatedMatches() const
 {
     try {
       auto enquire = getEnquire();
-      // Force xapian to check at least one document even if we ask for an empty mset.
+      // Force xapian to check at least 10 documents even if we ask for an empty mset.
       // Else, the get_matches_estimated may be wrong and return 0 even if we have results.
-      auto mset = enquire.get_mset(0, 0, 1);
+      auto mset = enquire.get_mset(0, 0, 10);
       return mset.get_matches_estimated();
     } catch(Xapian::QueryParserError& e) {
       return 0;

--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -205,9 +205,9 @@ int SuggestionSearch::getEstimatedMatches() const
   if (mp_internalDb->hasDatabase()) {
     try {
       auto enquire = getEnquire();
-      // Force xapian to check at least one document even if we ask for an empty mset.
+      // Force xapian to check at least 10 documents even if we ask for an empty mset.
       // Else, the get_matches_estimated may be wrong and return 0 even if we have results.
-      auto mset = enquire.get_mset(0, 0, 1);
+      auto mset = enquire.get_mset(0, 0, 10);
       return mset.get_matches_estimated();
     } catch(...) {
       std::cerr << "Query Parsing failed, Switching to search without index." << std::endl;


### PR DESCRIPTION
Forcing xapian to check 1 documents is not enough and it may still leads to wrong results.

This is difficult to know which is the good number to put here, between a small number to avoid too many checks and a big number to force a accurate result.
10 seems to work for now, at least for small results set as used in tests.

This fix the unit test bug in python-libzim https://github.com/openzim/python-libzim/runs/3672830814

I ask for a favor here and do not add a specific unit test in libzim.
It would need to add a new content in openzim/zim_testing_suite and the change is pretty well contained, I don't see how it could break things.