### PR TITLE
Run the macos CI on macos-latest (macos-11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - iOS_i386
           - iOS_x86_64
           - iOS_armv7
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
         target:
           - native_dyn
           - iOS_arm64
-          - iOS_i386
           - iOS_x86_64
-          - iOS_armv7
     runs-on: macos-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
The dependencies and meson crossfile are generated by kiwix-build on
macos-latest. We must use the same image.