### PR TITLE
Rename `*Url*` symbols to `*Path*`.

### DIFF
--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -95,7 +95,7 @@ namespace zim
     CHECKSUM,
 
     /**
-     * Checks that offsets in UrlPtrList are valid.
+     * Checks that offsets in PathPtrList are valid.
      */
     DIRENT_PTRS,
 

--- a/src/_dirent.h
+++ b/src/_dirent.h
@@ -46,7 +46,7 @@ namespace zim
 
       char ns;
       std::string title;
-      std::string url;
+      std::string path;
       std::string parameter;
 
     public:
@@ -79,15 +79,15 @@ namespace zim
       entry_index_t getRedirectIndex() const      { return isRedirect() ? redirectIndex : entry_index_t(0); }
 
       char getNamespace() const               { return ns; }
-      const std::string& getTitle() const     { return title.empty() ? url : title; }
-      const std::string& getUrl() const       { return url; }
-      std::string getLongUrl() const;
+      const std::string &getTitle() const     { return title.empty() ? path : title; }
+      const std::string &getPath() const      { return path; }
+      std::string getLongPath() const;
       const std::string& getParameter() const { return parameter; }
 
       size_t getDirentSize() const
       {
-        size_t ret = (isRedirect() ? 12 : 16) + url.size() + parameter.size() + 2;
-        if (title != url)
+        size_t ret = (isRedirect() ? 12 : 16) + path.size() + parameter.size() + 2;
+        if (title != path)
           ret += title.size();
         return ret;
       }
@@ -97,10 +97,10 @@ namespace zim
         title = title_;
       }
 
-      void setUrl(char ns_, const std::string& url_)
+      void setPath(char ns_, const std::string &path_)
       {
         ns = ns_;
-        url = url_;
+        path = path_;
       }
 
       void setParameter(const std::string& parameter_)

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -136,7 +136,7 @@ namespace zim
     auto end = m_impl->getNamespaceEndOffset('M');
     for (auto idx=start; idx!=end; idx++) {
       auto dirent = m_impl->getDirent(idx);
-      ret.push_back(dirent->getUrl());
+      ret.push_back(dirent->getPath());
     }
     return ret;
   }

--- a/src/dirent.cpp
+++ b/src/dirent.cpp
@@ -76,21 +76,21 @@ namespace zim
       dirent.setItem(mimeType, cluster_index_t(clusterNumber), blob_index_t(blobNumber));
     }
 
-    std::string url;
+    std::string path;
     std::string title;
     std::string parameter;
 
-    log_debug("read url, title and parameters");
+    log_debug("read path, title and parameters");
 
-    size_type url_size = strnlen(
+    size_type path_size = strnlen(
       reader.current(),
       reader.left().v - extraLen
     );
-    if (url_size >= reader.left().v) {
+    if (path_size >= reader.left().v) {
       return false;
     }
-    url = std::string(reader.current(), url_size);
-    reader.skip(zsize_t(url_size+1));
+    path = std::string(reader.current(), path_size);
+    reader.skip(zsize_t(path_size + 1));
 
     size_type title_size = strnlen(
       reader.current(),
@@ -106,7 +106,7 @@ namespace zim
       return false;
     }
     parameter = std::string(reader.current(), extraLen);
-    dirent.setUrl(ns, url);
+    dirent.setPath(ns, path);
     dirent.setTitle(title);
     dirent.setParameter(parameter);
     return true;
@@ -120,12 +120,12 @@ namespace zim
     }
 
     // We don't know the size of the dirent because it depends of the size of
-    // the title, url and extra parameters.
+    // the title, path and extra parameters.
     // This is a pity but we have no choice.
     // We cannot take a buffer of the size of the file, it would be really
     // inefficient. Let's do try, catch and retry while chosing a smart value
     // for the buffer size. Most dirent will be "Article" entry (header's size
-    // == 16) without extra parameters. Let's hope that url + title size will
+    // == 16) without extra parameters. Let's hope that path + title size will
     // be < 256 and if not try again with a bigger size.
 
     size_t bufferSize(std::min(size_type(256), mp_zimReader->size().v-offset.v));
@@ -139,12 +139,12 @@ namespace zim
     }
   }
 
-  std::string Dirent::getLongUrl() const
+  std::string Dirent::getLongPath() const
   {
-    log_trace("Dirent::getLongUrl()");
+    log_trace("Dirent::getLongPath()");
     log_debug("namespace=" << getNamespace() << " title=" << getTitle());
 
-    return std::string(1, getNamespace()) + '/' + getUrl();
+    return std::string(1, getNamespace()) + '/' + getPath();
   }
 
 }

--- a/src/dirent_accessor.cpp
+++ b/src/dirent_accessor.cpp
@@ -29,9 +29,12 @@
 
 using namespace zim;
 
-DirectDirentAccessor::DirectDirentAccessor(std::shared_ptr<DirentReader> direntReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount)
+DirectDirentAccessor::DirectDirentAccessor(
+  std::shared_ptr<DirentReader> direntReader,
+  std::unique_ptr<const Reader> pathPtrReader,
+  entry_index_t direntCount)
   : mp_direntReader(direntReader),
-    mp_urlPtrReader(std::move(urlPtrReader)),
+    mp_pathPtrReader(std::move(pathPtrReader)),
     m_direntCount(direntCount),
     m_direntCache(envValue("ZIM_DIRENTCACHE", DIRENT_CACHE_SIZE)),
     m_bufferDirentZone(256)
@@ -60,7 +63,7 @@ offset_t DirectDirentAccessor::getOffset(entry_index_t idx) const
   if (idx >= m_direntCount) {
     throw std::out_of_range("entry index out of range");
   }
-  offset_t offset(mp_urlPtrReader->read_uint<offset_type>(offset_t(sizeof(offset_type)*idx.v)));
+  offset_t offset(mp_pathPtrReader->read_uint<offset_type>(offset_t(sizeof(offset_type)*idx.v)));
   return offset;
 }
 

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -45,7 +45,9 @@ class DirentReader;
 class DirectDirentAccessor
 {
 public: // functions
-  DirectDirentAccessor(std::shared_ptr<DirentReader> direntReader, std::unique_ptr<const Reader> urlPtrReader, entry_index_t direntCount);
+  DirectDirentAccessor(std::shared_ptr<DirentReader> direntReader,
+                       std::unique_ptr<const Reader> pathPtrReader,
+                       entry_index_t direntCount);
 
   offset_t    getOffset(entry_index_t idx) const;
   std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
@@ -56,7 +58,7 @@ private: // functions
 
 private: // data
   std::shared_ptr<DirentReader>  mp_direntReader;
-  std::unique_ptr<const Reader>  mp_urlPtrReader;
+  std::unique_ptr<const Reader>  mp_pathPtrReader;
   entry_index_t                  m_direntCount;
 
   mutable lru_cache<entry_index_type, std::shared_ptr<const Dirent>> m_direntCache;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -43,9 +43,9 @@ std::string Entry::getTitle() const
 std::string Entry::getPath() const
 {
   if (m_file->hasNewNamespaceScheme()) {
-    return m_dirent->getUrl();
+    return m_dirent->getPath();
   } else {
-    return m_dirent->getLongUrl();
+    return m_dirent->getLongPath();
   }
 }
 

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -53,7 +53,7 @@ namespace zim
     std::copy(getUuid().data, getUuid().data + sizeof(Uuid), header + 8);
     toLittleEndian(getArticleCount(), header + 24);
     toLittleEndian(getClusterCount(), header + 28);
-    toLittleEndian(getUrlPtrPos(), header + 32);
+    toLittleEndian(getPathPtrPos(), header + 32);
     toLittleEndian(getTitleIdxPos(), header + 40);
     toLittleEndian(getClusterPtrPos(), header + 48);
     toLittleEndian(getMimeListPos(), header + 56);
@@ -100,7 +100,7 @@ namespace zim
 
     setArticleCount(seqReader.read<uint32_t>());
     setClusterCount(seqReader.read<uint32_t>());
-    setUrlPtrPos(seqReader.read<uint64_t>());
+    setPathPtrPos(seqReader.read<uint64_t>());
     setTitleIdxPos(seqReader.read<uint64_t>());
     setClusterPtrPos(seqReader.read<uint64_t>());
     setMimeListPos(seqReader.read<uint64_t>());
@@ -120,8 +120,8 @@ namespace zim
       throw ZimFileFormatError("mimelistPos must be 80.");
     }
 
-    if (urlPtrPos < mimeListPos) {
-      throw ZimFileFormatError("urlPtrPos must be > mimelistPos.");
+    if (pathPtrPos < mimeListPos) {
+      throw ZimFileFormatError("pathPtrPos must be > mimelistPos.");
     }
     if (titleIdxPos < mimeListPos) {
       throw ZimFileFormatError("titleIdxPos must be > mimelistPos.");

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -48,7 +48,7 @@ namespace zim
       Uuid uuid;
       entry_index_type articleCount;
       offset_type titleIdxPos;
-      offset_type urlPtrPos;
+      offset_type pathPtrPos;
       offset_type mimeListPos;
       cluster_index_type clusterCount;
       offset_type clusterPtrPos;
@@ -62,7 +62,7 @@ namespace zim
           minorVersion(zimMinorVersion),
           articleCount(0),
           titleIdxPos(0),
-          urlPtrPos(0),
+          pathPtrPos(0),
           clusterCount(0),
           clusterPtrPos(0),
           mainPage(std::numeric_limits<entry_index_type>::max()),
@@ -92,8 +92,8 @@ namespace zim
       offset_type getTitleIdxPos() const           { return titleIdxPos; }
       void        setTitleIdxPos(offset_type p)    { titleIdxPos = p; }
 
-      offset_type getUrlPtrPos() const             { return urlPtrPos; }
-      void        setUrlPtrPos(offset_type p)      { urlPtrPos = p; }
+      offset_type getPathPtrPos() const            { return pathPtrPos; }
+      void        setPathPtrPos(offset_type p)     { pathPtrPos = p; }
 
       offset_type getMimeListPos() const           { return mimeListPos; }
       void        setMimeListPos(offset_type p)    { mimeListPos = p; }

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -50,7 +50,7 @@ namespace zim
 
       std::unique_ptr<const Reader> clusterOffsetReader;
 
-      std::shared_ptr<const DirectDirentAccessor> mp_urlDirentAccessor;
+      std::shared_ptr<const DirectDirentAccessor> mp_pathDirentAccessor;
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
@@ -72,7 +72,7 @@ namespace zim
         typedef DirectDirentAccessor DirentAccessorType;
         typedef entry_index_t index_t;
         static const std::string& getDirentKey(const Dirent& d) {
-          return d.getUrl();
+          return d.getPath();
         }
       };
 
@@ -119,8 +119,8 @@ namespace zim
       entry_index_t getIndexByClusterOrder(entry_index_t idx) const;
       entry_index_t getCountArticles() const { return entry_index_t(header.getArticleCount()); }
 
-      FindxResult findx(char ns, const std::string& url);
-      FindxResult findx(const std::string& url);
+      FindxResult findx(char ns, const std::string &path);
+      FindxResult findx(const std::string &path);
       FindxTitleResult findxByTitle(char ns, const std::string& title);
 
       std::shared_ptr<const Cluster> getCluster(cluster_index_t idx);

--- a/src/narrowdown.h
+++ b/src/narrowdown.h
@@ -104,7 +104,7 @@ public: // functions
   void add(const std::string& key, index_type i, const std::string& nextKey)
   {
     // It would be better to have `key >= nextKey`, but pretty old zim file were not enforce to
-    // have unique url, just that entries were sorted by url, but two entries could have the same url.
+    // have unique path, just that entries were sorted by path, but two entries could have the same path.
     // It is somehow a bug and have been fixed then, but we still have to be tolerent here and accept that
     // two concecutive keys can be equal.
     if (key > nextKey) {

--- a/src/template.h
+++ b/src/template.h
@@ -32,7 +32,7 @@ namespace zim
         public:
           virtual void onData(const std::string& data) = 0;
           virtual void onToken(const std::string& token) = 0;
-          virtual void onLink(char ns, const std::string& url) = 0;
+          virtual void onLink(char ns, const std::string &path) = 0;
           virtual ~Event() = default;
       };
 

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -173,7 +173,7 @@ namespace zim
         Dirent(const std::string& path, const std::string& title, const Dirent& target);
 
         // Creator for "temporary" dirent, used to search for dirent in container.
-        // We use them in url ordered container so we only need to set the namespace and the path.
+        // We use them in path ordered container so we only need to set the namespace and the path.
         // Other value are irrelevant.
         Dirent(NS ns, const std::string& path)
           : Dirent(ns, path, "", 0)
@@ -244,12 +244,11 @@ namespace zim
 
         void write(int out_fd) const;
 
-        friend bool compareUrl(const Dirent* d1, const Dirent* d2);
+        friend bool comparePath(const Dirent* d1, const Dirent* d2);
         friend inline bool compareTitle(const Dirent* d1, const Dirent* d2);
     } PACKED;
 
-
-    inline bool compareUrl(const Dirent* d1, const Dirent* d2)
+    inline bool comparePath(const Dirent* d1, const Dirent* d2)
     {
       return d1->getNamespace() < d2->getNamespace()
         || (d1->getNamespace() == d2->getNamespace() && d1->getPath() < d2->getPath());

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -360,8 +360,8 @@ namespace zim
         dirent->write(out_fd);
       }
 
-      TINFO(" write url prt list");
-      header.setUrlPtrPos(lseek(out_fd, 0, SEEK_CUR));
+      TINFO(" write path prt list");
+      header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
       for (auto& dirent: data->dirents)
       {
         char tmp_buff[sizeof(offset_type)];

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -44,7 +44,7 @@ namespace zim
   {
     struct UrlCompare {
       bool operator() (const Dirent* d1, const Dirent* d2) const {
-        return compareUrl(d1, d2);
+        return comparePath(d1, d2);
       }
     };
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -67,7 +67,7 @@ struct Optional<const std::string> {
 void test_article_dirent(
   std::shared_ptr<const Dirent> dirent,
   Optional<char> ns,
-  Optional<const std::string> url,
+  Optional<const std::string> path,
   Optional<const std::string> title,
   Optional<uint16_t> mimetype,
   Optional<cluster_index_t> clusterNumber,
@@ -75,7 +75,7 @@ void test_article_dirent(
 {
   ASSERT_TRUE(dirent->isArticle());
   ns.check(dirent->getNamespace());
-  url.check(dirent->getUrl());
+  path.check(dirent->getPath());
   title.check(dirent->getTitle());
   mimetype.check(dirent->getMimeType());
   clusterNumber.check(dirent->getClusterNumber());
@@ -85,13 +85,13 @@ void test_article_dirent(
 void test_redirect_dirent(
   std::shared_ptr<const Dirent> dirent,
   Optional<char> ns,
-  Optional<const std::string> url,
+  Optional<const std::string> path,
   Optional<const std::string> title,
   Optional<entry_index_t> target)
 {
   ASSERT_TRUE(dirent->isRedirect());
   ns.check(dirent->getNamespace());
-  url.check(dirent->getUrl());
+  path.check(dirent->getPath());
   title.check(dirent->getTitle());
   target.check(dirent->getRedirectIndex());
 }
@@ -125,8 +125,8 @@ TEST(ZimCreator, createEmptyZim)
   ASSERT_EQ(header.getArticleCount(), 2u); // counter + titleListIndexesv0
 
   //Read the only one item existing.
-  auto urlPtrReader = reader->sub_reader(offset_t(header.getUrlPtrPos()), zsize_t(sizeof(offset_t)*header.getArticleCount()));
-  DirectDirentAccessor direntAccessor(std::make_shared<DirentReader>(reader), std::move(urlPtrReader), entry_index_t(header.getArticleCount()));
+  auto pathPtrReader = reader->sub_reader(offset_t(header.getPathPtrPos()), zsize_t(sizeof(offset_t)*header.getArticleCount()));
+  DirectDirentAccessor direntAccessor(std::make_shared<DirentReader>(reader), std::move(pathPtrReader), entry_index_t(header.getArticleCount()));
   std::shared_ptr<const Dirent> dirent;
 
   dirent = direntAccessor.getDirent(entry_index_t(0));
@@ -184,7 +184,7 @@ TEST(ZimCreator, createZim)
   auto item = std::make_shared<TestItem>("foo", "Foo", "FooContent");
   EXPECT_NO_THROW(creator.addItem(item));
   EXPECT_THROW(creator.addItem(item), std::runtime_error);
-  // Be sure that title order is not the same that url order
+  // Be sure that title order is not the same that path order
   item = std::make_shared<TestItem>("foo2", "AFoo", "Foo2Content");
   creator.addItem(item);
   creator.addAlias("foo_bis", "The same Foo", "foo2");
@@ -223,8 +223,8 @@ TEST(ZimCreator, createZim)
   ASSERT_EQ(header.getArticleCount(), nb_entry);
 
   // Read dirent
-  auto urlPtrReader = reader->sub_reader(offset_t(header.getUrlPtrPos()), zsize_t(sizeof(offset_t)*header.getArticleCount()));
-  DirectDirentAccessor direntAccessor(std::make_shared<DirentReader>(reader), std::move(urlPtrReader), entry_index_t(header.getArticleCount()));
+  auto pathPtrReader = reader->sub_reader(offset_t(header.getPathPtrPos()), zsize_t(sizeof(offset_t)*header.getArticleCount()));
+  DirectDirentAccessor direntAccessor(std::make_shared<DirentReader>(reader), std::move(pathPtrReader), entry_index_t(header.getArticleCount()));
   std::shared_ptr<const Dirent> dirent;
 
   entry_index_type direntIdx = 0;

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -84,13 +84,13 @@ TEST(DirentTest, size)
 TEST(DirentTest, set_get_data_dirent)
 {
   zim::Dirent dirent;
-  dirent.setUrl('C', "Bar");
+  dirent.setPath('C', "Bar");
   dirent.setItem(17, zim::cluster_index_t(45), zim::blob_index_t(1234));
   dirent.setVersion(54346);
 
   ASSERT_TRUE(!dirent.isRedirect());
   ASSERT_EQ(dirent.getNamespace(), 'C');
-  ASSERT_EQ(dirent.getUrl(), "Bar");
+  ASSERT_EQ(dirent.getPath(), "Bar");
   ASSERT_EQ(dirent.getTitle(), "Bar");
   ASSERT_EQ(dirent.getParameter(), "");
   ASSERT_EQ(dirent.getBlobNumber().v, 1234U);
@@ -98,7 +98,7 @@ TEST(DirentTest, set_get_data_dirent)
 
   dirent.setTitle("Foo");
   ASSERT_EQ(dirent.getNamespace(), 'C');
-  ASSERT_EQ(dirent.getUrl(), "Bar");
+  ASSERT_EQ(dirent.getPath(), "Bar");
   ASSERT_EQ(dirent.getTitle(), "Foo");
   ASSERT_EQ(dirent.getParameter(), "");
 }
@@ -151,7 +151,7 @@ TEST(DirentTest, read_write_article_dirent_unicode)
 
   ASSERT_TRUE(!dirent2.isRedirect());
   ASSERT_EQ(dirent2.getNamespace(), 'C');
-  ASSERT_EQ(dirent2.getUrl(), "L\xc3\xbcliang");
+  ASSERT_EQ(dirent2.getPath(), "L\xc3\xbcliang");
   ASSERT_EQ(dirent2.getTitle(), "L\xc3\xbcliang");
   ASSERT_EQ(dirent2.getParameter(), "");
   ASSERT_EQ(dirent2.getClusterNumber().v, 45U);
@@ -177,18 +177,18 @@ TEST(DirentTest, read_write_redirect_dirent)
 
   ASSERT_TRUE(dirent2.isRedirect());
   ASSERT_EQ(dirent2.getNamespace(), 'C');
-  ASSERT_EQ(dirent2.getUrl(), "Bar");
+  ASSERT_EQ(dirent2.getPath(), "Bar");
   ASSERT_EQ(dirent2.getTitle(), "Bar");
   ASSERT_EQ(dirent2.getRedirectIndex().v, 321U);
 }
 
 TEST(DirentTest, dirent_size)
 {
-  // case url set, title empty, extralen empty
+  // case path set, title empty, extralen empty
   zim::writer::Dirent dirent(NS::C, "Bar", "", 17);
   ASSERT_EQ(dirent.getDirentSize(), writenDirentSize(dirent));
 
-  // case url set, title set, extralen empty
+  // case path set, title set, extralen empty
   zim::writer::Dirent dirent2(NS::C, "Bar", "Foo", 17);
   ASSERT_EQ(dirent2.getDirentSize(), writenDirentSize(dirent2));
 }

--- a/test/dirent_lookup.cpp
+++ b/test/dirent_lookup.cpp
@@ -30,7 +30,7 @@
 namespace
 {
 
-const std::vector<std::pair<char, std::string>> articleurl = {
+const std::vector<std::pair<char, std::string>> articlepath = {
   {'A', "aa"},       //0
   {'A', "aaaa"},     //1
   {'A', "aaaaaa"},   //2
@@ -51,17 +51,17 @@ struct GetDirentMock
   typedef GetDirentMock DirentAccessorType;
   typedef zim::entry_index_t index_t;
   static const std::string& getDirentKey(const zim::Dirent& d) {
-    return d.getUrl();
+    return d.getPath();
   }
 
   zim::entry_index_t getDirentCount() const {
-    return zim::entry_index_t(articleurl.size());
+    return zim::entry_index_t(articlepath.size());
   }
 
   std::shared_ptr<const zim::Dirent> getDirent(zim::entry_index_t idx) const {
-    auto info = articleurl.at(idx.v);
+    auto info = articlepath.at(idx.v);
     auto ret = std::make_shared<zim::Dirent>();
-    ret->setUrl(info.first, info.second);
+    ret->setPath(info.first, info.second);
     return ret;
   }
 };

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -54,9 +54,9 @@ TEST(FindTests, NotFoundByPath)
     for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
         zim::Archive archive (testfile.path);
 
-        auto range0 = archive.findByPath("unkwonUrl");
-        auto range1 = archive.findByPath("U/unkwonUrl");
-        auto range2 = archive.findByPath("A/unkwonUrl");
+        auto range0 = archive.findByPath("unkwonPath");
+        auto range1 = archive.findByPath("U/unkwonPath");
+        auto range2 = archive.findByPath("A/unkwonPath");
         auto range3 = archive.findByPath("X");
         auto range4 = archive.findByPath("X/");
         ASSERT_EQ(range0.begin(), range0.end());

--- a/test/header.cpp
+++ b/test/header.cpp
@@ -49,7 +49,7 @@ TEST(HeaderTest, read_write_header)
   zim::Fileheader header;
   header.setUuid("123456789\0abcd\nf");
   header.setArticleCount(4711);
-  header.setUrlPtrPos(12345);
+  header.setPathPtrPos(12345);
   header.setTitleIdxPos(23456);
   header.setClusterCount(14);
   header.setClusterPtrPos(45678);
@@ -59,7 +59,7 @@ TEST(HeaderTest, read_write_header)
 
   ASSERT_EQ(header.getUuid(), "123456789\0abcd\nf");
   ASSERT_EQ(header.getArticleCount(), 4711U);
-  ASSERT_EQ(header.getUrlPtrPos(), 12345U);
+  ASSERT_EQ(header.getPathPtrPos(), 12345U);
   ASSERT_EQ(header.getTitleIdxPos(), 23456U);
   ASSERT_EQ(header.getClusterCount(), 14U);
   ASSERT_EQ(header.getClusterPtrPos(), 45678U);
@@ -73,7 +73,7 @@ TEST(HeaderTest, read_write_header)
 
   ASSERT_EQ(header2.getUuid(), "123456789\0abcd\nf");
   ASSERT_EQ(header2.getArticleCount(), 4711U);
-  ASSERT_EQ(header2.getUrlPtrPos(), 12345U);
+  ASSERT_EQ(header2.getPathPtrPos(), 12345U);
   ASSERT_EQ(header2.getTitleIdxPos(), 23456U);
   ASSERT_EQ(header2.getClusterCount(), 14U);
   ASSERT_EQ(header2.getClusterPtrPos(), 45678U);

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -123,7 +123,7 @@ TEST(IteratorTests, beginByTitle)
 }
 
 
-// ByUrl
+// ByPath
 TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};


### PR DESCRIPTION
Dirents' "url" are not really url. They are u8 arrays which serve as the main "key".
Specification says that this u8 array store a utf-8 encoded string and we use this key as a path.

Public API already use path semantic so rename all internal symbols from url to path.

Fix #868