### PR TITLE
Fix build with ICU 76

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,9 +77,15 @@ else
 endif
 
 if xapian_dep.found()
-    icu_dep = dependency('icu-i18n', static:static_linkage)
+    icu_dep = [
+        dependency('icu-i18n', static:static_linkage),
+        dependency('icu-uc', static:static_linkage)
+    ]
 else
-    icu_dep = dependency('icu-i18n', required:false, static:static_linkage)
+    icu_dep = [
+        dependency('icu-i18n', required:false, static:static_linkage),
+        dependency('icu-uc', required:false, static:static_linkage)
+    ]
 endif
 
 gtest_dep = dependency('gtest', version: '>=1.10.0', main:true, fallback:['gtest', 'gtest_main_dep'], required:false)


### PR DESCRIPTION
Due to unicode-org/icu@199bc82, ICU 76 no longer adds `icu-uc` by default. This causes linker errors for undefined symbols like `icu_76::UnicodeString::doReplace(...)`, referenced from: `zim::removeAccents(...)` in tools.cpp.o.

Meson will automatically flatten the dependencies list as documented at https://mesonbuild.com/Reference-manual_functions.html#build_target

---

There didn't seem to be any usage of `icu_dep` methods and only passing it to `dependencies: [..., icu_dep, ...]`. If this changes, then may need to use multiple variables.