### PR TITLE
Optimization of the first call of zim::Archive::iterEfficient()

### DIFF
--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -104,9 +104,10 @@ public: // functions
     groupIds_.reserve(objectIdEnd - objectIdBegin);
   }
 
-  void add(ObjectId objectId, GroupId groupId)
+  // i'th call of add() is assumed to refer to the object
+  // with id (firstObjectId_+i)
+  void add(GroupId groupId)
   {
-    assert(objectId == firstObjectId_ + groupIds_.size());
     groupIds_.push_back(groupId);
     minGroupId_ = std::min(minGroupId_, groupId);
     maxGroupId_ = std::max(maxGroupId_, groupId);
@@ -435,11 +436,11 @@ private: // data
       // Get the mimeType of the dirent (offset 0) to know the type of the dirent
       uint16_t mimeType = zimReader->read_uint<uint16_t>(indexOffset);
       if (mimeType==Dirent::redirectMimeType || mimeType==Dirent::linktargetMimeType || mimeType == Dirent::deletedMimeType) {
-        g.add(i, 0);
+        g.add(0);
       } else {
         // If it is a classic article, get the clusterNumber (at offset 8)
         auto clusterNumber = zimReader->read_uint<zim::cluster_index_type>(indexOffset+offset_t(8));
-        g.add(i, clusterNumber);
+        g.add(clusterNumber);
       }
     }
     m_articleListByCluster = g.getGroupedObjectIds();

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -68,8 +68,7 @@ namespace zim
       typedef std::vector<std::string> MimeTypes;
       MimeTypes mimeTypes;
 
-      using pair_type = std::pair<cluster_index_type, entry_index_type>;
-      mutable std::vector<pair_type> m_articleListByCluster;
+      mutable std::vector<entry_index_type> m_articleListByCluster;
       mutable std::mutex m_articleListByClusterMutex;
 
       struct DirentLookupConfig


### PR DESCRIPTION
1. memory usage of `FileImpl::m_articleListByCluster` has been halved
2. general purpose O(NlogN) sorting algorithm was replaced with a counting sort approach (with O(N) time complexity).