### PR TITLE
Do not crash if looking for zim without illustration nor `X/W` namespace.

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -154,13 +154,17 @@ namespace zim
         /*No exit test*/;
         r++
        ) {
-      auto path = getEntryByPath(entry_index_type(r)).getPath();
-      if (path.find("Illustration_") != 0) {
+      try {
+        auto path = getEntryByPath(entry_index_type(r)).getPath();
+        if (path.find("Illustration_") != 0) {
+          break;
+        }
+        try {
+          ret.insert(parseIllustrationPathToSize(path));
+        } catch (...) {}
+      } catch (const std::out_of_range& e) {
         break;
       }
-      try {
-        ret.insert(parseIllustrationPathToSize(path));
-      } catch (...) {}
     }
     if (ret.find(48) == ret.end()) {
       try {


### PR DESCRIPTION
If the zim file do not contains any entry that would be after `M/Illustration_` the index returned by findx is past the end of entries in the zim file.
So `getEntryByPath` throw a std::out_of_range exception.
We must be prepared for that.

This can appear with old zim files with old namespace scheme and without xapian index (`X` namespace).
I've the issue with at least one pretty old file `wikipedia_en_wp1-0.7_2009-05.zim`