### PR TITLE
Compile test using `-Wno-error=restrict` on broken compiler (gcc 12)

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -31,9 +31,9 @@ endif
 
 datadir = get_option('test_data_dir')
 if datadir == 'none'
-    test_cpp_args = '-DWITH_TEST_DATA=0'
+    test_cpp_args = ['-DWITH_TEST_DATA=0']
 else
-    test_cpp_args = '-DWITH_TEST_DATA=1'
+    test_cpp_args = ['-DWITH_TEST_DATA=1']
     if datadir == ''
         # We need to download the test data.
         datadir = join_paths(meson.current_build_dir(), 'data')
@@ -43,6 +43,10 @@ endif
 
 testenv = environment()
 testenv.set('ZIM_TEST_DATA_DIR', datadir)
+
+if cpp.get_id() == 'gcc' and cpp.version().version_compare('>=12.0.0') and cpp.version().version_compare('<13.0.0')
+    test_cpp_args += ['-Wno-error=restrict']
+endif
 
 if gtest_dep.found() and not meson.is_cross_build()
     foreach test_name : tests


### PR DESCRIPTION
Fix kiwix/kiwix-build#691

See https://github.com/google/googletest/issues/4232

