### PR TITLE
pread64(3) is Linux-specific and not declared on other platforms

### DIFF
--- a/src/fs_unix.cpp
+++ b/src/fs_unix.cpp
@@ -36,10 +36,10 @@ namespace unix {
 
 zsize_t FD::readAt(char* dest, zsize_t size, offset_t offset) const
 {
-#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__HAIKU__)
-# define PREAD pread
-#else
+#if defined(__linux__)
 # define PREAD pread64
+#else
+# define PREAD pread
 #endif
   ssize_t full_size_read = 0;
   auto size_to_read = size.v;


### PR DESCRIPTION
https://man.netbsd.org/read.2