### PR TITLE
Do not call `hasIndexData` in the main thread.

### DIFF
--- a/include/zim/writer/item.h
+++ b/include/zim/writer/item.h
@@ -127,6 +127,8 @@ namespace zim
          * The contentProvider will be created in the main thread but the data reading and
          * parsing will occur in a different thread.
          *
+         * All methods of `IndexData` will be called in a different (same) thread.
+         *
          * @return the indexData of the item.
          *         May return a nullptr if there is no indexData.
          */

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -120,9 +120,8 @@ void XapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
     if (!indexData) {
       return;
     }
-    auto title = indexData->getTitle();
     auto path = dirent->getPath();
-    mp_creatorData->taskList.pushToQueue(new IndexTask(indexData, path, title, mp_fulltextIndexer.get()));
+    mp_creatorData->taskList.pushToQueue(new IndexTask(indexData, path, mp_fulltextIndexer.get()));
   }
 }
 

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -117,7 +117,7 @@ void XapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
   // FullText index
   if (mp_fulltextIndexer) {
     auto indexData = item->getIndexData();
-    if (!indexData || !indexData->hasIndexData()) {
+    if (!indexData) {
       return;
     }
     auto title = indexData->getTitle();

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -70,7 +70,7 @@ namespace zim
 
       std::string fullPath = "C/" + m_path;
       document.set_data(fullPath);
-      document.add_value(0, m_title);
+      document.add_value(0, mp_indexData->getTitle());
 
       std::stringstream countWordStringStream;
       countWordStringStream << mp_indexData->getWordCount();

--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -50,6 +50,9 @@ namespace zim
     }
 
     void IndexTask::run(CreatorData* data) {
+      if (!mp_indexData->hasIndexData()) {
+        return;
+      }
       Xapian::Stem stemmer;
       Xapian::TermGenerator indexer;
       try {

--- a/src/writer/xapianWorker.h
+++ b/src/writer/xapianWorker.h
@@ -35,10 +35,9 @@ class IndexTask : public Task {
   public:
     IndexTask(const IndexTask&) = delete;
     IndexTask& operator=(const IndexTask&) = delete;
-    IndexTask(std::shared_ptr<IndexData> indexData, const std::string& path, const std::string& title, XapianIndexer* indexer) :
+    IndexTask(std::shared_ptr<IndexData> indexData, const std::string& path, XapianIndexer* indexer) :
       mp_indexData(indexData),
       m_path(path),
-      m_title(title),
       mp_indexer(indexer)
     {
       ++waiting_task;
@@ -56,7 +55,6 @@ class IndexTask : public Task {
   private:
     std::shared_ptr<IndexData> mp_indexData;
     std::string m_path;
-    std::string m_title;
     XapianIndexer* mp_indexer;
 };
 


### PR DESCRIPTION
Do not call `hasIndexData` and `getTitle` in the main thread.

- Default implementation of `hasIndexData ` need to parse the content and we don't want to parse the content in the main thread.
- Default implementation of `getTitle` do not need to parse the content but it is better to move the call in another thread for consistency.

Fix #683