### PR TITLE
Added Entry::getRedirectEntryIndex()

### DIFF
--- a/include/zim/entry.h
+++ b/include/zim/entry.h
@@ -69,9 +69,17 @@ namespace zim
       /** Get the Entry targeted by the entry.
        *
        * @return The entry directly targeted by this redirect entry.
-       * @exception InvalidEntry in the entry is not a redirection.
+       * @exception InvalidEntry if the entry is not a redirection.
        */
       Entry getRedirectEntry() const;
+
+      /** Get the index of the Entry targeted by the entry.
+       *
+       * @return The index of the entry directly targeted by this redirect
+       *         entry.
+       * @exception InvalidEntry if the entry is not a redirection.
+       */
+      entry_index_type getRedirectEntryIndex() const;
 
       entry_index_type getIndex() const   { return m_idx; }
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -80,11 +80,15 @@ Item Entry::getRedirect() const {
   return nextEntry.getItem(false);
 }
 
-Entry Entry::getRedirectEntry() const  {
+entry_index_type Entry::getRedirectEntryIndex() const  {
   if (!isRedirect()) {
     std::ostringstream sstream;
     sstream << "Entry " << getPath() << " is not a redirect entry.";
     throw InvalidType(sstream.str());
   }
-  return Entry(m_file, static_cast<entry_index_type>(m_dirent->getRedirectIndex()));
+  return m_dirent->getRedirectIndex().v;
+}
+
+Entry Entry::getRedirectEntry() const  {
+  return Entry(m_file, getRedirectEntryIndex());
 }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -204,6 +204,8 @@ TEST(ZimArchive, openCreatedArchive)
   ASSERT_EQ(foo.getPath(), "foo");
   ASSERT_EQ(foo.getTitle(), "Foo");
   ASSERT_EQ(std::string(foo.getItem().getData()), "FooContent");
+  ASSERT_THROW(foo.getRedirectEntry(), zim::InvalidType);
+  ASSERT_THROW(foo.getRedirectEntryIndex(), zim::InvalidType);
 
   auto foo2 = archive.getEntryByPath("foo2");
   ASSERT_EQ(foo2.getPath(), "foo2");
@@ -215,10 +217,12 @@ TEST(ZimArchive, openCreatedArchive)
   ASSERT_EQ(foo3.getTitle(), "FooRedirection");
   ASSERT_TRUE(foo3.isRedirect());
   ASSERT_EQ(foo3.getRedirectEntry().getIndex(), foo.getIndex());
+  ASSERT_EQ(foo3.getRedirectEntryIndex(), foo.getIndex());
 
   auto main = archive.getMainEntry();
   ASSERT_TRUE(main.isRedirect());
   ASSERT_EQ(main.getRedirectEntry().getIndex(), foo.getIndex());
+  ASSERT_EQ(main.getRedirectEntryIndex(), foo.getIndex());
   ASSERT_EQ(archive.getMainEntryIndex(), main.getIndex());
 }
 


### PR DESCRIPTION
Needed for openzim/zim-tools#312

`Entry::getRedirectEntryIndex()` is functionally equivalent to `Entry::getRedirectEntry().getIndex()`. However, the latter involves access to the dirent of the target entry. When only the index of the target entry is of interest, unnecessarily loading the target dirent may turn sequential disk IO (when iterating entries by their native order) to somewhat random disk IO. The new method is devoid of that drawback.
