### PR TITLE
Introduce Archive::getMediaCount

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -140,9 +140,7 @@ namespace zim
        *  The definition of "article" depends of the zim archive.
        *  On recent archives, this correspond to all entries marked as "FRONT_ARTICLE"
        *  at creaton time.
-       *  On old archives, this correspond to all entries in 'A' namespace.
-       *  Few archives may have been created without namespace but also without specific
-       *  article listing. In this case, articles are all user entries.
+       *  On old archives, this corresponds to all "text/html*" entries.
        *
        *  @return the number of articles in the archive.
        */

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -148,6 +148,14 @@ namespace zim
        */
       entry_index_type getArticleCount() const;
 
+      /** Return the number of media in the archive.
+       *
+       * This definition of "media" is based on the mimetype.
+       *
+       * @return the number of media in the archive.
+       */
+      entry_index_type getMediaCount() const;
+
       /** The uuid of the archive.
        *
        *  @return the uuid of the archive.

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -70,14 +70,18 @@ namespace zim
   {
     if (m_impl->hasFrontArticlesIndex()) {
       return m_impl->getFrontEntryCount().v;
-    } else if (m_impl->hasNewNamespaceScheme()) {
-      return m_impl->getNamespaceEntryCount('C').v;
     } else {
-      return m_impl->getNamespaceEntryCount('A').v;
+      try {
+        return countMimeType(
+          getMetadata("Counter"),
+          [](const std::string& mimetype) { return mimetype.find("text/html") == 0; }
+        );
+      } catch(const EntryNotFound& e) {
+        const char articleNs = m_impl->hasNewNamespaceScheme() ? 'C' : 'A';
+        return m_impl->getNamespaceEntryCount(articleNs).v;
+      }
     }
   }
-
-
 
   entry_index_type Archive::getMediaCount() const
   {

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -77,6 +77,20 @@ namespace zim
     }
   }
 
+
+
+  entry_index_type Archive::getMediaCount() const
+  {
+    return countMimeType(
+      getMetadata("Counter"),
+      [](const std::string& mimetype) {
+        return mimetype.find("image/") == 0 ||
+               mimetype.find("video/") == 0 ||
+               mimetype.find("audio/") == 0;
+      }
+    );
+  }
+
   Uuid Archive::getUuid() const
   {
     return m_impl->getFileheader().getUuid();

--- a/src/tools.h
+++ b/src/tools.h
@@ -56,6 +56,8 @@ namespace zim {
 
   std::map<std::string, int> read_valuesmap(const std::string& s);
 
+  using MimeCounterType = std::map<const std::string, zim::entry_index_type>;
+  MimeCounterType parseMimetypeCounter(const std::string& counterData);
 // Xapian based tools
 #if defined(ENABLE_XAPIAN)
   std::string removeAccents(const std::string& text);

--- a/src/tools.h
+++ b/src/tools.h
@@ -58,6 +58,18 @@ namespace zim {
 
   using MimeCounterType = std::map<const std::string, zim::entry_index_type>;
   MimeCounterType parseMimetypeCounter(const std::string& counterData);
+
+  template<class Filter>
+  entry_index_type countMimeType(const std::string& counterData, Filter filter) {
+    entry_index_type count = 0;
+    for (auto& pair: parseMimetypeCounter(counterData)) {
+      if (filter(pair.first)) {
+        count += pair.second;
+      }
+    }
+    return count;
+  }
+
 // Xapian based tools
 #if defined(ENABLE_XAPIAN)
   std::string removeAccents(const std::string& text);

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -322,9 +322,9 @@ TEST(ZimArchive, articleNumber)
      // Name                                          mediaCount,  withns                                           nons
      //                                                            {articles, userEntries, allEntries}, {articles, userEntries, allEntries}
     {"small.zim",                                     1,           { 1,       17,          17,       }, { 1,       2,           16        }},
-    {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 70,      118,         118,      }, { 66,      109,         123       }},
-    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 70,      118,         118,      }, { 66,      109,         123       }},
-    {"wikipedia_en_climate_change_nopic_2020-01.zim", 333,         { 7253,    7646,        7646,     }, { 1837,    7633,        7649      }}
+    {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 66,      118,         118,      }, { 66,      109,         123       }},
+    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 66,      118,         118,      }, { 66,      109,         123       }},
+    {"wikipedia_en_climate_change_nopic_2020-01.zim", 333,         { 1837,    7646,        7646,     }, { 1837,    7633,        7649      }}
   };
   // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
   // for small.zim, there is always 1 article, whatever the article is in 'A' namespace or in specific index.

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -302,6 +302,7 @@ struct ZimFileInfo {
 
 struct TestDataInfo {
   const char* const name;
+  zim::entry_index_type mediaCount;
   ZimFileInfo withnsInfo, nonsInfo;
 
 
@@ -318,12 +319,12 @@ struct TestDataInfo {
 TEST(ZimArchive, articleNumber)
 {
   TestDataInfo zimfiles[] = {
-     // Name                                           withns                               nons
-     //                                               {articles, userEntries, allEntries}, {articles, userEntries, allEntries}
-    {"small.zim",                                     { 1,       17,          17 },        { 1,       2,           16        }},
-    {"wikibooks_be_all_nopic_2017-02.zim",            { 70,      118,         118},        { 66,      109,         123       }},
-    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   { 70,      118,         118},        { 66,      109,         123       }},
-    {"wikipedia_en_climate_change_nopic_2020-01.zim", { 7253,    7646,        7646},       { 1837,    7633,        7649      }}
+     // Name                                          mediaCount,  withns                                           nons
+     //                                                            {articles, userEntries, allEntries}, {articles, userEntries, allEntries}
+    {"small.zim",                                     1,           { 1,       17,          17,       }, { 1,       2,           16        }},
+    {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 70,      118,         118,      }, { 66,      109,         123       }},
+    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 70,      118,         118,      }, { 66,      109,         123       }},
+    {"wikipedia_en_climate_change_nopic_2020-01.zim", 333,         { 7253,    7646,        7646,     }, { 1837,    7633,        7649      }}
   };
   // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
   // for small.zim, there is always 1 article, whatever the article is in 'A' namespace or in specific index.
@@ -336,6 +337,7 @@ TEST(ZimArchive, articleNumber)
       EXPECT_EQ( archive.getAllEntryCount(), testZimInfo.allEntryCount ) << ctx;
       EXPECT_EQ( archive.getEntryCount(), testZimInfo.entryCount ) << ctx;
       EXPECT_EQ( archive.getArticleCount(), testZimInfo.articleCount ) << ctx;
+      EXPECT_EQ( archive.getMediaCount(), testdata.mediaCount) << ctx;
     }
   }
 }

--- a/test/counterParsing.cpp
+++ b/test/counterParsing.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 Matthieu Gautier
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <zim/zim.h>
+#include "../src/tools.h"
+
+using namespace zim;
+#define parse parseMimetypeCounter
+
+namespace
+{
+TEST(ParseCounterTest, simpleMimeType)
+{
+  {
+    std::string counterStr = "";
+    MimeCounterType counterMap = {};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "foo=1";
+    MimeCounterType counterMap = {{"foo", 1}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "foo=1;text/html=50;";
+    MimeCounterType counterMap = {{"foo", 1}, {"text/html", 50}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+}
+
+TEST(ParseCounterTest, paramMimeType)
+{
+  {
+    std::string counterStr = "text/html;raw=true=1";
+    MimeCounterType counterMap = {{"text/html;raw=true", 1}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "foo=1;text/html;raw=true=50;bar=2";
+    MimeCounterType counterMap = {{"foo", 1}, {"text/html;raw=true", 50}, {"bar", 2}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "foo=1;text/html;raw=true;param=value=50;bar=2";
+    MimeCounterType counterMap = {{"foo", 1}, {"text/html;raw=true;param=value", 50}, {"bar", 2}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "foo=1;text/html;raw=true=50;bar=2";
+    MimeCounterType counterMap = {{"foo", 1}, {"text/html;raw=true", 50}, {"bar", 2}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "application/javascript=8;text/html=3;application/warc-headers=28364;text/html;raw=true=6336;text/css=47;text/javascript=98;image/png=968;image/webp=24;application/json=3694;image/gif=10274;image/jpeg=1582;font/woff2=25;text/plain=284;application/atom+xml=247;application/x-www-form-urlencoded=9;video/mp4=9;application/x-javascript=7;application/xml=1;image/svg+xml=5";
+    MimeCounterType counterMap = {
+      {"application/javascript", 8},
+      {"text/html", 3},
+      {"application/warc-headers", 28364},
+      {"text/html;raw=true", 6336},
+      {"text/css", 47},
+      {"text/javascript", 98},
+      {"image/png", 968},
+      {"image/webp", 24},
+      {"application/json", 3694},
+      {"image/gif", 10274},
+      {"image/jpeg", 1582},
+      {"font/woff2", 25},
+      {"text/plain", 284},
+      {"application/atom+xml", 247},
+      {"application/x-www-form-urlencoded", 9},
+      {"video/mp4", 9},
+      {"application/x-javascript", 7},
+      {"application/xml", 1},
+      {"image/svg+xml", 5}
+    };
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+}
+
+TEST(ParseCounterTest, wrongType)
+{
+  MimeCounterType empty = {};
+  {
+    std::string counterStr = "text/html";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html=";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html=foo";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html=123foo";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html=50;foo";
+    MimeCounterType counterMap = {{"text/html", 50}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html;foo=20";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html;foo=20;";
+    ASSERT_EQ(parse(counterStr), empty) << counterStr;
+  }
+  {
+    std::string counterStr = "text/html=50;;foo";
+    MimeCounterType counterMap = {{"text/html", 50}};
+    ASSERT_EQ(parse(counterStr), counterMap) << counterStr;
+  }
+}
+

--- a/test/counterParsing.cpp
+++ b/test/counterParsing.cpp
@@ -136,3 +136,66 @@ TEST(ParseCounterTest, wrongType)
   }
 }
 
+#define CHECK(TEST, EXPECTED) \
+{ auto count = countMimeType(counterStr, [](const std::string& s) { return TEST;}); ASSERT_EQ(count, EXPECTED); }
+
+TEST(ParseCounterTest, countMimeType) {
+  {
+    std::string counterStr = "text/html;raw=true=1";
+    CHECK(true, 1);
+    CHECK(false, 0);
+    CHECK(s.find("text/html") == 0, 1);
+    CHECK(s.find("text/html;raw=true") == 0, 1);
+  }
+  {
+    std::string counterStr = "foo=1;text/html;raw=true=50;bar=2";
+    CHECK(true, 53);
+    CHECK(false, 0);
+    CHECK(s.find("text/html") == 0, 50);
+    CHECK(s == "text/html", 0);
+    CHECK(s.find("text/html;raw=true") == 0, 50);
+    CHECK(s == "text/html;raw=true", 50);
+    CHECK(s.find("text/html;raw=true;param=value") == 0, 0);
+  }
+  {
+    std::string counterStr = "foo=1;text/html;raw=true;param=value=50;bar=2";
+    CHECK(true, 53);
+    CHECK(false, 0);
+    CHECK(s.find("text/html") == 0, 50);
+    CHECK(s.find("text/html;raw=true") == 0, 50);
+    CHECK(s == "text/html;raw=true", 0);
+    CHECK(s.find("text/html;raw=true;param=value") == 0, 50);
+  }
+  {
+    std::string counterStr = "application/javascript=8;text/html=3;application/warc-headers=28364;text/html;raw=true=6336;text/css=47;text/javascript=98;image/png=968;image/webp=24;application/json=3694;image/gif=10274;image/jpeg=1582;font/woff2=25;text/plain=284;application/atom+xml=247;application/x-www-form-urlencoded=9;video/mp4=9;application/x-javascript=7;application/xml=1;image/svg+xml=5";
+    CHECK(true, 51985);
+    CHECK(false, 0);
+    CHECK(s == "application/javascript", 8);
+    CHECK(s == "text/html", 3);
+    CHECK(s == "application/warc-headers", 28364);
+    CHECK(s == "text/html;raw=true", 6336);
+    CHECK(s == "text/css", 47);
+    CHECK(s == "text/javascript", 98);
+    CHECK(s == "image/png", 968);
+    CHECK(s == "image/webp", 24);
+    CHECK(s == "application/json", 3694);
+    CHECK(s == "image/gif", 10274);
+    CHECK(s == "image/jpeg", 1582);
+    CHECK(s == "font/woff2", 25);
+    CHECK(s == "text/plain", 284);
+    CHECK(s == "application/atom+xml", 247);
+    CHECK(s == "application/x-www-form-urlencoded", 9);
+    CHECK(s == "video/mp4", 9);
+    CHECK(s == "application/x-javascript", 7);
+    CHECK(s == "application/xml", 1);
+    CHECK(s == "image/svg+xml", 5);
+    CHECK(s.find("text/") == 0, 3+6336+47+98+284);
+    CHECK(s.find("text/html") == 0, 3+6336);
+    CHECK(s.find("application/") == 0, 8+28364+3694+247+9+7+1);
+    CHECK(s.find("image/") == 0, 968+24+10274+1582+5);
+    CHECK(s.find("xml") != std::string::npos, 247+1+5);
+    CHECK(s.find("image/") == 0 || s.find("video/") == 0 || s.find("sound/") == 0, 968+24+10274+1582+9+5);
+  }
+}
+
+};

--- a/test/meson.build
+++ b/test/meson.build
@@ -22,7 +22,8 @@ tests = [
     'tooltesting',
     'tinyString',
     'suggestion_iterator',
-    'indexing_criteria'
+    'indexing_criteria',
+    'counterParsing'
 ]
 
 if xapian_dep.found()


### PR DESCRIPTION
Fix #729 

Code is based on getArchiveMediaCount in libkiwix.
`readFullMimetypeAndCounterString` and `parseASingleMimetypeCounter` are copied from libkiwix, without modification.