### PR TITLE
Make CI compile on Windows with xapian.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           set PKG_CONFIG_PATH=%cd%\BUILD_win-amd64\INSTALL\lib\pkgconfig
           dir %PKG_CONFIG_PATH%
-          meson.exe setup . build -Dwith_xapian=false -Dwerror=false
+          meson.exe setup . build -Dwith_xapian_fuller=false -Dwerror=false
           cd build
           ninja.exe
 


### PR DESCRIPTION
We now have a compiled xapian on Windows.
We still have to workaroud a xapian/meson compilation issue by decativating "Fuller" compaction when creating db.