### PR TITLE
Optimization of Entry::getItem()

### DIFF
--- a/include/zim/entry.h
+++ b/include/zim/entry.h
@@ -83,7 +83,7 @@ namespace zim
 
       entry_index_type getIndex() const   { return m_idx; }
 
-    private:
+    protected: // so that Item can be implemented as a wrapper over Entry
       std::shared_ptr<FileImpl> m_file;
       entry_index_type m_idx;
       std::shared_ptr<const Dirent> m_dirent;

--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -23,28 +23,27 @@
 
 #include "zim.h"
 #include "blob.h"
+#include "entry.h"
 #include <string>
 
 namespace zim
 {
-  class Dirent;
-  class FileImpl;
-
   /**
    * An `Item` in an `Archive`
    *
+   * There is no public constructor - the only way to obtain an `Item`
+   * is via `Entry::getItem()` or `Entry::getRedirect()`.
+   *
    * All `Item`'s methods are threadsafe.
    */
-  class Item
+  class Item : private Entry
   {
     public: // types
       typedef std::pair<std::string, offset_type> DirectAccessInfo;
 
     public: // functions
-      explicit Item(std::shared_ptr<FileImpl> file_, entry_index_type idx_);
-
-      std::string getTitle() const;
-      std::string getPath() const;
+      std::string getTitle() const { return Entry::getTitle(); }
+      std::string getPath() const  { return Entry::getPath(); }
       std::string getMimetype() const;
 
       /** Get the data associated to the item
@@ -87,16 +86,15 @@ namespace zim
        */
       DirectAccessInfo getDirectAccessInformation() const;
 
-      entry_index_type getIndex() const   { return m_idx; }
+      entry_index_type getIndex() const   { return Entry::getIndex(); }
 
 #ifdef ZIM_PRIVATE
       cluster_index_type getClusterIndex() const;
 #endif
 
-    private: // data
-      std::shared_ptr<FileImpl> m_file;
-      entry_index_type m_idx;
-      std::shared_ptr<const Dirent> m_dirent;
+    private: // functions
+      explicit Item(const Entry& entry);
+      friend class Entry;
   };
 
 }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -68,7 +68,7 @@ Item Entry::getItem(bool follow) const
     return getRedirect();
  }
 
-  return Item(m_file, m_idx);
+  return Item(*this);
 }
 
 Item Entry::getRedirect() const {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -20,7 +20,6 @@
 
 #define ZIM_PRIVATE
 #include <zim/item.h>
-#include "_dirent.h"
 #include "cluster.h"
 #include "fileimpl.h"
 #include "file_part.h"
@@ -30,24 +29,10 @@ log_define("zim.item")
 
 using namespace zim;
 
-Item::Item(std::shared_ptr<FileImpl> file, entry_index_type idx)
-  : m_file(file),
-    m_idx(idx),
-    m_dirent(file->getDirent(entry_index_t(idx)))
-{}
-
-std::string Item::getTitle() const
+Item::Item(const Entry& entry)
+  : Entry(entry)
 {
-  return m_dirent->getTitle();
-}
-
-std::string Item::getPath() const
-{
-  if (m_file->hasNewNamespaceScheme()) {
-    return m_dirent->getUrl();
-  } else {
-    return m_dirent->getLongUrl();
-  }
+  assert(!entry.isRedirect());
 }
 
 std::string Item::getMimetype() const


### PR DESCRIPTION
The opportunity for this easy optimization was noticed while evaluating the proposal to get rid of the dirent cache (#438). This change aligns with that proposal since it reduces the need for that kind of cache (making `Entry` serve as the cache for `Item`).

--- 

For a client of libzim the only way to create an `Item` object is through `Entry::getItem()` or `Entry::getRedirect()` (the latter relying on the former to deliver the final result).

Before this change, `Entry::getItem()` performed (via the `Item` constructor) an extra call to `FileImpl::getDirent(entry_index_t)`. Now the result of that operation that is readily available in the source `Entry` object is reused.