### PR TITLE
Remove transaction system from xapian indexer.

### DIFF
--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -106,7 +106,6 @@ void XapianIndexer::indexingPrelude()
   }
   writableDatabase.set_metadata("language", language);
   writableDatabase.set_metadata("stopwords", stopwords);
-  writableDatabase.begin_transaction(true);
 }
 
 /*
@@ -155,16 +154,8 @@ void XapianIndexer::indexTitle(const std::string& path, const std::string& title
   empty = false;
 }
 
-void XapianIndexer::flush()
-{
-  this->writableDatabase.commit_transaction();
-  this->writableDatabase.begin_transaction(true);
-}
-
 void XapianIndexer::indexingPostlude()
 {
-  this->flush();
-  this->writableDatabase.commit_transaction();
   this->writableDatabase.commit();
   this->writableDatabase.compact(indexPath, Xapian::DBCOMPACT_SINGLE_FILE);
   this->writableDatabase.close();

--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -157,7 +157,7 @@ void XapianIndexer::indexTitle(const std::string& path, const std::string& title
 void XapianIndexer::indexingPostlude()
 {
   this->writableDatabase.commit();
-  this->writableDatabase.compact(indexPath, Xapian::DBCOMPACT_SINGLE_FILE);
+  this->writableDatabase.compact(indexPath, Xapian::DBCOMPACT_SINGLE_FILE|Xapian::Compactor::FULLER);
   this->writableDatabase.close();
 }
 

--- a/src/writer/xapianIndexer.h
+++ b/src/writer/xapianIndexer.h
@@ -46,7 +46,6 @@ class XapianIndexer
   virtual ~XapianIndexer();
   std::string getIndexPath() { return indexPath; }
   void indexingPrelude();
-  void flush();
   void indexingPostlude();
   bool is_empty() { return empty; }
 


### PR DESCRIPTION
Transactions are used to regroup modifications together and be sure that
they are either written all together in the database or not at all.

But here we don't care about coherence of the database. Either we succeed
to write index all documents or we have fail all the process.
And we never read the database will we are creating it.

On top of that, transaction probably prevent xapian to automatically
commit the modifications and so we are keeping everything in memory and
commit in fs only at the end of the process.

By removing transactions, we let xapian handle commits "correctly".
By default xapian will commit every 10000 documents.
This can be changed with the env var XAPIAN_FLUSH_THRESHOLD
See https://xapian.org/docs/apidoc/html/classXapian_1_1WritableDatabase.html#acbea2163142de795024880a7123bc693