### PR TITLE
Correctly handle failing mmap on FileReader.

### DIFF
--- a/src/file_reader.cpp
+++ b/src/file_reader.cpp
@@ -53,9 +53,8 @@ MultiPartFileReader::MultiPartFileReader(std::shared_ptr<const FileCompound> sou
   : MultiPartFileReader(source, offset_t(0), source->fsize()) {}
 
 MultiPartFileReader::MultiPartFileReader(std::shared_ptr<const FileCompound> source, offset_t offset, zsize_t size)
-  : source(source),
-    _offset(offset),
-    _size(size)
+  : BaseFileReader(offset, size),
+    source(source)
 {
   ASSERT(offset.v, <=, source->fsize().v);
   ASSERT(offset.v+size.v, <=, source->fsize().v);
@@ -229,9 +228,8 @@ std::unique_ptr<const Reader> MultiPartFileReader::sub_reader(offset_t offset, z
 ////////////////////////////////////////////////////////////////////////////////
 
 FileReader::FileReader(FileHandle fh, offset_t offset, zsize_t size)
-  : _fhandle(fh)
-  , _offset(offset)
-  , _size(size)
+  : BaseFileReader(offset, size)
+    , _fhandle(fh)
 {
 }
 

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -36,6 +36,10 @@ class BaseFileReader : public Reader {
     zsize_t size() const { return _size; };
     offset_t offset() const { return _offset; };
 
+    virtual const Buffer get_mmap_buffer(offset_t offset,
+                                         zsize_t size) const = 0;
+    const Buffer get_buffer(offset_t offset, zsize_t size) const;
+
   protected: // data
     offset_t _offset;
     zsize_t _size;
@@ -50,9 +54,9 @@ class FileReader : public BaseFileReader {
     ~FileReader() = default;
 
     char read(offset_t offset) const;
-    void read(char* dest, offset_t offset, zsize_t size) const;
-    const Buffer get_buffer(offset_t offset, zsize_t size) const;
+    void read(char *dest, offset_t offset, zsize_t size) const;
 
+    const Buffer get_mmap_buffer(offset_t offset, zsize_t size) const;
     std::unique_ptr<const Reader> sub_reader(offset_t offset, zsize_t size) const;
 
   private: // data
@@ -68,9 +72,9 @@ class MultiPartFileReader : public BaseFileReader {
     ~MultiPartFileReader() {};
 
     char read(offset_t offset) const;
-    void read(char* dest, offset_t offset, zsize_t size) const;
-    const Buffer get_buffer(offset_t offset, zsize_t size) const;
+    void read(char *dest, offset_t offset, zsize_t size) const;
 
+    const Buffer get_mmap_buffer(offset_t offset, zsize_t size) const;
     std::unique_ptr<const Reader> sub_reader(offset_t offset, zsize_t size) const;
 
   private:

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -33,7 +33,7 @@ class FileReader : public Reader {
     typedef std::shared_ptr<const DEFAULTFS::FD> FileHandle;
 
   public: // functions
-    explicit FileReader(FileHandle fh, offset_t offset, zsize_t size);
+    FileReader(FileHandle fh, offset_t offset, zsize_t size);
     ~FileReader() = default;
 
     zsize_t size() const { return _size; };
@@ -56,7 +56,7 @@ class FileReader : public Reader {
 
 class MultiPartFileReader : public Reader {
   public:
-    MultiPartFileReader(std::shared_ptr<const FileCompound> source);
+    explicit MultiPartFileReader(std::shared_ptr<const FileCompound> source);
     ~MultiPartFileReader() {};
 
     zsize_t size() const { return _size; };

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -28,16 +28,26 @@ namespace zim {
 
 class FileCompound;
 
-class FileReader : public Reader {
+class BaseFileReader : public Reader {
+  public: // functions
+    BaseFileReader(offset_t offset, zsize_t size)
+      : _offset(offset), _size(size) {}
+    ~BaseFileReader() = default;
+    zsize_t size() const { return _size; };
+    offset_t offset() const { return _offset; };
+
+  protected: // data
+    offset_t _offset;
+    zsize_t _size;
+};
+
+class FileReader : public BaseFileReader {
   public: // types
     typedef std::shared_ptr<const DEFAULTFS::FD> FileHandle;
 
   public: // functions
     FileReader(FileHandle fh, offset_t offset, zsize_t size);
     ~FileReader() = default;
-
-    zsize_t size() const { return _size; };
-    offset_t offset() const { return _offset; };
 
     char read(offset_t offset) const;
     void read(char* dest, offset_t offset, zsize_t size) const;
@@ -50,17 +60,12 @@ class FileReader : public Reader {
     // by a sub_reader (otherwise the file handle would be invalidated by
     // FD destructor when the sub-reader is destroyed).
     FileHandle _fhandle;
-    offset_t _offset;
-    zsize_t _size;
 };
 
-class MultiPartFileReader : public Reader {
+class MultiPartFileReader : public BaseFileReader {
   public:
     explicit MultiPartFileReader(std::shared_ptr<const FileCompound> source);
     ~MultiPartFileReader() {};
-
-    zsize_t size() const { return _size; };
-    offset_t offset() const { return _offset; };
 
     char read(offset_t offset) const;
     void read(char* dest, offset_t offset, zsize_t size) const;
@@ -72,8 +77,6 @@ class MultiPartFileReader : public Reader {
     MultiPartFileReader(std::shared_ptr<const FileCompound> source, offset_t offset, zsize_t size);
 
     std::shared_ptr<const FileCompound> source;
-    offset_t _offset;
-    zsize_t _size;
 };
 
 };


### PR DESCRIPTION
If we try to mmap a region to high (>4GB), `makeMmappedBuffer` will throw a `MMapException`. In this case, we want to do a read in the file instead of mmap.

This case is handled in `MultiPartFileReader` but was missing in `FileReader`.

Fix #866