### PR TITLE
Revert "Optimization of Entry::getItem()" (on br 8.1)

### DIFF
--- a/include/zim/entry.h
+++ b/include/zim/entry.h
@@ -83,7 +83,7 @@ namespace zim
 
       entry_index_type getIndex() const   { return m_idx; }
 
-    protected: // so that Item can be implemented as a wrapper over Entry
+    private:
       std::shared_ptr<FileImpl> m_file;
       entry_index_type m_idx;
       std::shared_ptr<const Dirent> m_dirent;

--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -23,27 +23,28 @@
 
 #include "zim.h"
 #include "blob.h"
-#include "entry.h"
 #include <string>
 
 namespace zim
 {
+  class Dirent;
+  class FileImpl;
+
   /**
    * An `Item` in an `Archive`
    *
-   * There is no public constructor - the only way to obtain an `Item`
-   * is via `Entry::getItem()` or `Entry::getRedirect()`.
-   *
    * All `Item`'s methods are threadsafe.
    */
-  class Item : private Entry
+  class Item
   {
     public: // types
       typedef std::pair<std::string, offset_type> DirectAccessInfo;
 
     public: // functions
-      std::string getTitle() const { return Entry::getTitle(); }
-      std::string getPath() const  { return Entry::getPath(); }
+      explicit Item(std::shared_ptr<FileImpl> file_, entry_index_type idx_);
+
+      std::string getTitle() const;
+      std::string getPath() const;
       std::string getMimetype() const;
 
       /** Get the data associated to the item
@@ -86,15 +87,16 @@ namespace zim
        */
       DirectAccessInfo getDirectAccessInformation() const;
 
-      entry_index_type getIndex() const   { return Entry::getIndex(); }
+      entry_index_type getIndex() const   { return m_idx; }
 
 #ifdef ZIM_PRIVATE
       cluster_index_type getClusterIndex() const;
 #endif
 
-    private: // functions
-      explicit Item(const Entry& entry);
-      friend class Entry;
+    private: // data
+      std::shared_ptr<FileImpl> m_file;
+      entry_index_type m_idx;
+      std::shared_ptr<const Dirent> m_dirent;
   };
 
 }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -68,7 +68,7 @@ Item Entry::getItem(bool follow) const
     return getRedirect();
  }
 
-  return Item(*this);
+  return Item(m_file, m_idx);
 }
 
 Item Entry::getRedirect() const {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -20,6 +20,7 @@
 
 #define ZIM_PRIVATE
 #include <zim/item.h>
+#include "_dirent.h"
 #include "cluster.h"
 #include "fileimpl.h"
 #include "file_part.h"
@@ -29,10 +30,24 @@ log_define("zim.item")
 
 using namespace zim;
 
-Item::Item(const Entry& entry)
-  : Entry(entry)
+Item::Item(std::shared_ptr<FileImpl> file, entry_index_type idx)
+  : m_file(file),
+    m_idx(idx),
+    m_dirent(file->getDirent(entry_index_t(idx)))
+{}
+
+std::string Item::getTitle() const
 {
-  assert(!entry.isRedirect());
+  return m_dirent->getTitle();
+}
+
+std::string Item::getPath() const
+{
+  if (m_file->hasNewNamespaceScheme()) {
+    return m_dirent->getUrl();
+  } else {
+    return m_dirent->getLongUrl();
+  }
 }
 
 std::string Item::getMimetype() const


### PR DESCRIPTION
This reverts commit 1aca07b29d3936f4928b861d9184ac449a6e75d5.

While this change was technically correct, it removes the methods and breaks the ABI.
We shouldn't had introduced it in the 8.1 branch.

Once accepted and merged in `br_8.1`, a patch release `8.1.1` will be made. See https://github.com/openzim/python-libzim/issues/160