### PR TITLE
Returning of random entry from namespace A

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -265,12 +265,22 @@ namespace zim
   }
 
   Entry Archive::getRandomEntry() const {
-    auto frontEntryCount = m_impl->getFrontEntryCount().v;
-    if (frontEntryCount == 0) {
-      throw EntryNotFound("Cannot find valid random entry (no front entry at all)");
-    }
+    if ( !m_impl->hasNewNamespaceScheme() ) {
+      const auto startOfNamespaceA = m_impl->getNamespaceBeginOffset('A');
+      const auto endOfNamespaceA = m_impl->getNamespaceEndOffset('A');
+      const auto n = (endOfNamespaceA - startOfNamespaceA).v;
+      if ( n == 0 ) {
+          throw EntryNotFound("Cannot find valid random entry (empty namespace 'A'");
+      }
+      return getEntryByPath(startOfNamespaceA.v + randomNumber(n-1));
+    } else {
+      auto frontEntryCount = m_impl->getFrontEntryCount().v;
+      if (frontEntryCount == 0) {
+        throw EntryNotFound("Cannot find valid random entry (no front entry at all)");
+      }
 
-    return getEntryByTitle(randomNumber(frontEntryCount-1));
+      return getEntryByTitle(randomNumber(frontEntryCount-1));
+    }
   }
 
   bool Archive::hasFulltextIndex() const {

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -269,18 +269,8 @@ namespace zim
     if (frontEntryCount == 0) {
       throw EntryNotFound("Cannot find valid random entry (no front entry at all)");
     }
-    int watchdog = 42;
-    while(--watchdog) {
-      auto idx = randomNumber(frontEntryCount-1);
-      auto entry =  getEntryByTitle(idx);
-      auto item = entry.getItem(true);
 
-      if (item.getMimetype().find("text/html") == std::string::npos) {
-        continue;
-      }
-      return entry;
-    }
-    throw EntryNotFound("Cannot find valid random entry");
+    return getEntryByTitle(randomNumber(frontEntryCount-1));
   }
 
   bool Archive::hasFulltextIndex() const {

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -74,6 +74,7 @@ namespace zim
 
       using DirentLookup = zim::DirentLookup<DirectDirentAccessor>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
+      mutable std::once_flag m_direntLookupOnceFlag;
 
     public:
       using FindxResult = std::pair<bool, entry_index_t>;
@@ -110,9 +111,9 @@ namespace zim
       offset_t getClusterOffset(cluster_index_t idx) const;
       offset_t getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx);
 
-      entry_index_t getNamespaceBeginOffset(char ch);
-      entry_index_t getNamespaceEndOffset(char ch);
-      entry_index_t getNamespaceEntryCount(char ch) {
+      entry_index_t getNamespaceBeginOffset(char ch) const;
+      entry_index_t getNamespaceEndOffset(char ch) const;
+      entry_index_t getNamespaceEntryCount(char ch) const {
         return getNamespaceEndOffset(ch) - getNamespaceBeginOffset(ch);
       }
 
@@ -123,8 +124,6 @@ namespace zim
       entry_index_t getUserEntryCount() const { return m_endUserEntry - m_startUserEntry; }
       // The number of enties that can be considered as front article (no resource)
       entry_index_t getFrontEntryCount() const;
-
-      bool hasNamespace(char ch) const;
 
       const std::string& getMimeType(uint16_t idx) const;
 
@@ -140,7 +139,7 @@ namespace zim
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessor(const std::string& path);
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessor(const offset_t offset, const zsize_t size, const std::string& name);
 
-      DirentLookup& direntLookup();
+      DirentLookup& direntLookup() const;
       ClusterHandle readCluster(cluster_index_t idx);
       offset_type getMimeListEndUpperLimit() const;
       void readMimeTypes();


### PR DESCRIPTION
This PR implements the suggestion contained in https://github.com/kiwix/libkiwix/issues/643#issuecomment-990968425 and thus may be considered a fix for PR kiwix/libkiwix#643.

On old ZIM archives (using the old namespace scheme) `Archive::getRandomEntry()` returns an entry from the namespace "A".