### PR TITLE
Charset-aware default mimetype for addMetadata

### DIFF
--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -133,7 +133,7 @@ namespace zim
          * @param mimetype the mimetype of the metadata.
          *                 Only used to detect if the metadata must be compressed or not.
          */
-        void addMetadata(const std::string& name, const std::string& content, const std::string& mimetype = "text/plain");
+        void addMetadata(const std::string& name, const std::string& content, const std::string& mimetype = "text/plain;charset=utf-8");
 
         /**
          * Add a metadata to the archive using a contentProvider instead of plain string.

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -203,12 +203,14 @@ TEST(ZimCreator, createZim)
   int png_mimetype = 2;
   int html_mimetype = 3;
   int plain_mimetype = 4;
+  int plainutf8_mimetype = 5;
 #else
   entry_index_type nb_entry = 10; // counter + 2*illustration + foo + foo2 + foo3 + Title + mainPage + titleListIndexes*2
   int listing_mimetype = 0;
   int png_mimetype = 1;
   int html_mimetype = 2;
   int plain_mimetype = 3;
+  int plainutf8_mimetype = 4;
 #endif
 
   ASSERT_EQ(header.getArticleCount(), nb_entry);
@@ -243,7 +245,7 @@ TEST(ZimCreator, createZim)
   auto illustration96BlobIndex = dirent->getBlobNumber();
 
   dirent = direntAccessor.getDirent(entry_index_t(direntIdx++));
-  test_article_dirent(dirent, 'M', "Title", "Title", plain_mimetype, cluster_index_t(0), None);
+  test_article_dirent(dirent, 'M', "Title", "Title", plainutf8_mimetype, cluster_index_t(0), None);
   auto titleBlobIndex = dirent->getBlobNumber();
 
   dirent = direntAccessor.getDirent(entry_index_t(direntIdx++));


### PR DESCRIPTION
Specify the charset (UTF-8) in the default mimetype for addMetadata() so that readers can display it properly.

Similar to https://github.com/openzim/python-libzim/pull/119/commits/ebe062fcf5830f2040c2f409bb91919a399d91f5

