### PR TITLE
Correctly test for `LIBZIM_WITH_XAPIAN` instead of `ENABLE_XAPIAN`.

### DIFF
--- a/include/zim/tools.h
+++ b/include/zim/tools.h
@@ -24,7 +24,7 @@
 
 
 namespace zim {
-#if defined(ENABLE_XAPIAN)
+#if defined(LIBZIM_WITH_XAPIAN)
 
   /** Helper function to set the icu data directory.
    *


### PR DESCRIPTION
`ENABLE_XAPIAN` is a internal define.
The public define (and the one to check) is `LIBZIM_WITH_XAPIAN`.

Fix #739