### PR TITLE
Some clean-up in test code

### DIFF
--- a/test/counterParsing.cpp
+++ b/test/counterParsing.cpp
@@ -25,7 +25,7 @@
 #include "../src/tools.h"
 
 using namespace zim;
-#define parse parseMimetypeCounter
+const auto parse = parseMimetypeCounter;
 
 namespace
 {

--- a/test/defaultIndexdata.cpp
+++ b/test/defaultIndexdata.cpp
@@ -96,7 +96,7 @@ namespace {
     ASSERT_EQ(indexData->getWordCount(), 3U);
     auto geoPos = indexData->getGeoPosition();
     ASSERT_TRUE(std::get<0>(geoPos));
-    ASSERT_TRUE(std::abs(std::get<1>(geoPos)-45.005) < 0.00001);
-    ASSERT_TRUE(std::abs(std::get<2>(geoPos)-10.1) < 0.00001);
+    ASSERT_NEAR(std::get<1>(geoPos), 45.005, 0.00001);
+    ASSERT_NEAR(std::get<2>(geoPos), 10.1, 0.00001);
   }
 }

--- a/test/error_in_creator.cpp
+++ b/test/error_in_creator.cpp
@@ -182,36 +182,21 @@ TEST_P(FaultyItemErrorTest, faultyItem)
   EXPECT_NO_THROW(creator.finishZimCreation());
 }
 
-// It would be more natural to put the `#if defined` only around the
-// discarded values, but when crosscompiling on Windows, compiler fail to
-// understand ``#if defined` when used inside the `INSTANTIATE_TEST_SUITE_P`
-// macro. I suspect some macro definition conflicts.
+const auto errorKinds = {
+  ERRORKIND::PATH,
+  ERRORKIND::TITLE,
+  ERRORKIND::MIMETYPE,
+  ERRORKIND::HINTS,
+  ERRORKIND::GET_CONTENTPROVIDER,
+  ERRORKIND::EXCEPTION_CONTENTPROVIDER_SIZE,
 #if defined(ENABLE_XAPIAN)
-INSTANTIATE_TEST_SUITE_P(
-CreatorError,
-FaultyItemErrorTest,
-::testing::Values(
-    ERRORKIND::PATH,
-    ERRORKIND::TITLE,
-    ERRORKIND::MIMETYPE,
-    ERRORKIND::HINTS,
-    ERRORKIND::GET_CONTENTPROVIDER,
-    ERRORKIND::EXCEPTION_CONTENTPROVIDER_SIZE,
-    ERRORKIND::GET_INDEXDATA
-));
-#else
-INSTANTIATE_TEST_SUITE_P(
-CreatorError,
-FaultyItemErrorTest,
-::testing::Values(
-    ERRORKIND::PATH,
-    ERRORKIND::TITLE,
-    ERRORKIND::MIMETYPE,
-    ERRORKIND::HINTS,
-    ERRORKIND::GET_CONTENTPROVIDER,
-    ERRORKIND::EXCEPTION_CONTENTPROVIDER_SIZE
-));
+  ERRORKIND::GET_INDEXDATA,
 #endif //ENABLE_XAPIAN
+};
+INSTANTIATE_TEST_SUITE_P(
+CreatorError,
+FaultyItemErrorTest,
+::testing::ValuesIn(errorKinds));
 
 double getWaitTimeFactor() {
   char* str_time_factor = std::getenv("WAIT_TIME_FACTOR_TEST");
@@ -352,35 +337,21 @@ TEST_P(FaultyDelayedItemErrorTest, faultyUnfinishedCreator)
       zim::ZimFileFormatError
   );
 }
-// It would be more natural to put the `#if defined` only around the
-// discarded values, but when crosscompiling on Windows, compiler fail to
-// understand ``#if defined` when used inside the `INSTANTIATE_TEST_SUITE_P`
-// macro. I suspect some macro definition conflicts.
+const auto delayedErrorKinds = {
+  ERRORKIND::EXCEPTION_CONTENTPROVIDER_FEED,
+  ERRORKIND::WRONG_OVER_SIZE_CONTENTPROVIDER,
+  ERRORKIND::WRONG_UNDER_SIZE_CONTENTPROVIDER,
 #if defined(ENABLE_XAPIAN)
-INSTANTIATE_TEST_SUITE_P(
-CreatorError,
-FaultyDelayedItemErrorTest,
-::testing::Values(
-    ERRORKIND::EXCEPTION_CONTENTPROVIDER_FEED,
-    ERRORKIND::WRONG_OVER_SIZE_CONTENTPROVIDER,
-    ERRORKIND::WRONG_UNDER_SIZE_CONTENTPROVIDER ,
-    ERRORKIND::HAS_INDEXDATA,
-    ERRORKIND::GET_INDEXDATA_TITLE,
-    ERRORKIND::GET_INDEXDATA_CONTENT,
-    ERRORKIND::GET_INDEXDATA_KEYWORD,
-    ERRORKIND::GET_INDEXDATA_WORDCOUNT,
-    ERRORKIND::GET_INDEXDATA_POSITION
-));
-#else
-INSTANTIATE_TEST_SUITE_P(
-CreatorError,
-FaultyDelayedItemErrorTest,
-::testing::Values(
-    ERRORKIND::EXCEPTION_CONTENTPROVIDER_FEED,
-    ERRORKIND::WRONG_OVER_SIZE_CONTENTPROVIDER,
-    ERRORKIND::WRONG_UNDER_SIZE_CONTENTPROVIDER
-));
+  ERRORKIND::HAS_INDEXDATA,
+  ERRORKIND::GET_INDEXDATA_TITLE,
+  ERRORKIND::GET_INDEXDATA_CONTENT,
+  ERRORKIND::GET_INDEXDATA_KEYWORD,
+  ERRORKIND::GET_INDEXDATA_WORDCOUNT,
+  ERRORKIND::GET_INDEXDATA_POSITION,
 #endif // ENABLE_XAPIAN
+};
+INSTANTIATE_TEST_SUITE_P(
+CreatorError,
+FaultyDelayedItemErrorTest,
+::testing::ValuesIn(delayedErrorKinds));
 } // unnamed namespace
-
-

--- a/test/parseLongPath.cpp
+++ b/test/parseLongPath.cpp
@@ -25,7 +25,7 @@ namespace zim {
   std::tuple<char, std::string> parseLongPath(const std::string& longPath);
 };
 
-using namespace zim;
+using zim::parseLongPath;
 
 namespace
 {
@@ -44,55 +44,17 @@ TEST(ParseLongPathTest, invalid)
 
 TEST(ParseLongPathTest, valid)
 {
-  char ns;
-  std::string path;
-
-  std::tie(ns, path) = parseLongPath("A/path");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "path");
-
-  std::tie(ns, path) = parseLongPath("A/p");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "p");
-
-  std::tie(ns, path) = parseLongPath("/B/path");
-  ASSERT_EQ(ns, 'B');
-  ASSERT_EQ(path, "path");
-
-  std::tie(ns, path) = parseLongPath("/B/p");
-  ASSERT_EQ(ns, 'B');
-  ASSERT_EQ(path, "p");
-
-  std::tie(ns, path) = parseLongPath("C//path");
-  ASSERT_EQ(ns, 'C');
-  ASSERT_EQ(path, "/path");
-
-  std::tie(ns, path) = parseLongPath("/C//path");
-  ASSERT_EQ(ns, 'C');
-  ASSERT_EQ(path, "/path");
-
-  std::tie(ns, path) = parseLongPath("L/path/with/separator");
-  ASSERT_EQ(ns, 'L');
-  ASSERT_EQ(path, "path/with/separator");
-
-  std::tie(ns, path) = parseLongPath("L//path/with/separator");
-  ASSERT_EQ(ns, 'L');
-  ASSERT_EQ(path, "/path/with/separator");
-
-  std::tie(ns, path) = parseLongPath("A");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "");
-
-  std::tie(ns, path) = parseLongPath("/A");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "");
-
-  std::tie(ns, path) = parseLongPath("A/");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "");
-
-  std::tie(ns, path) = parseLongPath("/A/");
-  ASSERT_EQ(ns, 'A');
-  ASSERT_EQ(path, "");
+  ASSERT_EQ(parseLongPath("A/path"), std::make_tuple('A', "path"));
+  ASSERT_EQ(parseLongPath("A/p"), std::make_tuple('A', "p"));
+  ASSERT_EQ(parseLongPath("/B/path"), std::make_tuple('B', "path"));
+  ASSERT_EQ(parseLongPath("/B/p"), std::make_tuple('B', "p"));
+  ASSERT_EQ(parseLongPath("C//path"), std::make_tuple('C', "/path"));
+  ASSERT_EQ(parseLongPath("/C//path"), std::make_tuple('C', "/path"));
+  ASSERT_EQ(parseLongPath("L/path/with/separator"), std::make_tuple('L', "path/with/separator"));
+  ASSERT_EQ(parseLongPath("L//path/with/separator"), std::make_tuple('L', "/path/with/separator"));
+  ASSERT_EQ(parseLongPath("A"), std::make_tuple('A', ""));
+  ASSERT_EQ(parseLongPath("/A"), std::make_tuple('A', ""));
+  ASSERT_EQ(parseLongPath("A/"), std::make_tuple('A', ""));
+  ASSERT_EQ(parseLongPath("/A/"), std::make_tuple('A', ""));
 }
 };


### PR DESCRIPTION
`counterParsing`
- replace macro with global variable

`defaultIndexdata`
- replace arithmetic operations with floating point comparison macro

`error_in_creator`
- reduce duplication of template test parameters as described in the comment

`parseLongPath`
- succinct assertions using tuple value comparisons