### PR TITLE
Replace pkg-config deb dependency with pkgconf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper-compat (= 13),
  libgtest-dev,
  meson,
  ninja-build,
- pkg-config
+ pkgconf
 Maintainer: Kiwix team <kiwix@kiwix.org>
 Homepage: https://www.openzim.org/wiki/Libzim
 Standards-Version: 4.4.1


### PR DESCRIPTION
Replace pkg-config deb dependency with pkgconf, as pkg-config package is deprecated