### PR TITLE
fix: dll export issue on Windows

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -480,14 +480,14 @@ namespace zim
   };
 
   template<EntryOrder order>
-  entry_index_type _toPathOrder(const FileImpl& file, entry_index_type idx);
+  LIBZIM_API entry_index_type _toPathOrder(const FileImpl& file, entry_index_type idx);
 
   template<>
-  entry_index_type _toPathOrder<EntryOrder::pathOrder>(const FileImpl& file, entry_index_type idx);
+  LIBZIM_API entry_index_type _toPathOrder<EntryOrder::pathOrder>(const FileImpl& file, entry_index_type idx);
   template<>
-  entry_index_type _toPathOrder<EntryOrder::titleOrder>(const FileImpl& file, entry_index_type idx);
+  LIBZIM_API entry_index_type _toPathOrder<EntryOrder::titleOrder>(const FileImpl& file, entry_index_type idx);
   template<>
-  entry_index_type _toPathOrder<EntryOrder::efficientOrder>(const FileImpl& file, entry_index_type idx);
+  LIBZIM_API entry_index_type _toPathOrder<EntryOrder::efficientOrder>(const FileImpl& file, entry_index_type idx);
 
 
   /**
@@ -498,7 +498,7 @@ namespace zim
    * An `EntryRange` can't be modified is consequently threadsafe.
    */
   template<EntryOrder order>
-  class Archive::EntryRange {
+  class LIBZIM_API Archive::EntryRange {
     public:
       explicit EntryRange(const std::shared_ptr<FileImpl> file, entry_index_type begin, entry_index_type end)
         : m_file(file),
@@ -541,7 +541,7 @@ private:
    * An `EntryRange` can't be modified and is consequently threadsafe.
    */
   template<EntryOrder order>
-  class Archive::iterator : public std::iterator<std::bidirectional_iterator_tag, Entry>
+  class LIBZIM_API Archive::iterator : public std::iterator<std::bidirectional_iterator_tag, Entry>
   {
     public:
       explicit iterator(const std::shared_ptr<FileImpl> file, entry_index_type idx)

--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -33,13 +33,13 @@
 #define DEPRECATED
 #endif
 
+#include <zim/zim_config.h>
+
 #if (defined _WIN32 || defined __CYGWIN__) && defined LIBZIM_EXPORT_DLL
     #define LIBZIM_API __declspec(dllexport)
 #else
     #define LIBZIM_API
 #endif
-
-#include <zim/zim_config.h>
 
 namespace zim
 {

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ lzma_dep = dependency('liblzma', static:static_linkage)
 if static_linkage
   add_project_arguments('-DLZMA_API_STATIC', language: 'cpp')
 else
-  private_conf.set('LIBZIM_EXPORT_DLL', true)
+  public_conf.set('LIBZIM_EXPORT_DLL', true)
 endif
 
 zstd_dep = dependency('libzstd', static:static_linkage)


### PR DESCRIPTION
supercedes https://github.com/openzim/libzim/pull/792

fixes #795

try to fix the dll export issue on Windows. 

The current situation :
the dll exported is not whole ,  most of the methods have not been exported to the dll .  which is disscussed in this https://github.com/openzim/libzim/issues/795

The reason:
When put LIBZIM_EXPORT_DLL in private_conf, the generated config.h was not included in zim.h . That's why it does not work
while -DLIBZIM_EXPORT_DLL works.

The solution:
move LIBZIM_EXPORT_DLL  to public_conf which will be generate in `zim/zim_config.h`
and put the include file before the macro check 