### PR TITLE
Make search remove accents from the queried string.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -151,14 +151,15 @@ Xapian::Query InternalDataBase::parseQuery(const Query& query)
 {
   Xapian::Query xquery;
 
-  xquery = m_queryParser.parse_query(query.m_query, Xapian::QueryParser::FLAG_CJK_NGRAM);
+  const auto unaccentedQuery = removeAccents(query.m_query);
+  xquery = m_queryParser.parse_query(unaccentedQuery, Xapian::QueryParser::FLAG_CJK_NGRAM);
 
   if (query.m_geoquery && hasValue("geo.position")) {
     Xapian::GreatCircleMetric metric;
     Xapian::LatLongCoord centre(query.m_latitude, query.m_longitude);
     Xapian::LatLongDistancePostingSource ps(valueSlot("geo.position"), centre, metric, query.m_distance);
     Xapian::Query geoQuery(&ps);
-    if (query.m_query.empty()) {
+    if (unaccentedQuery.empty()) {
       xquery = geoQuery;
     } else {
       xquery = Xapian::Query(Xapian::Query::OP_FILTER, xquery, geoQuery);

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -319,7 +319,9 @@ TEST(Search, accents)
     zim::Query query("test àrticlé");
     auto search = searcher.search(query);
 
-    ASSERT_EQ(0, search.getEstimatedMatches());
+    ASSERT_EQ(archive.getEntryCount(), search.getEstimatedMatches());
+    auto result = search.getResults(0, 1);
+    ASSERT_EQ(result.begin().getTitle(), "Test Article0");
   }
 }
 } // unnamed namespace


### PR DESCRIPTION
Fix kiwix/libkiwix#953

This is libzim (through defaultIndexer) which removing accents at indexation. We should do the same when searching.