### PR TITLE
Fix meson pkgconfig

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,6 +1,5 @@
 
 executable('createZimExample', 'createZimExample.cpp',
            link_with: libzim,
-           link_args: extra_link_args,
            include_directories: include_directory,
-           dependencies: [thread_dep, xapian_dep, icu_dep, lzma_dep, zstd_dep])
+           dependencies: [thread_dep, xapian_dep, icu_dep, lzma_dep, zstd_dep, win_deps])

--- a/meson.build
+++ b/meson.build
@@ -60,11 +60,12 @@ private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
 public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
 
 if build_machine.system() == 'windows'
-    extra_link_args = ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-licuuc', '-licuin']
-    extra_cpp_args = ['-DSORTPP_PASS']
+    win_deps = declare_dependency(
+        compile_args: ['-DSORTPP_PASS'],
+        link_args: ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-lshlwapi']
+    )
 else
-    extra_link_args = []
-    extra_cpp_args = []
+    win_deps = declare_dependency()
 endif
 
 compiler = meson.get_compiler('cpp')

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,6 @@ endif
 private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
 public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
 
-pkg_requires = ['liblzma', 'libzstd']
 if build_machine.system() == 'windows'
     extra_link_args = ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-licuuc', '-licuin']
     extra_cpp_args = ['-DSORTPP_PASS']
@@ -77,9 +76,7 @@ else
 endif
 
 if xapian_dep.found()
-    pkg_requires += ['xapian-core']
     icu_dep = dependency('icu-i18n', static:static_linkage)
-    pkg_requires += ['icu-i18n']
 else
     icu_dep = dependency('icu-i18n', required:false, static:static_linkage)
 endif
@@ -107,5 +104,4 @@ pkg_mod.generate(libraries : libzim,
                  version : meson.project_version(),
                  name : 'libzim',
                  filebase : 'libzim',
-                 description : 'A Library to read/write ZIM files.',
-                 requires : pkg_requires)
+                 description : 'A Library to read/write ZIM files.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,7 +57,7 @@ xapian_sources = [
 ]
 
 sources = common_sources
-deps = [thread_dep, lzma_dep, zstd_dep]
+deps = [thread_dep, lzma_dep, zstd_dep, win_deps]
 
 if target_machine.system() == 'freebsd'
     deps += [execinfo_dep]
@@ -73,8 +73,6 @@ libzim = library('zim',
                  sources,
                  include_directories : inc,
                  dependencies : deps,
-                 link_args : extra_link_args,
-                 cpp_args : extra_cpp_args,
                  version: meson.project_version(),
                  install : true)
 libzim_dep = declare_dependency(link_with: libzim,

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,7 +54,6 @@ if gtest_dep.found() and not meson.is_cross_build()
                               implicit_include_directories: false,
                               include_directories: [include_directory, src_directory],
                               link_with: libzim,
-                              link_args: extra_link_args,
                               cpp_args: test_cpp_args,
                               dependencies: deps + [gtest_dep],
                               build_rpath: '$ORIGIN')


### PR DESCRIPTION
Let's meson's module pkg-config generate totally our `libzim.pc` instead of trying to give smart values.