### PR TITLE
Got rid of std::call_once usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,9 @@ jobs:
         cd $HOME/libzim/build
         ninja download_test_data
         meson test --verbose
-        ninja coverage
+        if [[ "${{matrix.target}}" =~ native_.* ]]; then
+          ninja coverage
+        fi
       env:
         LD_LIBRARY_PATH: "/home/runner/BUILD_${{matrix.target}}/INSTALL/lib:/home/runner/BUILD_${{matrix.target}}/INSTALL/lib${{matrix.lib_postfix}}"
         SKIP_BIG_MEMORY_TEST: 1

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -346,10 +346,8 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
     return entry_index_t(mp_titleDirentAccessor->getDirentCount().v);
   }
 
-  entry_index_t FileImpl::getIndexByClusterOrder(entry_index_t idx) const
+  void FileImpl::prepareArticleListByCluster() const
   {
-      std::call_once(orderOnceFlag, [this]
-      {
           articleListByCluster.reserve(getUserEntryCount().v);
 
           auto endIdx = getEndUserEntry().v;
@@ -368,8 +366,11 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
               }
           }
           std::sort(articleListByCluster.begin(), articleListByCluster.end());
-      });
+  }
 
+  entry_index_t FileImpl::getIndexByClusterOrder(entry_index_t idx) const
+  {
+      std::call_once(orderOnceFlag, [this]{ prepareArticleListByCluster(); });
       if (idx.v >= articleListByCluster.size())
         throw std::out_of_range("entry index out of range");
       return entry_index_t(articleListByCluster[idx.v].second);

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -348,24 +348,24 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
 
   void FileImpl::prepareArticleListByCluster() const
   {
-          articleListByCluster.reserve(getUserEntryCount().v);
+    articleListByCluster.reserve(getUserEntryCount().v);
 
-          auto endIdx = getEndUserEntry().v;
-          for(auto i = getStartUserEntry().v; i < endIdx; i++)
-          {
-              // This is the offset of the dirent in the zimFile
-              auto indexOffset = mp_urlDirentAccessor->getOffset(entry_index_t(i));
-              // Get the mimeType of the dirent (offset 0) to know the type of the dirent
-              uint16_t mimeType = zimReader->read_uint<uint16_t>(indexOffset);
-              if (mimeType==Dirent::redirectMimeType || mimeType==Dirent::linktargetMimeType || mimeType == Dirent::deletedMimeType) {
-                articleListByCluster.push_back(std::make_pair(0, i));
-              } else {
-                // If it is a classic article, get the clusterNumber (at offset 8)
-                auto clusterNumber = zimReader->read_uint<zim::cluster_index_type>(indexOffset+offset_t(8));
-                articleListByCluster.push_back(std::make_pair(clusterNumber, i));
-              }
-          }
-          std::sort(articleListByCluster.begin(), articleListByCluster.end());
+    auto endIdx = getEndUserEntry().v;
+    for(auto i = getStartUserEntry().v; i < endIdx; i++)
+    {
+      // This is the offset of the dirent in the zimFile
+      auto indexOffset = mp_urlDirentAccessor->getOffset(entry_index_t(i));
+      // Get the mimeType of the dirent (offset 0) to know the type of the dirent
+      uint16_t mimeType = zimReader->read_uint<uint16_t>(indexOffset);
+      if (mimeType==Dirent::redirectMimeType || mimeType==Dirent::linktargetMimeType || mimeType == Dirent::deletedMimeType) {
+        articleListByCluster.push_back(std::make_pair(0, i));
+      } else {
+        // If it is a classic article, get the clusterNumber (at offset 8)
+        auto clusterNumber = zimReader->read_uint<zim::cluster_index_type>(indexOffset+offset_t(8));
+        articleListByCluster.push_back(std::make_pair(clusterNumber, i));
+      }
+    }
+    std::sort(articleListByCluster.begin(), articleListByCluster.end());
   }
 
   entry_index_t FileImpl::getIndexByClusterOrder(entry_index_t idx) const

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -370,17 +370,17 @@ makeFileReader(std::shared_ptr<const FileCompound> zimFile, offset_t offset, zsi
 
   entry_index_t FileImpl::getIndexByClusterOrder(entry_index_t idx) const
   {
-      // Not using std::call_once because it is buggy. See the comment
-      // in FileImpl::direntLookup().
+    // Not using std::call_once because it is buggy. See the comment
+    // in FileImpl::direntLookup().
+    if ( m_articleListByCluster.empty() ) {
+      std::lock_guard<std::mutex> lock(m_articleListByClusterMutex);
       if ( m_articleListByCluster.empty() ) {
-        std::lock_guard<std::mutex> lock(m_articleListByClusterMutex);
-        if ( m_articleListByCluster.empty() ) {
-          prepareArticleListByCluster();
-        }
+        prepareArticleListByCluster();
       }
-      if (idx.v >= m_articleListByCluster.size())
-        throw std::out_of_range("entry index out of range");
-      return entry_index_t(m_articleListByCluster[idx.v].second);
+    }
+    if (idx.v >= m_articleListByCluster.size())
+      throw std::out_of_range("entry index out of range");
+    return entry_index_t(m_articleListByCluster[idx.v].second);
   }
 
   FileImpl::ClusterHandle FileImpl::readCluster(cluster_index_t idx)

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -83,7 +83,7 @@ namespace zim
 
       using DirentLookup = zim::FastDirentLookup<DirentLookupConfig>;
       mutable std::unique_ptr<DirentLookup> m_direntLookup;
-      mutable std::once_flag m_direntLookupOnceFlag;
+      mutable std::mutex m_direntLookupCreationMutex;
 
 
       struct ByTitleDirentLookupConfig

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -69,7 +69,7 @@ namespace zim
       MimeTypes mimeTypes;
 
       using pair_type = std::pair<cluster_index_type, entry_index_type>;
-      mutable std::vector<pair_type> articleListByCluster;
+      mutable std::vector<pair_type> m_articleListByCluster;
       mutable std::mutex m_articleListByClusterMutex;
 
       struct DirentLookupConfig

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -161,6 +161,7 @@ namespace zim
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessor(const std::string& path);
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessor(const offset_t offset, const zsize_t size, const std::string& name);
 
+      void prepareArticleListByCluster() const;
       DirentLookup& direntLookup() const;
       ClusterHandle readCluster(cluster_index_t idx);
       offset_type getMimeListEndUpperLimit() const;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -70,7 +70,7 @@ namespace zim
 
       using pair_type = std::pair<cluster_index_type, entry_index_type>;
       mutable std::vector<pair_type> articleListByCluster;
-      mutable std::once_flag orderOnceFlag;
+      mutable std::mutex m_articleListByClusterMutex;
 
       struct DirentLookupConfig
       {


### PR DESCRIPTION
Fixes #671 

`std::call_once` [is buggy](https://github.com/openzim/libzim/issues/671#issuecomment-1170979900):

1. It doesn't play well with musl libc - an exception thrown by the callable results in SIGABRT even if there is a handler for it higher
   in the call stack.

2. With `glibc` an exceptional execution of `std::call_once` doesn't unlock the mutex associated with the `std::once_flag` object.