### PR TITLE
Don't specify python version in Brew link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install packages
         run: |
           brew update
-          brew install gcovr pkg-config ninja || brew link --overwrite python@3.9
+          brew install gcovr pkg-config ninja || brew link --overwrite python
       - name: Install python modules
         run: pip3 install meson==0.52.1 pytest
       - name: Install deps


### PR DESCRIPTION
Looks like ninja depends on default brew python which is now python 3.11 but the action tries to link to 3.9.

See #743 