### PR TITLE
Increase test timeout to 10 minutes

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -53,6 +53,6 @@ if gtest_dep.found() and not meson.is_cross_build()
                               cpp_args: test_cpp_args,
                               dependencies: deps + [gtest_dep],
                               build_rpath: '$ORIGIN')
-        test(test_name, test_exe, timeout : 120, env: testenv)
+        test(test_name, test_exe, timeout : 600, env: testenv)
     endforeach
 endif


### PR DESCRIPTION
The cluster test takes 186 seconds on my x86_64 laptop from 2017.  I imagine on other slower/older machines it could take even longer.  So let's increase the timeout to something that will still catch genuinely stuck tests, but not fail unnecessarily for people using older computers.
