### PR TITLE
Fix compilation with last xcode version

### DIFF
--- a/src/file_compound.h
+++ b/src/file_compound.h
@@ -41,7 +41,7 @@ struct Range {
   const offset_t max;
 };
 
-struct less_range : public std::binary_function< Range, Range, bool>
+struct less_range
 {
   bool operator()(const Range& lhs, const Range& rhs) const {
     return lhs.min < rhs.min && lhs.max <= rhs.min;

--- a/src/zim_types.h
+++ b/src/zim_types.h
@@ -31,74 +31,29 @@
 #define PACKED
 #endif
 
-
-template<typename B>
+template<typename B, typename S>
 struct REAL_TYPEDEF{
   typedef B base_type;
+  typedef S SELF;
+
   B v;
   REAL_TYPEDEF() : v(0) {};
   explicit REAL_TYPEDEF(B v) : v(v) {};
   explicit inline operator bool() const { return v != 0; }
   explicit inline operator B() const { return v; }
 
-  inline bool operator==(const REAL_TYPEDEF<B>& rhs) const
+  inline bool operator==(const REAL_TYPEDEF<B, S>& rhs) const
   { return v == rhs.v; }
 
-  inline REAL_TYPEDEF<B>& operator++()
+  inline REAL_TYPEDEF<B, S>& operator++()
   { v++; return *this; }
 
-  inline REAL_TYPEDEF<B> operator++(int)
-  { return REAL_TYPEDEF<B>(v++); }
+  inline REAL_TYPEDEF<B, S> operator++(int)
+  { return REAL_TYPEDEF<B, S>(v++); }
 } PACKED;
 
-template<typename T> inline T& operator+= (T& lhs, const T& rhs)
-{
-  lhs.v += rhs.v;
-  return lhs;
-}
-
-template<typename T> inline T& operator+= (T& lhs, const typename T::base_type& rhs)
-{
-  lhs.v += rhs;
-  return lhs;
-}
-
-template<typename T> inline T operator+(T lhs, const T& rhs)
-{
-  lhs += rhs;
-  return lhs;
-}
-
-template<typename T> inline T& operator-=(T& lhs, const T& rhs)
-{
-  lhs.v -= rhs.v;
-  return lhs;
-}
-
-template<typename T> inline T operator-(T lhs, const T& rhs)
-{
-  lhs -= rhs;
-  return lhs;
-}
-
-template<typename T> inline bool operator< (const T& lhs, const T& rhs)
-{ return lhs.v < rhs.v; }
-
-template<typename T> inline bool operator> (const T& lhs, const T& rhs)
-{ return rhs < lhs; }
-
-template<typename T> inline bool operator<=(const T& lhs, const T& rhs)
-{ return !(lhs > rhs); }
-
-template<typename T> inline bool operator>=(const T& lhs, const T& rhs)
-{ return !(lhs < rhs); }
-
-template<typename T> inline bool operator!=(const T& lhs, const T& rhs)
-{ return !(lhs == rhs); }
-
-
-template<typename B>
-std::ostream& operator<<(std::ostream& os, const REAL_TYPEDEF<B>& obj)
+template<typename B, typename S>
+std::ostream& operator<<(std::ostream& os, const REAL_TYPEDEF<B, S>& obj)
 {
     os << obj.v;
     return os;
@@ -106,9 +61,20 @@ std::ostream& operator<<(std::ostream& os, const REAL_TYPEDEF<B>& obj)
 
 namespace zim {
 
-#define TYPEDEF(NAME, TYPE) struct NAME : public REAL_TYPEDEF<TYPE> { \
-explicit NAME(TYPE v=0) : REAL_TYPEDEF<TYPE>(v) {}; } PACKED; \
-static_assert(sizeof(NAME) == sizeof(TYPE), "");
+#define TYPEDEF(NAME, TYPE) struct NAME : public REAL_TYPEDEF<TYPE, NAME> {          \
+explicit NAME(TYPE v=0) : REAL_TYPEDEF<TYPE, NAME>(v) {}; } PACKED;                  \
+static_assert(sizeof(NAME) == sizeof(TYPE), "");                                     \
+inline NAME& operator+= (NAME& lhs, const NAME& rhs) { lhs.v += rhs.v; return lhs; } \
+inline NAME& operator+= (NAME& lhs, const TYPE& rhs) { lhs.v += rhs; return lhs; }   \
+inline NAME operator+(NAME lhs, const NAME& rhs) { lhs += rhs; return lhs; }         \
+inline NAME& operator-=(NAME& lhs, const NAME& rhs) { lhs.v -= rhs.v; return lhs; }  \
+inline NAME operator-(NAME lhs, const NAME& rhs) { lhs -= rhs; return lhs; }         \
+inline bool operator< (const NAME& lhs, const NAME& rhs) { return lhs.v < rhs.v; }   \
+inline bool operator> (const NAME& lhs, const NAME& rhs) { return rhs < lhs; }       \
+inline bool operator<=(const NAME& lhs, const NAME& rhs) { return !(lhs > rhs); }    \
+inline bool operator>=(const NAME& lhs, const NAME& rhs) { return !(lhs < rhs); }    \
+inline bool operator!=(const NAME& lhs, const NAME& rhs) { return !(lhs == rhs); }
+
 
 TYPEDEF(entry_index_t, entry_index_type)
 TYPEDEF(title_index_t, entry_index_type)

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -33,7 +33,6 @@
 #include "concurrent_cache.h"
 #include "gtest/gtest.h"
 
-const int NUM_OF_TEST1_RECORDS = 100;
 const int NUM_OF_TEST2_RECORDS = 100;
 const int TEST2_CACHE_CAPACITY = 50;
 


### PR DESCRIPTION
Fixes #778 (hopefully this PR will be enough)

This PR fails on macOS because its compiler is recenter and stricter than others. The code needs to be slightly fixed to avoid the compiler complaining. Something necessary anyway if we want to move to C++14/17 like requested in #757.