### PR TITLE
Correctly include `zim/tools.h`

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "tools.h"
+#include "zim/tools.h"
 #include "fs.h"
 
 #include <sys/types.h>


### PR DESCRIPTION
`setICUDataDirectory` must be declared in zim namespace if we want to define it in the same namespace.
So we must include `zim/tools.h` where the function is declared.