### PR TITLE
Avoid working on too long strings when removing accents.

### DIFF
--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -21,6 +21,11 @@
 
 #include "gtest/gtest.h"
 #include <sstream>
+#include <string>
+
+#if defined(ENABLE_XAPIAN)
+  #include <unicode/unistr.h>
+#endif
 
 namespace {
   TEST(Tools, wordCount) {
@@ -59,12 +64,58 @@ namespace {
   TEST(Tools, removeAccents) {
     ASSERT_EQ(zim::removeAccents("bépoàǹ"), "bepoan");
     std::ostringstream ss;
-    for(auto i=0; i<4*1024; i++) {
+    // Create 2 and half batches (3 boundaries) of 4kb.
+    // Each bondary has its property:
+    // - A 4 bytes chars being cut by the boundary
+    // - A "é" stored in NDF form when the "e" is before the boundary and the "´" is after
+    // - Nothing special
+    for(auto j=0; j<1023; j++) {
+      ss << "bépo";
+    }
+    ss << "bép𩸽";
+    for(auto j=0; j<1023; j++) {
+      ss << "bépo";
+    }
+    ss << "bép" << "e" << "\xcc\x81";
+    for (auto j=0; j<512; j++) {
       ss << "bépo";
     }
     auto accentedString(ss.str());
+    // Check our input data (that we have a char in the middle of a batch boundary)
+    // Indexing is made on u16
+    icu::UnicodeString ustring(accentedString.c_str());
+
+    // Test input data.
+    // "bépo" is 4 chars
+    ASSERT_EQ(ustring.getChar32Limit(0), 0);
+    ASSERT_EQ(ustring.getChar32Limit(1), 1);
+    ASSERT_EQ(ustring.getChar32Limit(2), 2);
+    ASSERT_EQ(ustring.getChar32Limit(3), 3);
+    ASSERT_EQ(ustring.getChar32Limit(4), 4);
+    // 𩸽 is in the middle of a boundary
+    ASSERT_EQ(ustring.getChar32Limit(4*1024-1), 4*1024-1);
+    ASSERT_EQ(ustring.getChar32Limit(4*1024), 4*1024+1);
+    ASSERT_EQ(ustring.getChar32Limit(4*1024+1), 4*1024+1);
+    // Because of 𩸽 at first boundary, second boundary will search at (4*1024+1) + 4*1024 so 8*1024+1
+    ASSERT_EQ(ustring.getChar32Limit(8*1024), 8*1024);
+    ASSERT_EQ(ustring.getChar32Limit(8*1024+1), 8*1024+1);
+    ASSERT_EQ(ustring.getChar32Limit(8*1024+2), 8*1024+2);
+    // boundary is in the middle of "e´"
+    EXPECT_EQ(ustring[8*1024-1], 'p'); // boundary - 2
+    EXPECT_EQ(ustring[8*1024], 'e'); // boundary - 1
+    EXPECT_EQ(ustring[8*1024+1], 0x0301); // boundary. Unicode symbol for '´' (utf16: 0x0301, utf8 : 0xCC 0x81)
+    EXPECT_EQ(ustring[8*1024+2], 'b'); // boundary + 1
+    EXPECT_EQ(ustring[8*1024+3], 233 /*ascii code for é*/); // boundary + 2
     ss.str("");
-    for(auto i=0; i<4*1024; i++) {
+    for(auto j=0; j<1023; j++) {
+      ss << "bepo";
+    }
+    ss << "bep𩸽";
+    for(auto j=0; j<1023; j++) {
+      ss << "bepo";
+    }
+    ss << "bep" << "e";
+    for (auto j=0; j<512; j++) {
       ss << "bepo";
     }
     auto unaccentedString(ss.str());

--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -20,6 +20,7 @@
 #include "../src/tools.h"
 
 #include "gtest/gtest.h"
+#include <sstream>
 
 namespace {
   TEST(Tools, wordCount) {
@@ -54,4 +55,20 @@ namespace {
     ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_1 28x1 28@1"), std::runtime_error);
   }
 
+#if defined(ENABLE_XAPIAN)
+  TEST(Tools, removeAccents) {
+    ASSERT_EQ(zim::removeAccents("bépoàǹ"), "bepoan");
+    std::ostringstream ss;
+    for(auto i=0; i<4*1024; i++) {
+      ss << "bépo";
+    }
+    auto accentedString(ss.str());
+    ss.str("");
+    for(auto i=0; i<4*1024; i++) {
+      ss << "bepo";
+    }
+    auto unaccentedString(ss.str());
+    ASSERT_EQ(zim::removeAccents(accentedString), unaccentedString);
+  }
+#endif
 }


### PR DESCRIPTION
My use case is a 20Mb french text string to index, on my computer, a simple "transliterate" takes around 50 minutes to finish.

If we assume a ratio of 1/10 letter with accents, a 20 million char text would need `20M/10[number of replacement] * 20M/2[number of char to move]` moves. It is something like : `2*10^13` char moves.

By using batch of 4K, we have `4K/10*4K/2=0.8M` moves per batch. And we have `20M/4K=5000` batches.
So a total of `5000*0.8M=4G (4*10^9)`.
The ratio is 5000. So we could expect a code running 5000 times faster.

In practice, it goes from 49 minutes to 3 or 4 seconds.

@rgaudin It would be nice to know the real improvement in speed (if any) with a more common content.