### PR TITLE
Remove listing/titleOrdered/v0.

### DIFF
--- a/scripts/download_test_data.py
+++ b/scripts/download_test_data.py
@@ -26,7 +26,7 @@ from urllib.error import *
 import tarfile
 import sys
 
-TEST_DATA_VERSION = "0.6.0"
+TEST_DATA_VERSION = "0.7.0"
 ARCHIVE_URL_TEMPL = "https://github.com/openzim/zim-testing-suite/releases/download/{version}/zim-testing-suite-{version}.tar.gz"
 
 if __name__ == "__main__":

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -136,7 +136,7 @@ namespace zim
     if (pathPtrPos < mimeListPos) {
       throw ZimFileFormatError("pathPtrPos must be > mimelistPos.");
     }
-    if (titleIdxPos < mimeListPos) {
+    if (titleIdxPos != 0 && titleIdxPos < mimeListPos) {
       throw ZimFileFormatError("titleIdxPos must be > mimelistPos.");
     }
     if (clusterPtrPos < mimeListPos) {

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -41,7 +41,7 @@ namespace zim
   const uint32_t Fileheader::zimMagic = 0x044d495a; // ="ZIM^d"
   const uint16_t Fileheader::zimOldMajorVersion = 5;
   const uint16_t Fileheader::zimMajorVersion = 6;
-  const uint16_t Fileheader::zimMinorVersion = 2;
+  const uint16_t Fileheader::zimMinorVersion = 3;
   const offset_type Fileheader::size = 80; // This is also mimeListPos (so an offset)
 
   Fileheader::Fileheader()

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -106,6 +106,9 @@ namespace zim
       bool        hasChecksum() const              { return getMimeListPos() >= 80; }
       offset_type getChecksumPos() const           { return hasChecksum() ? checksumPos : 0; }
       void        setChecksumPos(offset_type p)    { checksumPos = p; }
+
+      bool        useNewNamespaceScheme() const    { return minorVersion >= 1; }
+
   };
 
 }

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -79,6 +79,7 @@ namespace zim
       entry_index_type getArticleCount() const            { return articleCount; }
       void      setArticleCount(entry_index_type s)       { articleCount = s; }
 
+      bool hasTitleListingV0() const               { return titleIdxPos != 0; }
       offset_type getTitleIdxPos() const           { return titleIdxPos; }
       void        setTitleIdxPos(offset_type p)    { titleIdxPos = p; }
 

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -311,7 +311,10 @@ private: // data
   offset_type FileImpl::getMimeListEndUpperLimit() const
   {
     offset_type result(header.getPathPtrPos());
-    result = std::min(result, header.getTitleIdxPos());
+    auto titleIdxPos = header.getTitleIdxPos();
+    if (titleIdxPos != 0) {
+      result = std::min(result, titleIdxPos);
+    }
     result = std::min(result, header.getClusterPtrPos());
     if ( getCountArticles().v != 0 ) {
       // assuming that dirents are placed in the zim file in the same

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -186,7 +186,6 @@ private: // data
       zimReader(makeFileReader(zimFile)),
       direntReader(new DirentReader(zimReader)),
       clusterCache(envValue("ZIM_CLUSTERCACHE", CLUSTER_CACHE_SIZE)),
-      m_newNamespaceScheme(false),
       m_hasFrontArticlesIndex(true),
       m_startUserEntry(0),
       m_endUserEntry(0)
@@ -366,8 +365,7 @@ private: // data
       p = zp+1;
     }
 
-    const_cast<bool&>(m_newNamespaceScheme) = header.getMinorVersion() >= 1;
-    if (m_newNamespaceScheme) {
+    if (header.useNewNamespaceScheme()) {
       const_cast<entry_index_t&>(m_startUserEntry) = getNamespaceBeginOffset('C');
       const_cast<entry_index_t&>(m_endUserEntry) = getNamespaceEndOffset('C');
     } else {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -37,6 +37,7 @@
 #include "envvalue.h"
 #include "md5.h"
 #include "tools.h"
+#include "fileheader.h"
 
 log_define("zim.file.impl")
 

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -234,6 +234,9 @@ private: // data
     mp_titleDirentAccessor = getTitleAccessor("listing/titleOrdered/v1");
 
     if (!mp_titleDirentAccessor) {
+      if (!header.hasTitleListingV0()) {
+        throw ZimFileFormatError("Zim file doesn't contain a title ordered index");
+      }
       offset_t titleOffset(header.getTitleIdxPos());
       zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
       mp_titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Title index table");
@@ -746,12 +749,15 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
   bool FileImpl::checkTitleIndex() {
     const entry_index_type articleCount = getCountArticles().v;
 
-    offset_t titleOffset(header.getTitleIdxPos());
-    zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
-    auto titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Full Title index table");
-    auto ret = checkTitleListing(*titleDirentAccessor, articleCount);
+    auto ret = true;
+    if (header.hasTitleListingV0()) {
+      offset_t titleOffset(header.getTitleIdxPos());
+      zsize_t  titleSize(sizeof(entry_index_type)*header.getArticleCount());
+      auto titleDirentAccessor = getTitleAccessor(titleOffset, titleSize, "Full Title index table");
+      ret = checkTitleListing(*titleDirentAccessor, articleCount);
+    }
 
-    titleDirentAccessor = getTitleAccessor("listing/titleOrdered/v1");
+    auto titleDirentAccessor = getTitleAccessor("listing/titleOrdered/v1");
     if (titleDirentAccessor) {
       ret &= checkTitleListing(*titleDirentAccessor, articleCount);
     }

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -56,7 +56,6 @@ namespace zim
       typedef std::shared_ptr<const Cluster> ClusterHandle;
       ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
-      const bool m_newNamespaceScheme;
       const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;
       const entry_index_t m_endUserEntry;
@@ -109,7 +108,7 @@ namespace zim
       const std::string& getFilename() const   { return zimFile->filename(); }
       const Fileheader& getFileheader() const  { return header; }
       zsize_t getFilesize() const;
-      bool hasNewNamespaceScheme() const { return m_newNamespaceScheme; }
+      bool hasNewNamespaceScheme() const { return header.useNewNamespaceScheme(); }
       bool hasFrontArticlesIndex() const { return m_hasFrontArticlesIndex; }
 
       FileCompound::PartRange getFileParts(offset_t offset, zsize_t size);

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -22,6 +22,7 @@
 #include "tools.h"
 #include "zim/tools.h"
 #include "fs.h"
+#include "writer/_dirent.h"
 
 #include <sys/types.h>
 #include <string.h>
@@ -217,6 +218,20 @@ zim::MimeCounterType zim::parseMimetypeCounter(const std::string& counterData)
 
   return counters;
 }
+
+bool zim::writer::isFrontArticle(const zim::writer::Dirent* dirent, const zim::writer::Hints& hints)
+{
+  // By definition, dirent not in `C` namespace are not FRONT_ARTICLE
+  if (dirent->getNamespace() != NS::C) {
+    return false;
+  }
+  try {
+    return bool(hints.at(FRONT_ARTICLE));
+  } catch(std::out_of_range&) {
+    return false;
+  }
+}
+
 
 // Xapian based tools
 #if defined(ENABLE_XAPIAN)

--- a/src/tools.h
+++ b/src/tools.h
@@ -29,6 +29,7 @@
 #include "config.h"
 
 #include <zim/item.h>
+#include "zim/writer/item.h"
 
 #if defined(ENABLE_XAPIAN)
 namespace Xapian {
@@ -68,6 +69,11 @@ namespace zim {
       }
     }
     return count;
+  }
+
+  namespace writer {
+    class Dirent;
+    bool isFrontArticle(const Dirent* dirent, const Hints& hints);
   }
 
 // Xapian based tools

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -160,7 +160,6 @@ namespace zim
         offset_t offset;
         uint8_t _ns : 2;
         bool removed : 1;
-        bool frontArticle : 1;
 
       public:
         // Creator for a "classic" dirent
@@ -238,9 +237,6 @@ namespace zim
 
         bool isRemoved() const { return removed; }
         void markRemoved() { removed = true; }
-
-        bool isFrontArticle() const { return frontArticle; }
-        void setFrontArticle() { frontArticle = true; }
 
         void write(int out_fd) const;
 

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -119,9 +119,6 @@ namespace zim
         bool withIndex;
         std::string indexingLanguage;
 
-        std::shared_ptr<TitleListingHandler> mp_titleListingHandler;
-        offset_t m_titleListBlobOffset;  // The offset the title list blob,
-                                         // related to the beginning of the start of cluster's data.
         std::vector<std::shared_ptr<DirentHandler>> m_direntHandlers;
         void handle(Dirent* dirent, const Hints& hints = Hints()) {
           for(auto& handler: m_direntHandlers) {

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -56,8 +56,7 @@ Dirent::Dirent(NS ns, const std::string& path, const std::string& title, uint16_
     info(DirentInfo::Direct()),
     offset(0),
     _ns(static_cast<uint8_t>(ns)),
-    removed(false),
-    frontArticle(false)
+    removed(false)
 {}
 
 // Creator for a "redirection" dirent
@@ -68,8 +67,7 @@ Dirent::Dirent(NS ns, const std::string& path, const std::string& title, NS targ
     info(DirentInfo::Redirect(targetNs, targetPath)),
     offset(0),
     _ns(static_cast<uint8_t>(ns)),
-    removed(false),
-    frontArticle(false)
+    removed(false)
 {}
 
 Dirent::Dirent(const std::string& path, const std::string& title, const Dirent& target)
@@ -79,8 +77,7 @@ Dirent::Dirent(const std::string& path, const std::string& title, const Dirent& 
     info(target.info),
     offset(0),
     _ns(target._ns),
-    removed(false),
-    frontArticle(false)
+    removed(false)
 {}
 
 NS Dirent::getRedirectNs() const {

--- a/src/writer/titleListingHandler.cpp
+++ b/src/writer/titleListingHandler.cpp
@@ -21,6 +21,7 @@
 #include "creatordata.h"
 
 #include "../endian_tools.h"
+#include "tools.h"
 
 #include <zim/writer/contentProvider.h>
 #include <zim/blob.h>
@@ -90,17 +91,11 @@ void TitleListingHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
   handle(dirent, item->getAmendedHints());
 }
 
+
 void TitleListingHandler::handle(Dirent* dirent, const Hints& hints)
 {
-  // By definition, dirent not in `C` namespace are not FRONT_ARTICLE
-  if (dirent->getNamespace() != NS::C) {
-    return;
+  if (isFrontArticle(dirent, hints)) {
+    m_handledDirents.push_back(dirent);
   }
-
-  try {
-    if(bool(hints.at(FRONT_ARTICLE))) {
-      m_handledDirents.push_back(dirent);
-    }
-  } catch(std::out_of_range&) {}
 }
 

--- a/src/writer/titleListingHandler.cpp
+++ b/src/writer/titleListingHandler.cpp
@@ -87,14 +87,12 @@ void TitleListingHandler::stop() {
 
 DirentHandler::Dirents TitleListingHandler::createDirents() const {
   Dirents ret;
-  ret.push_back(mp_creatorData->createDirent(NS::X, "listing/titleOrdered/v0", "application/octet-stream+zimlisting", ""));
   ret.push_back(mp_creatorData->createDirent(NS::X, "listing/titleOrdered/v1", "application/octet-stream+zimlisting", ""));
   return ret;
 }
 
 DirentHandler::ContentProviders TitleListingHandler::getContentProviders() const {
   ContentProviders ret;
-  ret.push_back(std::unique_ptr<ContentProvider>(new ListingProvider(&m_handledDirents, false)));
   ret.push_back(std::unique_ptr<ContentProvider>(new ListingProvider(&m_handledDirents, true)));
   return ret;
 }

--- a/src/writer/titleListingHandler.cpp
+++ b/src/writer/titleListingHandler.cpp
@@ -70,8 +70,7 @@ class ListingProvider : public ContentProvider {
 } // end of anonymous namespace
 
 TitleListingHandler::TitleListingHandler(CreatorData* data)
-  : mp_creatorData(data),
-    m_hasFrontArticles(false)
+  : mp_creatorData(data)
 {}
 
 TitleListingHandler::~TitleListingHandler() = default;
@@ -89,18 +88,14 @@ void TitleListingHandler::stop() {
 DirentHandler::Dirents TitleListingHandler::createDirents() const {
   Dirents ret;
   ret.push_back(mp_creatorData->createDirent(NS::X, "listing/titleOrdered/v0", "application/octet-stream+zimlisting", ""));
-  if (m_hasFrontArticles) {
-    ret.push_back(mp_creatorData->createDirent(NS::X, "listing/titleOrdered/v1", "application/octet-stream+zimlisting", ""));
-  }
+  ret.push_back(mp_creatorData->createDirent(NS::X, "listing/titleOrdered/v1", "application/octet-stream+zimlisting", ""));
   return ret;
 }
 
 DirentHandler::ContentProviders TitleListingHandler::getContentProviders() const {
   ContentProviders ret;
   ret.push_back(std::unique_ptr<ContentProvider>(new ListingProvider(&m_handledDirents, false)));
-  if (m_hasFrontArticles) {
-    ret.push_back(std::unique_ptr<ContentProvider>(new ListingProvider(&m_handledDirents, true)));
-  }
+  ret.push_back(std::unique_ptr<ContentProvider>(new ListingProvider(&m_handledDirents, true)));
   return ret;
 }
 
@@ -120,7 +115,6 @@ void TitleListingHandler::handle(Dirent* dirent, const Hints& hints)
 
   try {
     if(bool(hints.at(FRONT_ARTICLE))) {
-      m_hasFrontArticles = true;
       dirent->setFrontArticle();
     }
   } catch(std::out_of_range&) {}

--- a/src/writer/titleListingHandler.cpp
+++ b/src/writer/titleListingHandler.cpp
@@ -99,7 +99,6 @@ void TitleListingHandler::handle(Dirent* dirent, const Hints& hints)
 
   try {
     if(bool(hints.at(FRONT_ARTICLE))) {
-      dirent->setFrontArticle();
       m_handledDirents.push_back(dirent);
     }
   } catch(std::out_of_range&) {}

--- a/src/writer/titleListingHandler.h
+++ b/src/writer/titleListingHandler.h
@@ -53,7 +53,6 @@ class TitleListingHandler : public DirentHandler {
     Dirents createDirents() const override;
     CreatorData* mp_creatorData;
     Dirents m_handledDirents;
-    bool m_hasFrontArticles;
 };
 }
 }

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -24,6 +24,7 @@
 #include "creatordata.h"
 
 #include <zim/writer/contentProvider.h>
+#include "tools.h"
 
 using namespace zim::writer;
 
@@ -99,15 +100,9 @@ void XapianHandler::indexTitle(Dirent* dirent) {
 
 void XapianHandler::handle(Dirent* dirent, const Hints& hints)
 {
-  if (dirent->getNamespace() != NS::C) {
-    return;
-  }
-
-  try {
-    if (bool(hints.at(FRONT_ARTICLE))) {
+  if (isFrontArticle(dirent, hints)) {
       indexTitle(dirent);
-    }
-  } catch(std::out_of_range&) {}
+  }
 }
 
 void XapianHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -251,7 +251,7 @@ TEST(ZimArchive, openRealZimArchive)
     "small.zim",
     "wikibooks_be_all_nopic_2017-02.zim",
     "wikibooks_be_all_nopic_2017-02_splitted.zim",
-    "wikipedia_en_climate_change_nopic_2020-01.zim"
+    "wikipedia_en_climate_change_mini_2024-06.zim"
   };
 
   for ( const std::string fname : zimfiles ) {
@@ -327,7 +327,7 @@ TEST(ZimArchive, randomEntry)
   const char* const zimfiles[] = {
     "wikibooks_be_all_nopic_2017-02.zim",
     "wikibooks_be_all_nopic_2017-02_splitted.zim",
-    "wikipedia_en_climate_change_nopic_2020-01.zim"
+    "wikipedia_en_climate_change_mini_2024-06.zim"
   };
 
   for ( const std::string fname : zimfiles ) {
@@ -398,7 +398,7 @@ TEST(ZimArchive, articleNumber)
     {"small.zim",                                     1,           { 1,       17,          17,       }, { 1,       2,           16        }},
     {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 66,      118,         118,      }, { 66,      109,         123       }},
     {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 66,      118,         118,      }, { 66,      109,         123       }},
-    {"wikipedia_en_climate_change_nopic_2020-01.zim", 333,         { 1837,    7646,        7646,     }, { 1837,    7633,        7649      }}
+    {"wikipedia_en_climate_change_mini_2024-06.zim",  111,         { 3821,    20565,       20565,    }, { 3821,    20551,       20568     }}
   };
   // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
   // for small.zim, there is always 1 article, whatever the article is in 'A' namespace or in specific index.

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -175,11 +175,11 @@ TEST(ZimArchive, openCreatedArchive)
 
   zim::Archive archive(tempPath);
 #if !defined(ENABLE_XAPIAN)
-// 2*listingIndex + M/Counter + M/Title + mainpage + 2*Illustration + 2*Item + redirection
-#define ALL_ENTRY_COUNT 10U
+// listingIndex + M/Counter + M/Title + mainpage + 2*Illustration + 2*Item + redirection
+#define ALL_ENTRY_COUNT 9U
 #else
 // same as above + 2 xapian indexes.
-#define ALL_ENTRY_COUNT 12U
+#define ALL_ENTRY_COUNT 11U
 #endif
   ASSERT_EQ(archive.getAllEntryCount(), ALL_ENTRY_COUNT);
 #undef ALL_ENTRY_COUNT

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -360,10 +360,10 @@ TEST(ZimArchive, illustration)
       const zim::Archive archive(testfile.path);
       ASSERT_TRUE(archive.hasIllustration(48)) << ctx;
       auto illustrationItem = archive.getIllustrationItem(48);
-      if(testfile.category == "nons") {
-        ASSERT_EQ(illustrationItem.getPath(), "Illustration_48x48@1") << ctx;
-      } else {
+      if(testfile.category == "withns") {
         ASSERT_EQ(illustrationItem.getPath(), "I/favicon.png") << ctx;
+      } else {
+        ASSERT_EQ(illustrationItem.getPath(), "Illustration_48x48@1") << ctx;
       }
       ASSERT_EQ(archive.getIllustrationSizes(), std::set<unsigned int>({48}));
     }
@@ -377,7 +377,7 @@ struct ZimFileInfo {
 struct TestDataInfo {
   const char* const name;
   zim::entry_index_type mediaCount;
-  ZimFileInfo withnsInfo, nonsInfo;
+  ZimFileInfo withnsInfo, nonsInfo, noTitleListingV0Info;
 
 
   const ZimFileInfo& getZimFileInfo(const std::string& category) const {
@@ -385,6 +385,8 @@ struct TestDataInfo {
       return nonsInfo;
     } else if (category == "withns") {
       return withnsInfo;
+    } else if (category == "noTitleListingV0") {
+      return noTitleListingV0Info;
     }
     throw std::runtime_error("Unknown category");
   }
@@ -393,12 +395,15 @@ struct TestDataInfo {
 TEST(ZimArchive, articleNumber)
 {
   TestDataInfo zimfiles[] = {
-     // Name                                          mediaCount,  withns                                           nons
-     //                                                            {articles, userEntries, allEntries}, {articles, userEntries, allEntries}
-    {"small.zim",                                     1,           { 1,       17,          17,       }, { 1,       2,           16        }},
-    {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 66,      118,         118,      }, { 66,      109,         123       }},
-    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 66,      118,         118,      }, { 66,      109,         123       }},
-    {"wikipedia_en_climate_change_mini_2024-06.zim",  111,         { 3821,    20565,       20565,    }, { 3821,    20551,       20568     }}
+     // Name                                          mediaCount,  withns                               nons                                 noTitleListingV0
+     //                                                            {articles, userEntries, allEntries}, {articles, userEntries, allEntries}, {articles, userEntries, allEntries}
+    {"small.zim",                                     1,           { 1,       17,          17,       }, { 1,       2,           16        }, { 1,       2,           16        }},
+// For some unknown reason, nons wikibooks already doesn't contain a v0 title index so number of allEntries is equal to noTitleListingV0.
+// But header titlePtrPos is initialized in nons and is 0 in noTitleListingV0.
+// I suspect here that nons file was generated using a local dev buggy zimrecreate.
+    {"wikibooks_be_all_nopic_2017-02.zim",            34,          { 66,      118,         118,      }, { 66,      109,         123       }, { 66,      109,         123       }},
+    {"wikibooks_be_all_nopic_2017-02_splitted.zim",   34,          { 66,      118,         118,      }, { 66,      109,         123       }, { 66,      109,         123       }},
+    {"wikipedia_en_climate_change_mini_2024-06.zim",  111,         { 3821,    20565,       20565,    }, { 3821,    20551,       20568     }, { 3821,    20551,       20567     }}
   };
   // "withns" zim files have no notion of user entries, so EntryCount == allEntryCount.
   // for small.zim, there is always 1 article, whatever the article is in 'A' namespace or in specific index.
@@ -446,6 +451,12 @@ public:
 #define TEST_BROKEN_ZIM_NAME(ZIMNAME, EXPECTED)                \
 for(auto& testfile: getDataFilePath(ZIMNAME)) {EXPECT_BROKEN_ZIMFILE(testfile.path, EXPECTED)}
 
+#define TEST_BROKEN_ZIM_NAME_CAT(ZIMNAME, CAT, EXPECTED)                \
+for(auto& testfile: getDataFilePath(ZIMNAME, CAT)) {EXPECT_BROKEN_ZIMFILE(testfile.path, EXPECTED)}
+
+// Use an intermediate define to avoid CPP to interpreted the comma as a parameter separator.
+#define WITH_TITLE_IDX_CAT {"withns", "nons"}
+
 #if WITH_TEST_DATA
 TEST(ZimArchive, validate)
 {
@@ -474,8 +485,10 @@ TEST(ZimArchive, validate)
     std::string expected;
     if (testfile.category == "withns") {
       expected = "Title index table outside (or not fully inside) ZIM file.\n";
-    } else {
+    } else if ( testfile.category == "nons") {
       expected = "Full Title index table outside (or not fully inside) ZIM file.\n";
+    } else {
+      continue;
     }
     EXPECT_BROKEN_ZIMFILE(testfile.path, expected)
   }
@@ -505,13 +518,15 @@ TEST(ZimArchive, validate)
     "Invalid dirent pointer\n"
   );
 
-  TEST_BROKEN_ZIM_NAME(
+  TEST_BROKEN_ZIM_NAME_CAT(
     "invalid.outofbounds_first_title_entry.zim",
+    WITH_TITLE_IDX_CAT,
     "Invalid title index entry.\n"
   );
 
-  TEST_BROKEN_ZIM_NAME(
+  TEST_BROKEN_ZIM_NAME_CAT(
     "invalid.outofbounds_last_title_entry.zim",
+    WITH_TITLE_IDX_CAT,
     "Invalid title index entry.\n"
   );
 
@@ -540,8 +555,9 @@ TEST(ZimArchive, validate)
     EXPECT_BROKEN_ZIMFILE(testfile.path, expected)
   }
 
-  TEST_BROKEN_ZIM_NAME(
+  TEST_BROKEN_ZIM_NAME_CAT(
     "invalid.nonsorted_title_index.zim",
+    WITH_TITLE_IDX_CAT,
     "Title index is not properly sorted.\n"
   );
 
@@ -554,8 +570,10 @@ TEST(ZimArchive, validate)
     std::string expected;
     if (testfile.category == "withns") {
       expected = "Entry M/Language has invalid MIME-type value 1234.\n";
-    } else {
+    } else if (testfile.category == "nons") {
       expected = "Entry M/Publisher has invalid MIME-type value 1234.\n";
+    } else {
+      expected = "Entry M/Name has invalid MIME-type value 1234.\n";
     }
     EXPECT_BROKEN_ZIMFILE(testfile.path, expected)
   }

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -133,7 +133,7 @@ TEST(ZimCreator, createEmptyZim)
   test_article_dirent(dirent, 'M', "Counter", None, 1, cluster_index_t(0), None);
 
   dirent = direntAccessor.getDirent(entry_index_t(1));
-  test_article_dirent(dirent, 'X', "listing/titleOrdered/v0", None, 0, cluster_index_t(1), None);
+  test_article_dirent(dirent, 'X', "listing/titleOrdered/v1", None, 0, cluster_index_t(1), None);
   auto v0BlobIndex = dirent->getBlobNumber();
 
   auto clusterPtrPos = header.getClusterPtrPos();
@@ -142,7 +142,7 @@ TEST(ZimCreator, createEmptyZim)
   ASSERT_EQ(cluster->getCompression(), Cluster::Compression::None);
   ASSERT_EQ(cluster->count(), blob_index_t(1)); // Only titleListIndexesv0
   auto blob = cluster->getBlob(v0BlobIndex);
-  ASSERT_EQ(blob.size(), 2*sizeof(title_index_t));
+  ASSERT_EQ(blob.size(), 0);
 }
 
 
@@ -204,7 +204,7 @@ TEST(ZimCreator, createZim)
   header.read(*reader);
   ASSERT_TRUE(header.hasMainPage());
 #if defined(ENABLE_XAPIAN)
-  entry_index_type nb_entry = 14; // counter + 2*illustration + xapiantitleIndex + xapianfulltextIndex + foo + foo2 + foo_bis + foo3 + foo_ter + Title + mainPage + titleListIndexes*2
+  entry_index_type nb_entry = 13; // counter + 2*illustration + xapiantitleIndex + xapianfulltextIndex + foo + foo2 + foo_bis + foo3 + foo_ter + Title + mainPage + titleListIndexes
   int xapian_mimetype = 0;
   int listing_mimetype = 1;
   int png_mimetype = 2;
@@ -212,7 +212,7 @@ TEST(ZimCreator, createZim)
   int plain_mimetype = 4;
   int plainutf8_mimetype = 5;
 #else
-  entry_index_type nb_entry = 12; // counter + 2*illustration + foo + foo_bis + foo2 + foo3 + foo_ter + Title + mainPage + titleListIndexes*2
+  entry_index_type nb_entry = 11; // counter + 2*illustration + foo + foo_bis + foo2 + foo3 + foo_ter + Title + mainPage + titleListIndexes
   int listing_mimetype = 0;
   int png_mimetype = 1;
   int html_mimetype = 2;
@@ -270,10 +270,6 @@ TEST(ZimCreator, createZim)
 #endif
 
   dirent = direntAccessor.getDirent(entry_index_t(direntIdx++));
-  test_article_dirent(dirent, 'X', "listing/titleOrdered/v0", None, listing_mimetype, cluster_index_t(1), None);
-  auto v0BlobIndex = dirent->getBlobNumber();
-
-  dirent = direntAccessor.getDirent(entry_index_t(direntIdx++));
   test_article_dirent(dirent, 'X', "listing/titleOrdered/v1", None, listing_mimetype, cluster_index_t(1), None);
   auto v1BlobIndex = dirent->getBlobNumber();
 
@@ -309,30 +305,7 @@ TEST(ZimCreator, createZim)
   ASSERT_EQ(cluster->getCompression(), Cluster::Compression::None);
   ASSERT_EQ(cluster->count(), blob_index_t(nb_entry-8)); // 7 entries are either compressed or redirections + 1 entry is a clone of content
 
-  ASSERT_EQ(header.getTitleIdxPos(), (clusterOffset+cluster->getBlobOffset(v0BlobIndex)).v);
-
-  blob = cluster->getBlob(v0BlobIndex);
-  ASSERT_EQ(blob.size(), nb_entry*sizeof(title_index_t));
-  std::vector<char> blob0Data(blob.data(), blob.end());
-  std::vector<char> expectedBlob0Data = {
-    1, 0, 0, 0,
-    0, 0, 0, 0,
-    2, 0, 0, 0,
-    3, 0, 0, 0,
-    4, 0, 0, 0,
-    5, 0, 0, 0,
-    6, 0, 0, 0,
-    7, 0, 0, 0,
-    8, 0, 0, 0,
-    9, 0, 0, 0,
-    10, 0, 0, 0,
-    11, 0, 0, 0
-#if defined(ENABLE_XAPIAN)
-    ,12, 0, 0, 0
-    ,13, 0, 0, 0
-#endif
-    };
-  ASSERT_EQ(blob0Data, expectedBlob0Data);
+  ASSERT_EQ(header.getTitleIdxPos(), 0);
 
   blob = cluster->getBlob(v1BlobIndex);
   ASSERT_EQ(blob.size(), 3*sizeof(title_index_t));

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -255,7 +255,7 @@ TEST(FindTests, ByPath)
 // By Path
 TEST(FindTests, ByPathNons)
 {
-  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"nons"})) {
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"nons", "noTitleListingV0"})) {
     zim::Archive archive (testfile.path);
 
     auto range0 = archive.findByPath("Першая_старонка.html");

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -182,7 +182,7 @@ TEST(FindTests, ByTitleWithDuplicate)
 // By Path
 TEST(FindTests, ByPath)
 {
-  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"withns"})) {
     zim::Archive archive (testfile.path);
 
     auto range0 = archive.findByPath("A/Main_Page.html");
@@ -255,7 +255,7 @@ TEST(FindTests, ByPath)
 // By Path
 TEST(FindTests, ByPathNons)
 {
-  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "nons")) {
+  for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"nons"})) {
     zim::Archive archive (testfile.path);
 
     auto range0 = archive.findByPath("Першая_старонка.html");

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -143,7 +143,7 @@ TEST(IteratorTests, beginByPath)
 
 TEST(IteartorTests, iteratorFunctions)
 {
-    for(auto& testfile:getDataFilePath("wikipedia_en_climate_change_nopic_2020-01.zim")) {
+    for(auto& testfile:getDataFilePath("wikipedia_en_climate_change_mini_2024-06.zim")) {
         const zim::Archive archive(testfile.path);
         ASSERT_TRUE(archive.hasTitleIndex());
         const auto mainItem = archive.getMainEntry().getItem(true);

--- a/test/iterator.cpp
+++ b/test/iterator.cpp
@@ -41,7 +41,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"withns"})) {
         zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
@@ -57,7 +57,7 @@ TEST(ClusterIteratorTest, getEntryByClusterOrder)
 
 TEST(getEntry, indexOutOfRange)
 {
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"withns"})) {
         zim::Archive archive (testfile.path);
 
         auto nbEntries = archive.getEntryCount();
@@ -84,7 +84,7 @@ TEST(IteratorTests, begin)
 117, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108 };
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"withns"})) {
         zim::Archive archive (testfile.path);
 
         int i = 0;
@@ -128,7 +128,7 @@ TEST(IteratorTests, beginByPath)
 {
     std::vector<zim::entry_index_type> expected = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", "withns")) {
+    for(auto& testfile:getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"withns"})) {
         zim::Archive archive (testfile.path);
 
         auto it = archive.iterByPath().begin();

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -136,7 +136,7 @@ const std::vector<TestFile> getDataFilePath(const std::string& filename, const s
     // We don't have dirent.h in windows.
     // If we move to test data out of the repository, we will need a way to discover the data.
     // Use a static list of categories for now.
-    for (auto& category: {"withns", "nons"}) {
+    for (auto& category: {"withns", "nons", "noTitleListingV0"}) {
       filePaths.emplace_back(dataDirPath, category, filename);
     }
 #else

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -120,15 +120,17 @@ TestFile::TestFile(const std::string& dataDir, const std::string& category, cons
 {
 }
 
-const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::string& category)
+const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::vector<std::string>& categories)
 {
   std::vector<TestFile> filePaths;
   std::string dataDirPath;
   setDataDir(dataDirPath);
 
-  if (!category.empty()) {
-      // We have asked for a particular category.
+  if (!categories.empty()) {
+    // We have asked for a particular category.
+    for (auto& category: categories) {
       filePaths.emplace_back(dataDirPath, category, filename);
+    }
   } else {
 #ifdef _WIN32
     // We don't have dirent.h in windows.

--- a/test/tools.h
+++ b/test/tools.h
@@ -139,7 +139,7 @@ struct TestFile {
   const std::string path;
 };
 
-const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::string& category = "");
+const std::vector<TestFile> getDataFilePath(const std::string& filename, const std::vector<std::string>& categories = {});
 
 // Helper class to create temporary zim and remove it once the test is done
 class TempZimArchive : zim::unittests::TempFile {


### PR DESCRIPTION
Fix #800

This PR needs testing files from https://github.com/openzim/zim-testing-suite/pull/13
(and a release of zim-testing-suite project to be correctly used here) and so, CI is failing (as expected).
The simpler for locally testing this PR is to copy https://github.com/openzim/zim-testing-suite/tree/no_v0/data/nov0 into you local zim-testing-suite v0.6.0 directory.

An important change is that `listing/titleOrdered/v1` is now created all the time, even if there is no front article.

This means that there will be no fallback to "all entries" (random, suggestion without xapian) when creator do not properly set front articles.
This case is really rare as we automatically mark item as front article if mimetype starts with "text/html" when no hint is given.