### PR TITLE
Remove duplicated line in test/error_in_creator.

### DIFF
--- a/test/error_in_creator.cpp
+++ b/test/error_in_creator.cpp
@@ -291,7 +291,6 @@ TEST_P(FaultyDelayedItemErrorTest, faultyCompressedItem)
   zim::microsleep(sleep_time * getWaitTimeFactor());
   // We detect it for any call after
   CHECK_ASYNC_EXCEPT(creator.addMetadata("Title", "This is a title"));
-  CHECK_ASYNC_EXCEPT(creator.addMetadata("Title", "This is a title"));
   CHECK_ASYNC_EXCEPT(creator.addIllustration(48, "PNGBinaryContent48"));
   CHECK_ASYNC_EXCEPT(creator.addRedirection("foo2", "FooRedirection", "foo"));
   CHECK_ASYNC_EXCEPT(creator.finishZimCreation());


### PR DESCRIPTION
Adding twice the same entry (metadata or not) will throw a exception. But we are testing async error here.
If the async error not thrown in time because the writer thread is "slow", we will not catch the async error in time and we will throw the "wrong" exception.

Should fix #775