### PR TITLE
Fixed CreatorData destructor

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -452,6 +452,7 @@ namespace zim
 
     CreatorData::~CreatorData()
     {
+      quitAllThreads();
       if (compCluster)
         delete compCluster;
       if (uncompCluster)
@@ -459,7 +460,6 @@ namespace zim
       for(auto& cluster: clustersList) {
         delete cluster;
       }
-      quitAllThreads();
     }
 
     void CreatorData::quitAllThreads() {

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -288,9 +288,11 @@ namespace zim
       TINFO("write zimfile :");
       writeLastParts();
       ::close(data->out_fd);
+      data->out_fd = -1;
 
       TINFO("rename tmpfile to final one.");
       DEFAULTFS::rename(data->tmpFileName, data->zimName);
+      data->tmpFileName.clear();
 
       TINFO("finish");
     }
@@ -459,6 +461,12 @@ namespace zim
         delete uncompCluster;
       for(auto& cluster: clustersList) {
         delete cluster;
+      }
+      if ( out_fd != - 1 ) {
+        ::close(out_fd);
+      }
+      if ( ! tmpFileName.empty() ) {
+        DEFAULTFS::removeFile(tmpFileName);
       }
     }
 


### PR DESCRIPTION
Fixes openzim/zim-tools#289

Clusters owned by `CreatorData` are used in the worker threads. If the `CreatorData` destructor is executed as a result of stack unwinding caused by an exception raised before `CreatorData::quitAllThreads()` is called from `Creator::finishZimCreation()`, then the worker threads are still running and should be stopped by the `CreatorData::quitAllThreads()` call from `CreatorData::~CreatorData()`. However, that must happen *before* the clusters are destroyed.