### PR TITLE
Correctly test invalid offsets in clusters.

### DIFF
--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -115,6 +115,11 @@ namespace zim
     CLUSTER_PTRS,
 
     /**
+     * Checks that offsets inside each clusters are valid.
+     */
+    CLUSTERS_OFFSETS,
+
+    /**
      * Checks that mime-type values in dirents are valid.
      */
     DIRENT_MIMETYPES,

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -118,7 +118,9 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
     while (--n_offset)
     {
       OFFSET_TYPE new_offset = seqReader.read<OFFSET_TYPE>();
-      ASSERT(new_offset, >=, offset);
+      if (new_offset < offset) {
+        throw zim::ZimFileFormatError("Error parsing cluster. Offsets are not ordered.");
+      }
 
       m_blobOffsets.push_back(offset_t(new_offset));
       offset = new_offset;

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -625,6 +625,7 @@ private: // data
       case IntegrityCheck::DIRENT_ORDER: return FileImpl::checkDirentOrder();
       case IntegrityCheck::TITLE_INDEX: return FileImpl::checkTitleIndex();
       case IntegrityCheck::CLUSTER_PTRS: return FileImpl::checkClusterPtrs();
+      case IntegrityCheck::CLUSTERS_OFFSETS: return FileImpl::checkClusters();
       case IntegrityCheck::DIRENT_MIMETYPES: return FileImpl::checkDirentMimeTypes();
       case IntegrityCheck::COUNT: ASSERT("shouldn't have reached here", ==, "");
     }
@@ -672,6 +673,21 @@ private: // data
         return false;
       }
       prevDirent = dirent;
+    }
+    return true;
+  }
+
+  bool FileImpl::checkClusters() {
+    const cluster_index_type clusterCount = getCountClusters().v;
+    for ( cluster_index_type i = 0; i < clusterCount; ++i )
+    {
+      // Force a read of each clusters (which will throw ZimFileFormatError in case of error)
+      try {
+        readCluster(cluster_index_t(i));
+      } catch (ZimFileFormatError& e) {
+        std::cerr << e.what() << std::endl;
+        return false;
+      }
     }
     return true;
   }

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -168,6 +168,7 @@ namespace zim
       bool checkDirentOrder();
       bool checkTitleIndex();
       bool checkClusterPtrs();
+      bool checkClusters();
       bool checkDirentMimeTypes();
   };
 

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -520,6 +520,11 @@ TEST(ZimArchive, validate)
     "Invalid cluster pointer\n"
   );
 
+  TEST_BROKEN_ZIM_NAME(
+    "invalid.offset_in_cluster.zim",
+     "Error parsing cluster. Offsets are not ordered.\n"
+  )
+
 
   for(auto& testfile: getDataFilePath("invalid.nonsorted_dirent_table.zim")) {
     std::string expected;


### PR DESCRIPTION
This offset test in the cluster is to check that value parsed are consistent.
This is not to catch a potential bug in our code.

So we must throw a ZimFileFormatError in this case.

Extend the `validate` function to test this kind of corrupted offset.

Need openzim/zim-testing-suite#9
Fix #893 