### PR TITLE
Changed minimal version of C++ standard to C++17

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libzim', ['c', 'cpp'],
   version : '8.1.0',
   license : 'GPL2',
-  default_options : ['c_std=c11', 'cpp_std=c++11'])
+  default_options : ['c_std=c11', 'cpp_std=c++17'])
 
 if build_machine.system() != 'windows'
   add_project_arguments('-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64', language: 'cpp')


### PR DESCRIPTION
Changed minimal version of C++ standard to C++14. Google Test since version 1.13.0 requires C++14.

Closes #757.