### PR TITLE
Prevent dereferencing of internal xapian iterator when it is end.

### DIFF
--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -56,7 +56,7 @@ class SearchIterator : public std::iterator<std::bidirectional_iterator_tag, Ent
         int getScore() const;
         std::string getSnippet() const;
         int getWordCount() const;
-        int getSize() const;
+        DEPRECATED int getSize() const;
         int getFileIndex() const;
         Uuid getZimId() const;
         reference operator*() const;

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -184,20 +184,6 @@ std::string SearchIterator::getSnippet() const {
 }
 
 int SearchIterator::getSize() const {
-    if ( ! internal ) {
-        return -1;
-    }
-    if ( ! internal->mp_internalDb->hasValuesmap() )
-    {
-        /* This is the old legacy version. Guess and try */
-        return internal->get_document().get_value(2).empty() == true ? -1 : atoi(internal->get_document().get_value(2).c_str());
-    }
-    else if ( internal->mp_internalDb->hasValue("size") )
-    {
-        return atoi(internal->get_document().get_value(internal->mp_internalDb->valueSlot("size")).c_str());
-    }
-    /* The size is never used. Do we really want to get the content and
-       calculate the size ? */
     return -1;
 }
 

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -162,9 +162,10 @@ std::string SearchIterator::getSnippet() const {
     {
         return internal->get_document().get_value(internal->mp_internalDb->valueSlot("snippet"));
     }
+
+    Entry& entry = internal->get_entry();
     /* No reader, no snippet */
     try {
-        Entry& entry = internal->get_entry();
         /* Get the content of the item to generate a snippet.
            We parse it and use the html dump to avoid remove html tags in the
            content and be able to nicely cut the text at random place. */

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -73,7 +73,7 @@ SearchIterator& SearchIterator::operator++() {
     if ( ! internal ) {
         return *this;
     }
-    ++(internal->iterator);
+    ++(internal->_iterator);
     internal->document_fetched = false;
     internal->_entry.reset();
     return *this;
@@ -89,7 +89,7 @@ SearchIterator& SearchIterator::operator--() {
     if ( ! internal ) {
         return *this;
     }
-    --(internal->iterator);
+    --(internal->_iterator);
     internal->document_fetched = false;
     internal->_entry.reset();
     return *this;
@@ -141,7 +141,7 @@ int SearchIterator::getScore() const {
     if ( ! internal ) {
         return 0;
     }
-    return internal->iterator.get_percent();
+    return internal->iterator().get_percent();
 }
 
 std::string SearchIterator::getSnippet() const {

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -61,8 +61,8 @@ TEST(search_iterator, end) {
   ASSERT_THROW(it.getTitle(), std::runtime_error);
   ASSERT_THROW(it.getPath(), std::runtime_error);
   ASSERT_EQ(it.getSnippet(), "");
-//  ASSERT_EQ(it.getScore(), 0); Unspecified, may be 0 or 1. To fix.
-  ASSERT_EQ(it.getFileIndex(), 0);
+  ASSERT_THROW(it.getScore(), std::runtime_error);
+  ASSERT_THROW(it.getFileIndex(), std::runtime_error);
   ASSERT_THROW(it.getWordCount(), std::runtime_error);
   ASSERT_EQ(it.getSize(), -1);
   ASSERT_THROW(*it, std::runtime_error);

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -60,7 +60,7 @@ TEST(search_iterator, end) {
 
   ASSERT_THROW(it.getTitle(), std::runtime_error);
   ASSERT_THROW(it.getPath(), std::runtime_error);
-  ASSERT_EQ(it.getSnippet(), "");
+  ASSERT_THROW(it.getSnippet(), std::runtime_error);
   ASSERT_THROW(it.getScore(), std::runtime_error);
   ASSERT_THROW(it.getFileIndex(), std::runtime_error);
   ASSERT_THROW(it.getWordCount(), std::runtime_error);


### PR DESCRIPTION
Initial cause for #773 is that `SearchIterator::InternalData::get_entry()` is getting the database number (with `get_databasenumber` which didn't check if iterator is end) before getting the document (which test for iterator).

So we were indeed throwing a exception (with `get_document`'s check) but we were doing some kind of out of bound just before. `-D_GLIBCXX_ASSERTIONS` make stdlibc++ catch that and so fail before we can throw the exception.

Fixing this, I've also fixed `getFileIndex` and `getScore`.
Even if `getSize` is not impacted by this bug, I take the occasion to depreciate it as it is useless.