### PR TITLE
`getMediaCount` do not fail if `M/Counter` is missing.

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -85,14 +85,19 @@ namespace zim
 
   entry_index_type Archive::getMediaCount() const
   {
-    return countMimeType(
-      getMetadata("Counter"),
-      [](const std::string& mimetype) {
-        return mimetype.find("image/") == 0 ||
-               mimetype.find("video/") == 0 ||
-               mimetype.find("audio/") == 0;
-      }
-    );
+    try {
+      return countMimeType(
+        getMetadata("Counter"),
+        [](const std::string& mimetype) {
+          return mimetype.find("image/") == 0 ||
+                 mimetype.find("video/") == 0 ||
+                 mimetype.find("audio/") == 0;
+        }
+      );
+    } catch(const EntryNotFound& e) {
+      return (m_impl->getNamespaceEntryCount('I').v
+            + m_impl->getNamespaceEntryCount('J').v);
+    }
   }
 
   Uuid Archive::getUuid() const

--- a/src/dirent_lookup.h
+++ b/src/dirent_lookup.h
@@ -131,6 +131,10 @@ entry_index_t getNamespaceBeginOffset(TDirentAccessor& direntAccessor, char ch)
   ASSERT(ch, >=, 32);
   ASSERT(ch, <=, 127);
 
+  if (direntAccessor.getDirentCount().v == 0) {
+    return entry_index_t(0);
+  }
+
   entry_index_type lower = 0;
   entry_index_type upper = entry_index_type(direntAccessor.getDirentCount());
   auto d = direntAccessor.getDirent(entry_index_t(0));

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -105,6 +105,9 @@ TEST(ZimArchive, openingAnEmptyZimArchiveSucceeds)
 
   zim::Archive archive(tmpfile->path());
   ASSERT_TRUE(archive.check());
+
+  ASSERT_EQ(archive.getMediaCount(), 0);
+  ASSERT_EQ(archive.getArticleCount(), 0);
 }
 
 bool isNastyOffset(int offset) {


### PR DESCRIPTION
- `M/Counter` is not mandatory.
- zimcheck doesn't check for it.
- we already accept a missing `M/Counter` in `getArticleCount`.

No reason to fail in `getMediaCount` if `M/Counter` is missing.

We test it by reading an empty zim file.
This reveal a bug in `getNamespaceBeginOffset` when there is no dirent in the direntAccessor.

Fix kiwix/kiwix-tools#640