### PR TITLE
More generic DirentLookup (able to perform by-title search too)

### DIFF
--- a/src/dirent_lookup.h
+++ b/src/dirent_lookup.h
@@ -46,6 +46,9 @@ public: // functions
 
   Result find(char ns, const std::string& url) const;
 
+protected: // functions
+  Result findInRange(entry_index_type l, entry_index_type u, char ns, const std::string& url) const;
+
 private: // functions
   std::string getDirentKey(entry_index_type i) const;
 
@@ -158,6 +161,13 @@ DirentLookup<TDirentAccessor>::find(char ns, const std::string& url) const
   if (l == u)
     return {false, entry_index_t(l)};
 
+  return findInRange(l, u, ns, url);
+}
+
+template<typename TDirentAccessor>
+typename DirentLookup<TDirentAccessor>::Result
+DirentLookup<TDirentAccessor>::findInRange(entry_index_type l, entry_index_type u, char ns, const std::string& url) const
+{
   while (true)
   {
     entry_index_type p = l + (u - l) / 2;

--- a/src/dirent_lookup.h
+++ b/src/dirent_lookup.h
@@ -198,9 +198,18 @@ template<typename TDirentAccessor>
 typename DirentLookup<TDirentAccessor>::Result
 DirentLookup<TDirentAccessor>::find(char ns, const std::string& url) const
 {
-  // FIXME: handle the edge cases correctly:
-  // FIXME:   - the query value is before the first dirent
-  // FIXME:   - the query value is after the last dirent
+  if ( direntCount == 0 )
+      return { false, entry_index_t(0) };
+
+  const auto c = compareWithDirentAt(ns, url, 0);
+  if ( c < 0 )
+      return { false, entry_index_t(0) };
+  else if ( c == 0 )
+      return { true, entry_index_t(0) };
+
+  if ( compareWithDirentAt(ns, url, direntCount-1) > 0 )
+      return { false, entry_index_t(direntCount) };
+
   return findInRange(0, direntCount, ns, url);
 }
 

--- a/src/dirent_lookup.h
+++ b/src/dirent_lookup.h
@@ -44,7 +44,7 @@ public: // functions
   entry_index_t getNamespaceRangeBegin(char ns) const;
   entry_index_t getNamespaceRangeEnd(char ns) const;
 
-  Result find(char ns, const std::string& url);
+  Result find(char ns, const std::string& url) const;
 
 private: // functions
   std::string getDirentKey(entry_index_type i) const;
@@ -149,7 +149,7 @@ DirentLookup<TDirentAccessor>::getNamespaceRangeEnd(char ns) const
 
 template<typename TDirentAccessor>
 typename DirentLookup<TDirentAccessor>::Result
-DirentLookup<TDirentAccessor>::find(char ns, const std::string& url)
+DirentLookup<TDirentAccessor>::find(char ns, const std::string& url) const
 {
   const auto r = lookupGrid.getRange(ns + url);
   entry_index_type l(r.begin);

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -75,6 +75,7 @@ namespace zim
       struct DirentLookupConfig
       {
         typedef DirectDirentAccessor DirentAccessorType;
+        typedef entry_index_t index_t;
         static const std::string& getDirentKey(const Dirent& d) {
           return d.getUrl();
         }
@@ -83,6 +84,19 @@ namespace zim
       using DirentLookup = zim::FastDirentLookup<DirentLookupConfig>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
       mutable std::once_flag m_direntLookupOnceFlag;
+
+
+      struct ByTitleDirentLookupConfig
+      {
+        typedef IndirectDirentAccessor DirentAccessorType;
+        typedef title_index_t index_t;
+        static const std::string& getDirentKey(const Dirent& d) {
+          return d.getTitle();
+        }
+      };
+
+      using ByTitleDirentLookup = zim::DirentLookup<ByTitleDirentLookupConfig>;
+      std::unique_ptr<ByTitleDirentLookup> m_byTitleDirentLookup;
 
     public:
       using FindxResult = std::pair<bool, entry_index_t>;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -72,7 +72,12 @@ namespace zim
       mutable std::vector<pair_type> articleListByCluster;
       mutable std::once_flag orderOnceFlag;
 
-      using DirentLookup = zim::FastDirentLookup<DirectDirentAccessor>;
+      struct DirentLookupConfig
+      {
+        typedef DirectDirentAccessor DirentAccessorType;
+      };
+
+      using DirentLookup = zim::FastDirentLookup<DirentLookupConfig>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
       mutable std::once_flag m_direntLookupOnceFlag;
 

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -75,6 +75,9 @@ namespace zim
       struct DirentLookupConfig
       {
         typedef DirectDirentAccessor DirentAccessorType;
+        static const std::string& getDirentKey(const Dirent& d) {
+          return d.getUrl();
+        }
       };
 
       using DirentLookup = zim::FastDirentLookup<DirentLookupConfig>;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -72,7 +72,7 @@ namespace zim
       mutable std::vector<pair_type> articleListByCluster;
       mutable std::once_flag orderOnceFlag;
 
-      using DirentLookup = zim::DirentLookup<DirectDirentAccessor>;
+      using DirentLookup = zim::FastDirentLookup<DirectDirentAccessor>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
       mutable std::once_flag m_direntLookupOnceFlag;
 

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -163,6 +163,7 @@ TEST_F(DirentLookupTest, NoExactMatch)
   CHECK_FIND_RESULT(expr,        false, expected_value); \
   CHECK_FIND_RESULT(fast_##expr, false, expected_value);
 
+  CHECK_NOEXACT_MATCH(direntLookup.find('A', "ABC"), 0);
   CHECK_NOEXACT_MATCH(direntLookup.find('U', "aa"), 10); // No U namespace => return 10 (the index of the first item from the next namespace)
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabb"), 5); // aabb is between aaaacc (4) and aabbaa (5) => 5
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabbb"), 6); // aabbb is between aabbaa (5) and aabbbb (6) => 6
@@ -172,6 +173,7 @@ TEST_F(DirentLookupTest, NoExactMatch)
   CHECK_NOEXACT_MATCH(direntLookup.find('M', "f"), 9); // f is before foo (9) => 9
   CHECK_NOEXACT_MATCH(direntLookup.find('M', "bar"), 9); // bar is before foo (9) => 9
   CHECK_NOEXACT_MATCH(direntLookup.find('M', "foo1"), 10); // foo1 is after foo (9) => 10
+  CHECK_NOEXACT_MATCH(direntLookup.find('z', "zz"), 13);
 
 #undef CHECK_NOEXACT_MATCH
 }

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -103,6 +103,31 @@ class DirentLookupTest : public :: testing::Test
     GetDirentMock dirents;
 };
 
+typedef zim::DirentLookup<GetDirentMock> DirentLookupType;
+
+// Provide access to protected functionality in order to unit-test it
+struct UnprotectedDirentLookup : DirentLookupType
+{
+  template<typename... T> UnprotectedDirentLookup(const T&... args)
+    : DirentLookupType(args...)
+  {}
+
+  using DirentLookupType::compareWithDirentAt;
+};
+
+
+TEST_F(DirentLookupTest, compareWithDirentAt)
+{
+  UnprotectedDirentLookup direntLookup(&dirents);
+
+  // Dirent at index 9 is {'M', "foo"}
+  EXPECT_LE(direntLookup.compareWithDirentAt('A', "foo", 9), 0);
+  EXPECT_LE(direntLookup.compareWithDirentAt('M', "boo", 9), 0);
+  EXPECT_EQ(direntLookup.compareWithDirentAt('M', "foo", 9), 0);
+  EXPECT_GE(direntLookup.compareWithDirentAt('M', "for", 9), 0);
+  EXPECT_GE(direntLookup.compareWithDirentAt('N', "foo", 9), 0);
+}
+
 
 #define CHECK_FIND_RESULT(expr, is_exact_match, expected_value) \
   { \

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -48,6 +48,8 @@ const std::vector<std::pair<char, std::string>> articleurl = {
 
 struct GetDirentMock
 {
+  typedef GetDirentMock DirentAccessorType;
+
   zim::entry_index_t getDirentCount() const {
     return zim::entry_index_t(articleurl.size());
   }

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -113,10 +113,13 @@ class DirentLookupTest : public :: testing::Test
 
 TEST_F(DirentLookupTest, ExactMatch)
 {
-#define CHECK_EXACT_MATCH(expr, expected_value)         \
-  CHECK_FIND_RESULT(expr, true, expected_value);
+  zim::DirentLookup<GetDirentMock> direntLookup(&dirents);
+  zim::FastDirentLookup<GetDirentMock> fast_direntLookup(&dirents, 4);
 
-  zim::FastDirentLookup<GetDirentMock> direntLookup(&dirents, 4);
+#define CHECK_EXACT_MATCH(expr, expected_value)         \
+  CHECK_FIND_RESULT(expr,        true, expected_value); \
+  CHECK_FIND_RESULT(fast_##expr, true, expected_value);
+
   CHECK_EXACT_MATCH(direntLookup.find('A', "aa"), 0);
   CHECK_EXACT_MATCH(direntLookup.find('a', "aa"), 10);
   CHECK_EXACT_MATCH(direntLookup.find('A', "aabbbb"), 6);
@@ -128,10 +131,13 @@ TEST_F(DirentLookupTest, ExactMatch)
 
 TEST_F(DirentLookupTest, NoExactMatch)
 {
-#define CHECK_NOEXACT_MATCH(expr, expected_value)        \
-  CHECK_FIND_RESULT(expr, false, expected_value);
+  zim::DirentLookup<GetDirentMock> direntLookup(&dirents);
+  zim::FastDirentLookup<GetDirentMock> fast_direntLookup(&dirents, 4);
 
-  zim::FastDirentLookup<GetDirentMock> direntLookup(&dirents, 4);
+#define CHECK_NOEXACT_MATCH(expr, expected_value)        \
+  CHECK_FIND_RESULT(expr,        false, expected_value); \
+  CHECK_FIND_RESULT(fast_##expr, false, expected_value);
+
   CHECK_NOEXACT_MATCH(direntLookup.find('U', "aa"), 10); // No U namespace => return 10 (the index of the first item from the next namespace)
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabb"), 5); // aabb is between aaaacc (4) and aabbaa (5) => 5
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabbb"), 6); // aabbb is between aabbaa (5) and aabbbb (6) => 6

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -49,6 +49,7 @@ const std::vector<std::pair<char, std::string>> articleurl = {
 struct GetDirentMock
 {
   typedef GetDirentMock DirentAccessorType;
+  typedef zim::entry_index_t index_t;
   static const std::string& getDirentKey(const zim::Dirent& d) {
     return d.getUrl();
   }

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -116,7 +116,7 @@ TEST_F(DirentLookupTest, ExactMatch)
 #define CHECK_EXACT_MATCH(expr, expected_value)         \
   CHECK_FIND_RESULT(expr, true, expected_value);
 
-  zim::DirentLookup<GetDirentMock> direntLookup(&dirents, 4);
+  zim::FastDirentLookup<GetDirentMock> direntLookup(&dirents, 4);
   CHECK_EXACT_MATCH(direntLookup.find('A', "aa"), 0);
   CHECK_EXACT_MATCH(direntLookup.find('a', "aa"), 10);
   CHECK_EXACT_MATCH(direntLookup.find('A', "aabbbb"), 6);
@@ -131,7 +131,7 @@ TEST_F(DirentLookupTest, NoExactMatch)
 #define CHECK_NOEXACT_MATCH(expr, expected_value)        \
   CHECK_FIND_RESULT(expr, false, expected_value);
 
-  zim::DirentLookup<GetDirentMock> direntLookup(&dirents, 4);
+  zim::FastDirentLookup<GetDirentMock> direntLookup(&dirents, 4);
   CHECK_NOEXACT_MATCH(direntLookup.find('U', "aa"), 10); // No U namespace => return 10 (the index of the first item from the next namespace)
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabb"), 5); // aabb is between aaaacc (4) and aabbaa (5) => 5
   CHECK_NOEXACT_MATCH(direntLookup.find('A', "aabbb"), 6); // aabbb is between aabbaa (5) and aabbbb (6) => 6

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -49,6 +49,9 @@ const std::vector<std::pair<char, std::string>> articleurl = {
 struct GetDirentMock
 {
   typedef GetDirentMock DirentAccessorType;
+  static const std::string& getDirentKey(const zim::Dirent& d) {
+    return d.getUrl();
+  }
 
   zim::entry_index_t getDirentCount() const {
     return zim::entry_index_t(articleurl.size());


### PR DESCRIPTION
This PR (originating from https://github.com/openzim/libzim/pull/647#discussion_r769655786) replaces the custom binary search in `FileImpl::findxByTitle()` by another DirentLookup object configured to work with dirents sorted by title.