### PR TITLE
Switch default_op for query parser to OP_AND

### DIFF
--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -86,7 +86,6 @@ void SuggestionDataBase::initXapianDb() {
       try {
           m_stemmer = Xapian::Stem(languageLocale.getLanguage());
           m_queryParser.set_stemmer(m_stemmer);
-          m_queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_SOME);
       } catch (...) {
           std::cout << "No stemming for language '" << languageLocale.getLanguage() << "'" << std::endl;
       }
@@ -131,20 +130,25 @@ int SuggestionDataBase::valueSlot(const std::string& valueName) const
  */
 Xapian::Query SuggestionDataBase::parseQuery(const std::string& query)
 {
+  std::lock_guard<std::mutex> locker(m_mutex);
   Xapian::Query xquery;
 
   const auto flags = Xapian::QueryParser::FLAG_DEFAULT | Xapian::QueryParser::FLAG_PARTIAL;
+
+  // Reset stemming strategy for normal parsing
+  m_queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_SOME);
   xquery = m_queryParser.parse_query(query, flags);
 
   if (!query.empty()) {
-    Xapian::QueryParser suggestionParser = m_queryParser;
-    suggestionParser.set_stemming_strategy(Xapian::QueryParser::STEM_NONE);
-    Xapian::Query subquery_phrase = suggestionParser.parse_query(query);
+    // Reconfigure stemming strategy for phrase search
+    m_queryParser.set_stemming_strategy(Xapian::QueryParser::STEM_NONE);
+
+    Xapian::Query subquery_phrase = m_queryParser.parse_query(query);
     // Force the OP_PHRASE window to be equal to the number of terms.
     subquery_phrase = Xapian::Query(Xapian::Query::OP_PHRASE, subquery_phrase.get_terms_begin(), subquery_phrase.get_terms_end(), subquery_phrase.get_length());
 
     auto qs = ANCHOR_TERM + query;
-    Xapian::Query subquery_anchored = suggestionParser.parse_query(qs);
+    Xapian::Query subquery_anchored = m_queryParser.parse_query(qs);
     subquery_anchored = Xapian::Query(Xapian::Query::OP_PHRASE, subquery_anchored.get_terms_begin(), subquery_anchored.get_terms_end(), subquery_anchored.get_length());
 
     xquery = Xapian::Query(Xapian::Query::OP_OR, xquery, subquery_phrase);

--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -138,7 +138,6 @@ Xapian::Query SuggestionDataBase::parseQuery(const std::string& query)
 
   if (!query.empty()) {
     Xapian::QueryParser suggestionParser = m_queryParser;
-    suggestionParser.set_default_op(Xapian::Query::op::OP_OR);
     suggestionParser.set_stemming_strategy(Xapian::QueryParser::STEM_NONE);
     Xapian::Query subquery_phrase = suggestionParser.parse_query(query);
     // Force the OP_PHRASE window to be equal to the number of terms.

--- a/src/suggestion_internal.h
+++ b/src/suggestion_internal.h
@@ -25,6 +25,7 @@
 #include "zim/archive.h"
 
 #include <stdexcept>
+#include <mutex>
 
 #if defined(LIBZIM_WITH_XAPIAN)
 #include <xapian.h>
@@ -47,6 +48,9 @@ class SuggestionDataBase {
 
     // Verbosity of operations.
     bool m_verbose;
+
+  private: // data
+    std::mutex m_mutex;
 
 #if defined(LIBZIM_WITH_XAPIAN)
 

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -535,4 +535,34 @@ TEST(Suggestion, searchByTitle)
       }
     );
   }
+
+  TEST(Suggestion, reuseSearcher) {
+    std::vector<std::string> titles = {
+                                        "song for you",
+                                        "sing a song for you",
+                                        "a song b for c you",
+                                        "song for someone"
+                                      };
+
+    TempZimArchive tza("testZim");
+    const zim::Archive archive = tza.createZimFromTitles(titles);
+
+    zim::SuggestionSearcher suggestionSearcher(archive);
+    suggestionSearcher.setVerbose(true);
+    auto suggestionSearch1 = suggestionSearcher.suggest("song for you");
+    auto suggestionResult1 = suggestionSearch1.getResults(0, 2);
+
+    int count = 0;
+    for (auto entry : suggestionResult1) {
+      count++;
+    }
+
+    auto suggestionSearch2 = suggestionSearcher.suggest("song for you");
+    auto suggestionResult2 = suggestionSearch2.getResults(2, archive.getEntryCount());
+
+    for (auto entry : suggestionResult2) {
+      count++;
+    }
+    ASSERT_EQ(count, 3);
+  }
 }

--- a/test/suggestion_iterator.cpp
+++ b/test/suggestion_iterator.cpp
@@ -182,14 +182,19 @@ TEST(search_iterator, stemmedSearch) {
   });
 
   zim::SuggestionSearcher searcher(archive);
+
   auto search = searcher.suggest("apples");
   auto result = search.getResults(0, 1);
-
   ASSERT_EQ(result.begin()->getSnippet(), "an <b>apple</b> a day, keeps the doctor away");
 
   search = searcher.suggest("chocolate factory");
   result = search.getResults(0, 1);
   ASSERT_EQ(result.begin()->getSnippet(), "charlie and the <b>chocolate</b> <b>factory</b>");
+
+  // Test stemming with reused searcher
+  search = searcher.suggest("apples");
+  result = search.getResults(0, 1);
+  ASSERT_EQ(result.begin()->getSnippet(), "an <b>apple</b> a day, keeps the doctor away");
 }
 #endif  // ENABLE_XAPIAN
 


### PR DESCRIPTION
Fixes #644 

Suggestions module had several flaws which mainly arose from insufficient testing of reusability. This PR aims to address the following issues:
- Bad configuration of default parse operator
The default_op for the query parser is already being set during the initialization of database. The reconfiguration in `SuggestionDataBase::parseQuery()` is redundant and wrong. We should parse suggestion queries only with `OP_AND` and `OP_PHRASE` to ensure relevant suggestions.
This bad-configuration bug came from a buggy separation of suggestions and FT search and it didn't cause any issue till now since we were passing the first query with the default OP set during initialization. But it surfaced during the implementation of caching since we were now using the bad-reconfiguration.
- Reconfiguration of stemming strategy for reuse of searchers
For proper parsing of queries, after first parsing with default `STEM_SOME` strategy, we reconfigure the stemming strategy to
`STEM_NONE` for the second phrase search parsing. To reuse the searcher properly we need to reset the stemming strategy back to `STEM_SOME`. This can lead to some issues in case of multithreading. To prevent such race conditions, we must protect the parsing with a mutex lock.

