### PR TITLE
Update the CI and add `aarch_dyn` target.

### DIFF
--- a/.github/script/build_libzim.cmd
+++ b/.github/script/build_libzim.cmd
@@ -3,7 +3,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliar
 set CC=cl.exe
 set CXX=cl.exe
 
-meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dwith_xapian=false -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static -Dliblzma:enable_xz=false
+meson.exe setup build . --force-fallback-for liblzma -Ddefault_library=static -Dwith_xapian=false -Dzstd:bin_programs=false -Dzstd:bin_tests=false -Dzstd:bin_contrib=false -Dliblzma:default_library=static
 
 cd build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,24 +122,24 @@ jobs:
           - target: native_dyn
             image_variant: bionic
             lib_postfix: '/x86_64-linux-gnu'
+          - target: alpine_dyn
+            image_variant: alpine
+            lib_postfix: '/x86_64-linux-musl'
           - target: android_arm
             image_variant: bionic
             lib_postfix: '/arm-linux-androideabi'
           - target: android_arm64
             image_variant: bionic
             lib_postfix: '/aarch64-linux-android'
-          - target: wasm
-            image_variant: bionic
-            lib_postfix: '/x86_64-linux-gnu'
-          - target: alpine_dyn
-            image_variant: alpine
-            lib_postfix: '/x86_64-linux-musl'
           - target: win32_static
             image_variant: f35
             lib_postfix: '64'
           - target: win32_dyn
             image_variant: f35
             lib_postfix: '64'
+          - target: wasm
+            image_variant: bionic
+            lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,19 +117,19 @@ jobs:
           - false
         include:
           - target: native_static
-            image_variant: bionic
+            image_variant: focal
             lib_postfix: '/x86_64-linux-gnu'
           - target: native_dyn
-            image_variant: bionic
+            image_variant: focal
             lib_postfix: '/x86_64-linux-gnu'
           - target: alpine_dyn
             image_variant: alpine
             lib_postfix: '/x86_64-linux-musl'
           - target: android_arm
-            image_variant: bionic
+            image_variant: focal
             lib_postfix: '/arm-linux-androideabi'
           - target: android_arm64
-            image_variant: bionic
+            image_variant: focal
             lib_postfix: '/aarch64-linux-android'
           - target: win32_static
             image_variant: f35
@@ -138,7 +138,7 @@ jobs:
             image_variant: f35
             lib_postfix: '64'
           - target: wasm
-            image_variant: bionic
+            image_variant: focal
             lib_postfix: '/x86_64-linux-gnu'
     env:
       HOME: /home/runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           then
             MESON_OPTION="$MESON_OPTION -Dexamples=false"
           fi
-          meson . build ${MESON_OPTION} -Dwith_xapian=${{matrix.with_xapian}}
+          meson setup . build ${MESON_OPTION} -Dwith_xapian=${{matrix.with_xapian}}
           cd build
           ninja
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:36"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:37"
 
     steps:
       - name: Install dependences

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           - native_static
           - native_dyn
           - alpine_dyn
+          - aarch64_dyn
           - android_arm
           - android_arm64
           - win32_static
@@ -125,6 +126,9 @@ jobs:
           - target: alpine_dyn
             image_variant: alpine
             lib_postfix: '/x86_64-linux-musl'
+          - target: aarch64_dyn
+            image_variant: focal
+            lib_postfix: '/aarch64-linux-gnu'
           - target: android_arm
             image_variant: focal
             lib_postfix: '/arm-linux-androideabi'

--- a/subprojects/liblzma.wrap
+++ b/subprojects/liblzma.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = xz-5.2.1
-
-source_url = http://tukaani.org/xz/xz-5.2.1.tar.xz
-source_filename = xz-5.2.1.tar.xz
-source_hash = 6ecdd4d80b12001497df0741d6037f918d270fa0f9a1ab4e2664bf4157ae323c
-
-patch_url = https://mirror.download.kiwix.org/dev/xz-5.2.1-wrap.zip
-patch_filename = xz-5.2.1-wrap.zip
-patch_hash = 782a4e56bcc26ebda18041a05f2f85dce70284109a5ce99ea960c6b4432a99e9
+directory = xz-5.2.11
+source_url = http://tukaani.org/xz/xz-5.2.11.tar.xz
+source_filename = xz-5.2.11.tar.xz
+source_hash = 503b4a9fb405e70e1d3912e418fdffe5de27e713e58925fb67e12d20d03a77bc
+patch_filename = liblzma_5.2.11-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/liblzma_5.2.11-2/get_patch
+patch_hash = 1a1a008b2f3a81e7332d8d5d28df16df70488038901496fe73c734afab74c645
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liblzma_5.2.11-2/xz-5.2.11.tar.xz
+wrapdb_version = 5.2.11-2
 
 [provide]
 liblzma = lzma_dep


### PR DESCRIPTION
Fix https://github.com/openzim/libzim/issues/702

This also remove a dependency to https://mirror.download.kiwix.org/dev/xz-5.2.1-wrap.zip as we now use (wrapdb) upstream wrap. (the same way we have fixed #663)

Depends of https://github.com/kiwix/kiwix-build/pull/596