### PR TITLE
Limit the cluster cache by memory instead of number of clusters

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -536,13 +536,13 @@ namespace zim
 
       /** Get the maximum size of the cluster cache.
        *
-       * @return The maximum number of clusters stored in  the cache.
+       * @return The maximum memory size used the cluster cache.
        */
       size_t getClusterCacheMaxSize() const;
 
       /** Get the current size of the cluster cache.
        *
-       * @return The number of clusters currently stored in  the cache.
+       * @return The current memory size used by the cluster cache.
        */
       size_t getClusterCacheCurrentSize() const;
 
@@ -551,9 +551,9 @@ namespace zim
        * If the new size is lower than the number of currently stored clusters
        * some clusters will be dropped from cache to respect the new size.
        *
-       * @param nbClusters The maximum number of clusters stored in the cache.
+       * @param sizeInB The memory limit (in bytes) for the cluster cache.
        */
-      void setClusterCacheMaxSize(size_t nbClusters);
+      void setClusterCacheMaxSize(size_t sizeInB);
 
       /** Get the size of the dirent cache.
        *

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -42,6 +42,27 @@ namespace zim
     efficientOrder
   };
 
+  /** Get the maximum size of the cluster cache.
+   *
+   * @return The maximum memory size used the cluster cache.
+   */
+  size_t LIBZIM_API getClusterCacheMaxSize();
+
+  /** Get the current size of the cluster cache.
+   *
+   * @return The current memory size used by the cluster cache.
+   */
+  size_t LIBZIM_API getClusterCacheCurrentSize();
+
+  /** Set the size of the cluster cache.
+   *
+   * If the new size is lower than the number of currently stored clusters
+   * some clusters will be dropped from cache to respect the new size.
+   *
+   * @param sizeInB The memory limit (in bytes) for the cluster cache.
+   */
+  void LIBZIM_API setClusterCacheMaxSize(size_t sizeInB);
+
   /**
    * The Archive class to access content in a zim file.
    *
@@ -533,27 +554,6 @@ namespace zim
        *  @return The shared_ptr
        */
       std::shared_ptr<FileImpl> getImpl() const { return m_impl; }
-
-      /** Get the maximum size of the cluster cache.
-       *
-       * @return The maximum memory size used the cluster cache.
-       */
-      size_t getClusterCacheMaxSize() const;
-
-      /** Get the current size of the cluster cache.
-       *
-       * @return The current memory size used by the cluster cache.
-       */
-      size_t getClusterCacheCurrentSize() const;
-
-      /** Set the size of the cluster cache.
-       *
-       * If the new size is lower than the number of currently stored clusters
-       * some clusters will be dropped from cache to respect the new size.
-       *
-       * @param sizeInB The memory limit (in bytes) for the cluster cache.
-       */
-      void setClusterCacheMaxSize(size_t sizeInB);
 
       /** Get the size of the dirent cache.
        *

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
-option('CLUSTER_CACHE_SIZE', type : 'string', value : '16',
-  description : 'set cluster cache size to number (default:16)')
+option('CLUSTER_CACHE_SIZE', type : 'string', value : '67108864',
+  description : 'set cluster cache size to number (default:64MB)')
 option('DIRENT_CACHE_SIZE', type : 'string', value : '512',
   description : 'set dirent cache size to number (default:512)')
 option('DIRENT_LOOKUP_CACHE_SIZE', type : 'string', value : '1024',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
-option('CLUSTER_CACHE_SIZE', type : 'string', value : '67108864',
-  description : 'set cluster cache size to number (default:64MB)')
+option('CLUSTER_CACHE_SIZE', type : 'string', value : '536870912',
+  description : 'set cluster cache size to number (default:512MB)')
 option('DIRENT_CACHE_SIZE', type : 'string', value : '512',
   description : 'set dirent cache size to number (default:512)')
 option('DIRENT_LOOKUP_CACHE_SIZE', type : 'string', value : '1024',

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -514,9 +514,9 @@ namespace zim
     return m_impl->getClusterCacheCurrentSize();
   }
 
-  void Archive::setClusterCacheMaxSize(size_t nbClusters)
+  void Archive::setClusterCacheMaxSize(size_t sizeInB)
   {
-    m_impl->setClusterCacheMaxSize(nbClusters);
+    m_impl->setClusterCacheMaxSize(sizeInB);
   }
 
   size_t Archive::getDirentCacheMaxSize() const

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -504,19 +504,19 @@ namespace zim
     return m_impl->hasNewNamespaceScheme();
   }
 
-  size_t Archive::getClusterCacheMaxSize() const
+  size_t getClusterCacheMaxSize()
   {
-    return m_impl->getClusterCacheMaxSize();
+    return getClusterCache().getMaxCost();
   }
 
-  size_t Archive::getClusterCacheCurrentSize() const
+  size_t getClusterCacheCurrentSize()
   {
-    return m_impl->getClusterCacheCurrentSize();
+    return getClusterCache().getCurrentCost();
   }
 
-  void Archive::setClusterCacheMaxSize(size_t sizeInB)
+  void setClusterCacheMaxSize(size_t sizeInB)
   {
-    m_impl->setClusterCacheMaxSize(sizeInB);
+    getClusterCache().setMaxCost(sizeInB);
   }
 
   size_t Archive::getDirentCacheMaxSize() const
@@ -533,7 +533,6 @@ namespace zim
   {
     m_impl->setDirentCacheMaxSize(nbDirents);
   }
-
 
   size_t Archive::getDirentLookupCacheMaxSize() const
   {

--- a/src/buffer_reader.cpp
+++ b/src/buffer_reader.cpp
@@ -44,6 +44,11 @@ zsize_t BufferReader::size() const
   return source.size();
 }
 
+size_t BufferReader::getMemorySize() const
+{
+  return source.size().v;
+}
+
 offset_t BufferReader::offset() const
 {
   return offset_t((offset_type)(static_cast<const void*>(source.data(offset_t(0)))));

--- a/src/buffer_reader.h
+++ b/src/buffer_reader.h
@@ -31,6 +31,7 @@ class LIBZIM_PRIVATE_API BufferReader : public Reader {
     virtual ~BufferReader() {};
 
     zsize_t size() const override;
+    size_t getMemorySize() const override;
     offset_t offset() const override;
 
     const Buffer get_buffer(offset_t offset, zsize_t size) const override;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -70,6 +70,8 @@ namespace zim
 
       mutable std::mutex m_readerAccessMutex;
       mutable BlobReaders m_blobReaders;
+      mutable size_t m_memorySize;
+      mutable size_t m_streamSize;
 
 
       template<typename OFFSET_TYPE>
@@ -90,7 +92,15 @@ namespace zim
       Blob getBlob(blob_index_t n) const;
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 
+      size_t getMemorySize() const;
+
       static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
+  };
+
+  struct ClusterMemorySize {
+    static size_t cost(const std::shared_ptr<const Cluster>& cluster) {
+      return cluster->getMemorySize();
+    }
   };
 
 }

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -60,6 +60,11 @@ void LZMA_INFO::stream_end_decode(stream_t* stream)
   lzma_end(stream);
 }
 
+size_t LZMA_INFO::state_size(const stream_t& stream)
+{
+  return lzma_memusage(&stream);
+}
+
 
 const std::string ZSTD_INFO::name = "zstd";
 
@@ -169,4 +174,12 @@ void ZSTD_INFO::stream_end_decode(stream_t* stream)
 
 void ZSTD_INFO::stream_end_encode(stream_t* stream)
 {
+}
+
+size_t ZSTD_INFO::state_size(const stream_t& stream) {
+  if (stream.decoder_stream) {
+    return ZSTD_sizeof_CStream(stream.encoder_stream);
+  } else {
+    return ZSTD_sizeof_DStream(stream.decoder_stream);
+  }
 }

--- a/src/compression.h
+++ b/src/compression.h
@@ -65,6 +65,7 @@ struct LZMA_INFO {
   static CompStatus stream_run_decode(stream_t* stream, CompStep step);
   static CompStatus stream_run(stream_t* stream, CompStep step);
   static void stream_end_decode(stream_t* stream);
+  static size_t state_size(const stream_t& stream);
 };
 
 
@@ -94,6 +95,7 @@ struct LIBZIM_PRIVATE_API ZSTD_INFO {
   static CompStatus stream_run_decode(stream_t* stream, CompStep step);
   static void stream_end_encode(stream_t* stream);
   static void stream_end_decode(stream_t* stream);
+  static size_t state_size(const stream_t& stream);
 };
 
 

--- a/src/concurrent_cache.h
+++ b/src/concurrent_cache.h
@@ -123,6 +123,12 @@ public: // types
     return Impl::drop(key);
   }
 
+  template<class F>
+  void dropAll(F f) {
+    std::unique_lock<std::mutex> l(lock_);
+    Impl::dropAll(f);
+  }
+
   size_t getMaxCost() const {
     std::unique_lock<std::mutex> l(lock_);
     return Impl::getMaxCost();

--- a/src/decoderstreamreader.h
+++ b/src/decoderstreamreader.h
@@ -23,6 +23,7 @@
 
 #include "compression.h"
 #include "istreamreader.h"
+#include <cstddef>
 
 namespace zim
 {
@@ -47,6 +48,10 @@ public: // functions
   ~DecoderStreamReader()
   {
     Decoder::stream_end_decode(&m_decoderState);
+  }
+
+  size_t getMemorySize() const override {
+    return m_encodedDataReader->getMemorySize() + m_encodedDataChunk.size().v + Decoder::state_size(m_decoderState);
   }
 
 private: // functions

--- a/src/dirent_accessor.h
+++ b/src/dirent_accessor.h
@@ -55,9 +55,9 @@ public: // functions
   std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
   entry_index_t getDirentCount() const  {  return m_direntCount; }
 
-  size_t getMaxCacheSize() const { return m_direntCache.getMaxSize(); }
-  size_t getCurrentCacheSize() const { return m_direntCache.size(); }
-  void setMaxCacheSize(size_t nbDirents) const { m_direntCache.setMaxSize(nbDirents); }
+  size_t getMaxCacheSize() const { return m_direntCache.getMaxCost(); }
+  size_t getCurrentCacheSize() const { return m_direntCache.cost(); }
+  void setMaxCacheSize(size_t nbDirents) const { m_direntCache.setMaxCost(nbDirents); }
 
 private: // functions
   std::shared_ptr<const Dirent> readDirent(offset_t) const;
@@ -67,7 +67,7 @@ private: // data
   std::unique_ptr<const Reader>  mp_pathPtrReader;
   entry_index_t                  m_direntCount;
 
-  mutable lru_cache<entry_index_type, std::shared_ptr<const Dirent>> m_direntCache;
+  mutable lru_cache<entry_index_type, std::shared_ptr<const Dirent>, UnitCostEstimation> m_direntCache;
   mutable std::mutex m_direntCacheLock;
 
   mutable std::vector<char>  m_bufferDirentZone;

--- a/src/file_reader.h
+++ b/src/file_reader.h
@@ -34,6 +34,7 @@ class LIBZIM_PRIVATE_API BaseFileReader : public Reader {
       : _offset(offset), _size(size) {}
     ~BaseFileReader() = default;
     zsize_t size() const override { return _size; };
+    size_t getMemorySize() const override { return 0; };
     offset_t offset() const override { return _offset; };
 
     virtual const Buffer get_mmap_buffer(offset_t offset,

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -263,6 +263,11 @@ private: // data
     readMimeTypes();
   }
 
+  FileImpl::~FileImpl() {
+    // We have to clean the global cache for our clusters.
+    clusterCache.dropAll([=](const cluster_index_type key) {return true;});
+  }
+
   std::unique_ptr<IndirectDirentAccessor> FileImpl::getTitleAccessorV1(const entry_index_t idx)
   {
     auto dirent = mp_pathDirentAccessor->getDirent(idx);

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -566,11 +566,11 @@ private: // data
 
     struct zim_MD5_CTX md5ctx;
     zim_MD5Init(&md5ctx);
-    
+
     unsigned char ch[CHUNK_SIZE];
     offset_type checksumPos = header.getChecksumPos();
     offset_type toRead = checksumPos;
-    
+
     for(auto part = zimFile->begin();
         part != zimFile->end();
         part++) {
@@ -580,7 +580,7 @@ private: // data
         zim_MD5Update(&md5ctx, ch, CHUNK_SIZE);
         toRead-=CHUNK_SIZE;
       }
-      
+
       // Previous read was good, so we have exited the previous `while` because
       // `toRead<CHUNK_SIZE`. Let's try to read `toRead` chars and process them later.
       // Else, the previous `while` exited because we didn't succeed to read
@@ -589,12 +589,12 @@ private: // data
       if(stream.good()){
         stream.read(reinterpret_cast<char*>(ch),toRead);
       }
-      
+
       // It updates the checksum with the remaining amount of data when we
       // reach the end of the file or part
       zim_MD5Update(&md5ctx, ch, stream.gcount());
       toRead-=stream.gcount();
-    
+
       if (stream.bad()) {
         perror("error while reading file");
         return false;
@@ -797,8 +797,8 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
   size_t FileImpl::getClusterCacheCurrentSize() const {
     return clusterCache.getCurrentCost();
   }
-  void FileImpl::setClusterCacheMaxSize(size_t nbClusters) {
-    clusterCache.setMaxCost(nbClusters);
+  void FileImpl::setClusterCacheMaxSize(size_t sizeInB) {
+    clusterCache.setMaxCost(sizeInB);
   }
 
   size_t FileImpl::getDirentCacheMaxSize() const {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -792,13 +792,13 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
 
 
   size_t FileImpl::getClusterCacheMaxSize() const {
-    return clusterCache.getMaxSize();
+    return clusterCache.getMaxCost();
   }
   size_t FileImpl::getClusterCacheCurrentSize() const {
-    return clusterCache.getCurrentSize();
+    return clusterCache.getCurrentCost();
   }
   void FileImpl::setClusterCacheMaxSize(size_t nbClusters) {
-    clusterCache.setMaxSize(nbClusters);
+    clusterCache.setMaxCost(nbClusters);
   }
 
   size_t FileImpl::getDirentCacheMaxSize() const {

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -166,6 +166,8 @@ namespace zim
       explicit FileImpl(std::shared_ptr<FileCompound> zimFile);
       FileImpl(std::shared_ptr<FileCompound> zimFile, offset_t offset, zsize_t size);
 
+      void dropCachedClusters() const;
+
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessorV1(const entry_index_t idx);
       std::unique_ptr<IndirectDirentAccessor> getTitleAccessor(const offset_t offset, const zsize_t size, const std::string& name);
 

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -107,6 +107,7 @@ namespace zim
       explicit FileImpl(FdInput fd);
       explicit FileImpl(const std::vector<FdInput>& fds);
 #endif
+      ~FileImpl();
 
       time_t getMTime() const;
 

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <string>
+#include <tuple>
 #include <vector>
 #include <memory>
 #include <zim/zim.h>
@@ -36,13 +37,17 @@
 #include "file_reader.h"
 #include "file_compound.h"
 #include "fileheader.h"
-#include "lrucache.h"
 #include "zim_types.h"
 #include "direntreader.h"
 
 
 namespace zim
 {
+  class FileImpl;
+  typedef std::shared_ptr<const Cluster> ClusterHandle;
+  typedef ConcurrentCache<std::tuple<FileImpl*, cluster_index_type>, ClusterHandle, ClusterMemorySize> ClusterCache;
+  ClusterCache& getClusterCache();
+
   class FileImpl
   {
       std::shared_ptr<FileCompound> zimFile;
@@ -54,9 +59,6 @@ namespace zim
 
       std::shared_ptr<const DirectDirentAccessor> mp_pathDirentAccessor;
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
-
-      typedef std::shared_ptr<const Cluster> ClusterHandle;
-      ConcurrentCache<cluster_index_type, ClusterHandle, ClusterMemorySize> clusterCache;
 
       const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;
@@ -155,9 +157,6 @@ namespace zim
 
       bool checkIntegrity(IntegrityCheck checkType);
 
-      size_t getClusterCacheMaxSize() const;
-      size_t getClusterCacheCurrentSize() const;
-      void setClusterCacheMaxSize(size_t nbClusters);
       size_t getDirentCacheMaxSize() const;
       size_t getDirentCacheCurrentSize() const;
       void setDirentCacheMaxSize(size_t nbDirents);

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -36,6 +36,7 @@
 #include "file_reader.h"
 #include "file_compound.h"
 #include "fileheader.h"
+#include "lrucache.h"
 #include "zim_types.h"
 #include "direntreader.h"
 
@@ -55,7 +56,7 @@ namespace zim
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
-      ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
+      ConcurrentCache<cluster_index_type, ClusterHandle, UnitCostEstimation> clusterCache;
 
       const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -56,7 +56,7 @@ namespace zim
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
-      ConcurrentCache<cluster_index_type, ClusterHandle, UnitCostEstimation> clusterCache;
+      ConcurrentCache<cluster_index_type, ClusterHandle, ClusterMemorySize> clusterCache;
 
       const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;

--- a/src/istreamreader.h
+++ b/src/istreamreader.h
@@ -59,6 +59,9 @@ public: // functions
   // Reads a blob of the specified size from the stream
   virtual std::unique_ptr<const Reader> sub_reader(zsize_t size);
 
+  // Get the total size occuped by the reader
+  virtual size_t getMemorySize() const = 0;
+
 private: // virtual methods
   // Reads exactly 'nbytes' bytes into the provided buffer 'buf'
   // (which must be at least that big). Throws an exception if

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -43,10 +43,38 @@
 #include <cstddef>
 #include <stdexcept>
 #include <cassert>
+#include <iostream>
 
 namespace zim {
 
-template<typename key_t, typename value_t>
+struct UnitCostEstimation {
+  template<typename value_t>
+  static size_t cost(const value_t& value) {
+    return 1;
+  }
+};
+
+/**
+ * A lru cache where the cost of each item can be different than 1.
+ *
+ * Most lru cache is limited by the number of items stored.
+ * This implementation may have a different "size" per item, so the current size of
+ * this lru is not the number of item but the sum of all items' size.
+ *
+ * This implementation used is pretty simple (dumb) and have few limitations:
+ * - We consider than size of a item do not change over time. Especially the size of a
+ *   item when we put it MUST be equal to the size of the same item when we drop it.
+ * - Cache eviction is still a Least Recently Used (LRU), so we drop the least used item(s) util
+ *   we have enough space. No other consideration is used to select which item to drop.
+ *
+ * This lru is parametrized by a CostEstimation type. The type must have a static method `cost`
+ * taking a reference to a `value_t` and returing its "cost". As already said, this method must
+ * always return the same cost for the same value.
+ *
+ * While cost could be any kind of value, this implemention is intended to be used only with
+ * `UnitCostEstimation` (classic lru) and `FutureToValueCostEstimation<ClusterMemorySize>`.
+ */
+template<typename key_t, typename value_t, typename CostEstimation>
 class lru_cache {
 public: // types
   typedef typename std::pair<key_t, value_t> key_value_pair_t;
@@ -81,9 +109,10 @@ public: // types
   };
 
 public: // functions
-  explicit lru_cache(size_t max_size) :
-    _max_size(max_size) {
-  }
+  explicit lru_cache(size_t max_cost) :
+    _max_cost(max_cost),
+    _current_cost(0)
+  {}
 
   // If 'key' is present in the cache, returns the associated value,
   // otherwise puts the given value into the cache (and returns it with
@@ -103,6 +132,8 @@ public: // functions
     auto it = _cache_items_map.find(key);
     if (it != _cache_items_map.end()) {
       _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+      decreaseCost(CostEstimation::cost(it->second->second));
+      increaseCost(CostEstimation::cost(value));
       it->second->second = value;
     } else {
       putMissing(key, value);
@@ -120,37 +151,72 @@ public: // functions
   }
 
   bool drop(const key_t& key) {
+    list_iterator_t list_it;
     try {
-      auto list_it = _cache_items_map.at(key);
-      _cache_items_list.erase(list_it);
-      _cache_items_map.erase(key);
-      return true;
+      list_it = _cache_items_map.at(key);
     } catch (std::out_of_range& e) {
       return false;
     }
+    decreaseCost(CostEstimation::cost(list_it->second));
+    _cache_items_list.erase(list_it);
+    _cache_items_map.erase(key);
+    return true;
   }
 
   bool exists(const key_t& key) const {
     return _cache_items_map.find(key) != _cache_items_map.end();
   }
 
-  size_t size() const {
-    return _cache_items_map.size();
+  size_t cost() const {
+    return _current_cost;
   }
 
-  size_t getMaxSize() const {
-    return _max_size;
+  size_t getMaxCost() const {
+    return _max_cost;
   }
 
-  void setMaxSize(size_t newSize) {
-    while (newSize < this->size()) {
+  void setMaxCost(size_t newMaxCost) {
+    while (newMaxCost < this->cost()) {
       dropLast();
     }
-    _max_size = newSize;
+    _max_cost = newMaxCost;
+  }
+
+ protected:
+
+  void increaseCost(size_t extra_cost) {
+    // increaseSize is called after we have added a value to the cache to update
+    // the size of the current cache.
+    // We must ensure that we don't drop the value we just added.
+    // While it is technically ok to keep no value if max cache size is 0 (or memory size < of the size of one cluster)
+    // it will make recreate the value all the time.
+    // Let's be nice with our user and be tolerent to misconfiguration.
+    if (!extra_cost) {
+      // Don't try to remove an item if we have new size == 0.
+      // This is the case when concurent cache add a future without value.
+      // We will handle the real increase size when concurent cache will directly call us.
+      return;
+    }
+    _current_cost += extra_cost;
+    while (_current_cost > _max_cost && size() > 1) {
+      dropLast();
+    }
+  }
+
+  void decreaseCost(size_t costToRemove) {
+    if (costToRemove > _current_cost) {
+      std::cerr << "WARNING: We have detected inconsistant cache management, trying to remove " << costToRemove << " from a cache with size " << _current_cost << std::endl;
+      std::cerr << "Please open an issue on https://github.com/openzim/libzim/issues with this message and the zim file you use" << std::endl;
+      _current_cost = 0;
+    } else {
+      _current_cost -= costToRemove;
+    }
   }
 
 private: // functions
   void dropLast() {
+    auto list_it = _cache_items_list.back();
+    decreaseCost(CostEstimation::cost(list_it.second));
     _cache_items_map.erase(_cache_items_list.back().first);
     _cache_items_list.pop_back();
   }
@@ -159,15 +225,19 @@ private: // functions
     assert(_cache_items_map.find(key) == _cache_items_map.end());
     _cache_items_list.push_front(key_value_pair_t(key, value));
     _cache_items_map[key] = _cache_items_list.begin();
-    if (_cache_items_map.size() > _max_size) {
-      dropLast();
-    }
+    increaseCost(CostEstimation::cost(value));
   }
+
+  size_t size() const {
+    return _cache_items_map.size();
+  }
+
 
 private: // data
   std::list<key_value_pair_t> _cache_items_list;
   std::map<key_t, list_iterator_t> _cache_items_map;
-  size_t _max_size;
+  size_t _max_cost;
+  size_t _current_cost;
 };
 
 } // namespace zim

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -43,6 +43,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <cassert>
+#include <vector>
 #include <iostream>
 
 namespace zim {
@@ -161,6 +162,21 @@ public: // functions
     _cache_items_list.erase(list_it);
     _cache_items_map.erase(key);
     return true;
+  }
+
+  template<class F>
+  void dropAll(F f) {
+    std::vector<key_t> keys_to_drop;
+    for (auto key_iter:_cache_items_map) {
+      key_t key = key_iter.first;
+      if (f(key)) {
+        keys_to_drop.push_back(key);
+      }
+    }
+
+    for(auto key:keys_to_drop) {
+      drop(key);
+    }
   }
 
   bool exists(const key_t& key) const {

--- a/src/rawstreamreader.h
+++ b/src/rawstreamreader.h
@@ -35,6 +35,10 @@ public: // functions
       m_readerPos(0)
   {}
 
+  size_t getMemorySize() const override {
+    return m_reader->getMemorySize();
+  }
+
   void readImpl(char* buf, zsize_t nbytes) override
   {
     m_reader->read(buf, m_readerPos, zsize_t(nbytes));

--- a/src/reader.h
+++ b/src/reader.h
@@ -36,6 +36,7 @@ class LIBZIM_PRIVATE_API Reader {
   public:
     Reader() {};
     virtual zsize_t size() const = 0;
+    virtual size_t getMemorySize() const = 0;
     virtual ~Reader() {};
 
     void read(char* dest, offset_t offset, zsize_t size) const {

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -50,6 +50,9 @@ class ZimArchive: public testing::Test {
     zim::setClusterCacheMaxSize(CLUSTER_CACHE_SIZE);
     ASSERT_EQ(zim::getClusterCacheCurrentSize(), 0);
   }
+  void TearDown() override {
+    ASSERT_EQ(zim::getClusterCacheCurrentSize(), 0);
+  }
 };
 
 using TestContextImpl = std::vector<std::pair<std::string, std::string> >;
@@ -691,7 +694,8 @@ public:
 #define EXPECT_BROKEN_ZIMFILE(ZIMPATH, EXPECTED_STDERROR_TEXT) \
   CapturedStderr stderror;                                     \
   EXPECT_FALSE(zim::validate(ZIMPATH, checksToRun));           \
-  EXPECT_EQ(EXPECTED_STDERROR_TEXT, std::string(stderror)) << ZIMPATH;
+  EXPECT_EQ(EXPECTED_STDERROR_TEXT, std::string(stderror)) << ZIMPATH; \
+  ASSERT_EQ(zim::getClusterCacheCurrentSize(), 0);
 
 #define TEST_BROKEN_ZIM_NAME(ZIMNAME, EXPECTED)                \
 for(auto& testfile: getDataFilePath(ZIMNAME)) {EXPECT_BROKEN_ZIMFILE(testfile.path, EXPECTED)}

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -286,33 +286,49 @@ struct TestCacheConfig {
   size_t direntLookupCacheSize;
 };
 
-
-#define ASSERT_ARCHIVE_EQUIVALENT(REF_ARCHIVE, TEST_ARCHIVE)  \
-  ASSERT_ARCHIVE_EQUIVALENT_LIMIT(REF_ARCHIVE, TEST_ARCHIVE, REF_ARCHIVE.getEntryCount())
-
-#define ASSERT_ARCHIVE_EQUIVALENT_LIMIT(REF_ARCHIVE, TEST_ARCHIVE, LIMIT)             \
-  {                                                                                   \
-    auto range = REF_ARCHIVE.iterEfficient();                                         \
-    auto ref_it = range.begin();                                                      \
-    ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(ref_it, range.end(), TEST_ARCHIVE, LIMIT)      \
+struct RefEntry {
+  void test_is_equal(const zim::Entry& entry) {
+    ASSERT_EQ(path, entry.getPath());
+    ASSERT_EQ(title, entry.getTitle());
+    ASSERT_EQ(isRedirect, entry.isRedirect());
+    if (isRedirect) {
+      zim::entry_index_type redirectId = redirect_or_hash;
+      ASSERT_EQ(redirectId, entry.getRedirectEntryIndex());
+    } else {
+      auto hash = std::hash<std::string>{}(std::string(entry.getItem().getData()));
+      ASSERT_EQ(redirect_or_hash, hash);
+    }
   }
 
+  std::string path;
+  std::string title;
+  bool        isRedirect;
+  // size_t is either 32 or 64 bits and entry_index_type (redirect id) is always 32 bits.
+  size_t      redirect_or_hash;
+};
 
-#define ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(REF_IT, REF_END, TEST_ARCHIVE, LIMIT)      \
-  for (auto i = 0U; i<LIMIT && REF_IT != REF_END; i++, REF_IT++) {                    \
-    auto test_entry = TEST_ARCHIVE.getEntryByPath(REF_IT->getPath());                 \
-    ASSERT_EQ(REF_IT->getPath(), test_entry.getPath());                               \
-    ASSERT_EQ(REF_IT->getTitle(), test_entry.getTitle());                             \
-    ASSERT_EQ(REF_IT->isRedirect(), test_entry.isRedirect());                         \
-    if (REF_IT->isRedirect()) {                                                       \
-      ASSERT_EQ(REF_IT->getRedirectEntryIndex(), test_entry.getRedirectEntryIndex()); \
-    }                                                                                 \
-    auto ref_item = REF_IT->getItem(true);                                            \
-    auto test_item = test_entry.getItem(true);                                        \
-    ASSERT_EQ(ref_item.getClusterIndex(), test_item.getClusterIndex());               \
-    ASSERT_EQ(ref_item.getBlobIndex(), test_item.getBlobIndex());                     \
-    ASSERT_EQ(ref_item.getData(), test_item.getData());                               \
+struct RefArchiveContent {
+  RefArchiveContent(const zim::Archive& archive) {
+    for (auto entry:archive.iterEfficient()) {
+      RefEntry ref_entry = {
+          entry.getPath(),
+          entry.getTitle(),
+          entry.isRedirect(),
+          entry.isRedirect() ? entry.getRedirectEntryIndex() : std::hash<std::string>{}(std::string(entry.getItem().getData())),
+      };
+      ref_entries.push_back(ref_entry);
+    }
   }
+
+  void test_is_equal(const zim::Archive& archive) {
+    for (auto ref_entry:ref_entries) {
+      auto entry = archive.getEntryByPath(ref_entry.path);
+      ref_entry.test_is_equal(entry);
+    }
+  }
+  std::vector<RefEntry> ref_entries;
+};
+
 
 TEST(ZimArchive, cacheDontImpactReading)
 {
@@ -331,7 +347,7 @@ TEST(ZimArchive, cacheDontImpactReading)
   };
 
   for (auto& testfile: getDataFilePath("small.zim")) {
-    auto ref_archive = zim::Archive(testfile.path);
+    RefArchiveContent ref_archive(zim::Archive(testfile.path));
 
     for (auto cacheConfig: cacheConfigs) {
       auto test_archive = zim::Archive(testfile.path);
@@ -343,7 +359,7 @@ TEST(ZimArchive, cacheDontImpactReading)
       EXPECT_EQ(test_archive.getDirentLookupCacheMaxSize(), cacheConfig.direntLookupCacheSize);
       EXPECT_EQ(test_archive.getClusterCacheMaxSize(), cacheConfig.clusterCacheSize);
 
-      ASSERT_ARCHIVE_EQUIVALENT(ref_archive, test_archive)
+      ref_archive.test_is_equal(test_archive);
     }
   }
 }
@@ -368,15 +384,17 @@ TEST(ZimArchive, cacheChange)
     const size_t L1_SIZE = 850 << 10;
     const size_t L2_SIZE = 2 << 20;
 
-    auto ref_archive = zim::Archive(testfile.path);
+    RefArchiveContent ref_archive(zim::Archive(testfile.path));
     auto archive = zim::Archive(testfile.path);
 
     archive.setDirentCacheMaxSize(30);
     archive.setClusterCacheMaxSize(L2_SIZE);
 
-    auto range = ref_archive.iterEfficient();
-    auto ref_it = range.begin();
-    ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(ref_it, range.end(), archive, 50)
+    auto ref_it = ref_archive.ref_entries.begin();
+    for (auto i = 0; i<50 && ref_it != ref_archive.ref_entries.end(); i++, ref_it++) {
+      auto entry = archive.getEntryByPath(ref_it->path);
+      ref_it->test_is_equal(entry);
+    }
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 30);
     EXPECT_LE(archive.getClusterCacheCurrentSize(), L2_SIZE); // Only 2 clusters in the file
 
@@ -389,7 +407,10 @@ TEST(ZimArchive, cacheChange)
 
     // We want to test change of cache while we are iterating on the archive.
     // So we don't reset the ref_it to `range.begin()`.
-    ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(ref_it, range.end(), archive, 50)
+    for (auto i = 0; i<50 && ref_it != ref_archive.ref_entries.end(); i++, ref_it++) {
+      auto entry = archive.getEntryByPath(ref_it->path);
+      ref_it->test_is_equal(entry);
+    }
 
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 10);
     EXPECT_LE(archive.getClusterCacheCurrentSize(), L1_SIZE);
@@ -408,7 +429,7 @@ TEST(ZimArchive, cacheChange)
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 0);
     EXPECT_EQ(archive.getClusterCacheCurrentSize(), 0);
 
-    ASSERT_ARCHIVE_EQUIVALENT(ref_archive, archive)
+    ref_archive.test_is_equal(archive);
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 20);
     EXPECT_LE(archive.getClusterCacheCurrentSize(), L1_SIZE);
   }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -43,6 +43,15 @@ using zim::unittests::TempFile;
 using zim::unittests::TestItem;
 using zim::unittests::IsFrontArticle;
 
+class ZimArchive: public testing::Test {
+  protected:
+  void SetUp() override {
+    zim::setClusterCacheMaxSize(0);
+    zim::setClusterCacheMaxSize(CLUSTER_CACHE_SIZE);
+    ASSERT_EQ(zim::getClusterCacheCurrentSize(), 0);
+  }
+};
+
 using TestContextImpl = std::vector<std::pair<std::string, std::string> >;
 struct TestContext : TestContextImpl {
   TestContext(const std::initializer_list<value_type>& il)
@@ -80,7 +89,7 @@ emptyZimArchiveContent()
   return content;
 }
 
-TEST(ZimArchive, openingAnInvalidZimArchiveFails)
+TEST_F(ZimArchive, openingAnInvalidZimArchiveFails)
 {
   const char* const prefixes[] = { "ZIM\x04", "" };
   const unsigned char bytes[] = {0x00, 0x01, 0x11, 0x30, 0xFF};
@@ -101,7 +110,7 @@ TEST(ZimArchive, openingAnInvalidZimArchiveFails)
   }
 }
 
-TEST(ZimArchive, openingAnEmptyZimArchiveSucceeds)
+TEST_F(ZimArchive, openingAnEmptyZimArchiveSucceeds)
 {
   const auto tmpfile = makeTempFile("empty_zim_file", emptyZimArchiveContent());
 
@@ -122,7 +131,7 @@ bool isNastyOffset(int offset) {
   return true;
 }
 
-TEST(ZimArchive, nastyEmptyZimArchive)
+TEST_F(ZimArchive, nastyEmptyZimArchive)
 {
   const std::string correctContent = emptyZimArchiveContent();
   for ( int offset = 0; offset < 80; ++offset ) {
@@ -136,7 +145,7 @@ TEST(ZimArchive, nastyEmptyZimArchive)
   }
 }
 
-TEST(ZimArchive, wrongChecksumInEmptyZimArchive)
+TEST_F(ZimArchive, wrongChecksumInEmptyZimArchive)
 {
   std::string zimfileContent = emptyZimArchiveContent();
   zimfileContent[85] = '\xff';
@@ -147,7 +156,7 @@ TEST(ZimArchive, wrongChecksumInEmptyZimArchive)
 }
 
 
-TEST(ZimArchive, openCreatedArchive)
+TEST_F(ZimArchive, openCreatedArchive)
 {
   TempFile temp("zimfile");
   auto tempPath = temp.path();
@@ -245,7 +254,7 @@ TEST(ZimArchive, openCreatedArchive)
 }
 
 #if WITH_TEST_DATA
-TEST(ZimArchive, openRealZimArchive)
+TEST_F(ZimArchive, openRealZimArchive)
 {
   const char* const zimfiles[] = {
     "small.zim",
@@ -266,7 +275,7 @@ TEST(ZimArchive, openRealZimArchive)
   }
 }
 
-TEST(ZimArchive, openSplitZimArchive)
+TEST_F(ZimArchive, openSplitZimArchive)
 {
   const char* fname = "wikibooks_be_all_nopic_2017-02_splitted.zim";
 
@@ -330,7 +339,7 @@ struct RefArchiveContent {
 };
 
 
-TEST(ZimArchive, cacheDontImpactReading)
+TEST_F(ZimArchive, cacheDontImpactReading)
 {
   const TestCacheConfig cacheConfigs[] = {
     {0, 0, 0},
@@ -364,7 +373,7 @@ TEST(ZimArchive, cacheDontImpactReading)
   }
 }
 
-TEST(ZimArchive, cacheClean) {
+TEST_F(ZimArchive, cacheClean) {
   for (auto& testfile: getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
     EXPECT_EQ(zim::getClusterCacheCurrentSize(), 0); // No clusters in cache
     {
@@ -383,7 +392,7 @@ TEST(ZimArchive, cacheClean) {
   }
 }
 
-TEST(ZimArchive, cacheChange)
+TEST_F(ZimArchive, cacheChange)
 {
   // We test only one variant here.
   // Each variant has cluster of different size (especially the old "withns" which
@@ -455,7 +464,7 @@ TEST(ZimArchive, cacheChange)
 }
 
 
-TEST(ZimArchive, MultiZimCache)
+TEST_F(ZimArchive, MultiZimCache)
 {
   // Get a list of several zim files to open (whatever the variant)
   std::vector<std::string> zimPaths;
@@ -516,7 +525,7 @@ TEST(ZimArchive, MultiZimCache)
   EXPECT_EQ(zim::getClusterCacheCurrentSize(), 0);
 }
 
-TEST(ZimArchive, openDontFallbackOnNonSplitZimArchive)
+TEST_F(ZimArchive, openDontFallbackOnNonSplitZimArchive)
 {
   const char* fname = "wikibooks_be_all_nopic_2017-02.zim";
 
@@ -532,7 +541,7 @@ TEST(ZimArchive, openDontFallbackOnNonSplitZimArchive)
   }
 }
 
-TEST(ZimArchive, openNonExistantZimArchive)
+TEST_F(ZimArchive, openNonExistantZimArchive)
 {
   const std::string fname = "non_existant.zim";
 
@@ -545,7 +554,7 @@ TEST(ZimArchive, openNonExistantZimArchive)
   }
 }
 
-TEST(ZimArchive, openNonExistantZimSplitArchive)
+TEST_F(ZimArchive, openNonExistantZimSplitArchive)
 {
   const std::string fname = "non_existant.zimaa";
 
@@ -558,7 +567,7 @@ TEST(ZimArchive, openNonExistantZimSplitArchive)
   }
 }
 
-TEST(ZimArchive, randomEntry)
+TEST_F(ZimArchive, randomEntry)
 {
   const char* const zimfiles[] = {
     "wikibooks_be_all_nopic_2017-02.zim",
@@ -583,7 +592,7 @@ TEST(ZimArchive, randomEntry)
   }
 }
 
-TEST(ZimArchive, illustration)
+TEST_F(ZimArchive, illustration)
 {
   const char* const zimfiles[] = {
     "small.zim",
@@ -628,7 +637,7 @@ struct TestDataInfo {
   }
 };
 
-TEST(ZimArchive, articleNumber)
+TEST_F(ZimArchive, articleNumber)
 {
   TestDataInfo zimfiles[] = {
      // Name                                          mediaCount,  withns                               nons                                 noTitleListingV0
@@ -694,7 +703,7 @@ for(auto& testfile: getDataFilePath(ZIMNAME, CAT)) {EXPECT_BROKEN_ZIMFILE(testfi
 #define WITH_TITLE_IDX_CAT {"withns", "nons"}
 
 #if WITH_TEST_DATA
-TEST(ZimArchive, validate)
+TEST_F(ZimArchive, validate)
 {
   zim::IntegrityCheckList all;
   all.set();
@@ -892,7 +901,7 @@ void checkEquivalence(const zim::Archive& archive1, const zim::Archive& archive2
 #endif
 }
 
-TEST(ZimArchive, multipart)
+TEST_F(ZimArchive, multipart)
 {
   auto nonSplittedZims = getDataFilePath("wikibooks_be_all_nopic_2017-02.zim");
   auto splittedZims = getDataFilePath("wikibooks_be_all_nopic_2017-02_splitted.zim");
@@ -921,7 +930,7 @@ TEST(ZimArchive, multipart)
 #endif
 
 #ifndef _WIN32
-TEST(ZimArchive, openByFD)
+TEST_F(ZimArchive, openByFD)
 {
   for(auto& testfile: getDataFilePath("small.zim")) {
     const zim::Archive archive1(testfile.path);
@@ -932,7 +941,7 @@ TEST(ZimArchive, openByFD)
   }
 }
 
-TEST(ZimArchive, openZIMFileEmbeddedInAnotherFile)
+TEST_F(ZimArchive, openZIMFileEmbeddedInAnotherFile)
 {
   auto normalZims = getDataFilePath("small.zim");
   auto embeddedZims = getDataFilePath("small.zim.embedded");
@@ -948,7 +957,7 @@ TEST(ZimArchive, openZIMFileEmbeddedInAnotherFile)
   }
 }
 
-TEST(ZimArchive, openZIMFileMultiPartEmbeddedInAnotherFile)
+TEST_F(ZimArchive, openZIMFileMultiPartEmbeddedInAnotherFile)
 {
   auto normalZims = getDataFilePath("small.zim");
   auto embeddedZims = getDataFilePath("small.zim.embedded.multi");
@@ -991,7 +1000,7 @@ zim::Blob readItemData(const zim::Item::DirectAccessInfo& dai, zim::size_type si
   return zim::Blob(data, size);
 }
 
-TEST(ZimArchive, getDirectAccessInformation)
+TEST_F(ZimArchive, getDirectAccessInformation)
 {
   for(auto& testfile:getDataFilePath("small.zim")) {
     const zim::Archive archive(testfile.path);
@@ -1012,7 +1021,7 @@ TEST(ZimArchive, getDirectAccessInformation)
 }
 
 #ifndef _WIN32
-TEST(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
+TEST_F(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
 {
   for(auto& testfile:getDataFilePath("small.zim")) {
     const int fd = OPEN_READ_ONLY(testfile.path);
@@ -1033,7 +1042,7 @@ TEST(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
   }
 }
 
-TEST(ZimArchive, getDirectAccessInformationFromEmbeddedArchive)
+TEST_F(ZimArchive, getDirectAccessInformationFromEmbeddedArchive)
 {
   auto normalZims = getDataFilePath("small.zim");
   auto embeddedZims = getDataFilePath("small.zim.embedded");

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -318,16 +318,16 @@ TEST(ZimArchive, cacheDontImpactReading)
 {
   const TestCacheConfig cacheConfigs[] = {
     {0, 0, 0},
-    {1, 1, 1},
-    {2, 2, 2},
-    {10, 10, 10},
-    {1000, 2000, 1000},
-    {0, 2000, 1000},
-    {1000, 0, 1000},
-    {1000, 2000, 0},
-    {1, 2000, 1000},
-    {1000, 1, 1000},
-    {1000, 2000, 1},
+    {1, 1<<20, 1},
+    {2, 2<<20, 2},
+    {10, 10<<20, 10},
+    {1000, 2000<<20, 1000},
+    {0, 2000<<20, 1000},
+    {1000, 0<<20, 1000},
+    {1000, 2000<<20, 0},
+    {1, 2000<<20, 1000},
+    {1000, 1<<20, 1000},
+    {1000, 2000<<20, 1},
   };
 
   for (auto& testfile: getDataFilePath("small.zim")) {
@@ -351,32 +351,48 @@ TEST(ZimArchive, cacheDontImpactReading)
 
 TEST(ZimArchive, cacheChange)
 {
-  for (auto& testfile: getDataFilePath("wikibooks_be_all_nopic_2017-02.zim")) {
+  // We test only one variant here.
+  // Each variant has cluster of different size (especially the old "withns" which
+  // have a cluster compressed with a algorithm/compression level making input stream
+  // having a size of 64MB),
+  // this make all the following reasoning about cluster size a bit too complex.
+  // As the test here don't test that we can read all variant, we don't have too.
+  for (auto& testfile: getDataFilePath("wikibooks_be_all_nopic_2017-02.zim", {"noTitleListingV0"})) {
+    // wikibooks has only 2 clusters. One of 492121 bytes and one of 823716 bytes.
+    // For a total of 1315837 bytes.
+    // Has we try to keep one cluster in the cache, any size under the size of one
+    // cluster will not be respected.
+    // So we will define 2 limits:
+    // 850<<10 : size higher than a cluster size but under 2
+    // 2 << 20 : size higher than two clusters
+    const size_t L1_SIZE = 850 << 10;
+    const size_t L2_SIZE = 2 << 20;
+
     auto ref_archive = zim::Archive(testfile.path);
     auto archive = zim::Archive(testfile.path);
 
     archive.setDirentCacheMaxSize(30);
-    archive.setClusterCacheMaxSize(5);
+    archive.setClusterCacheMaxSize(L2_SIZE);
 
     auto range = ref_archive.iterEfficient();
     auto ref_it = range.begin();
     ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(ref_it, range.end(), archive, 50)
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 30);
-    EXPECT_EQ(archive.getClusterCacheCurrentSize(), 2); // Only 2 clusters in the file
+    EXPECT_LE(archive.getClusterCacheCurrentSize(), L2_SIZE); // Only 2 clusters in the file
 
     // Reduce cache size
     archive.setDirentCacheMaxSize(10);
-    archive.setClusterCacheMaxSize(1);
+    archive.setClusterCacheMaxSize(L1_SIZE);
 
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 10);
-    EXPECT_EQ(archive.getClusterCacheCurrentSize(), 1);
+    EXPECT_LE(archive.getClusterCacheCurrentSize(), L1_SIZE);
 
     // We want to test change of cache while we are iterating on the archive.
     // So we don't reset the ref_it to `range.begin()`.
     ASSERT_ARCHIVE_EQUIVALENT_IT_LIMIT(ref_it, range.end(), archive, 50)
 
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 10);
-    EXPECT_EQ(archive.getClusterCacheCurrentSize(), 1);
+    EXPECT_LE(archive.getClusterCacheCurrentSize(), L1_SIZE);
 
     // Clean cache
     // (More than testing the value, this is needed as we want to be sure the cache is actually populated later)
@@ -388,13 +404,13 @@ TEST(ZimArchive, cacheChange)
 
     // Increase the cache
     archive.setDirentCacheMaxSize(20);
-    archive.setClusterCacheMaxSize(1);
+    archive.setClusterCacheMaxSize(L1_SIZE);
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 0);
     EXPECT_EQ(archive.getClusterCacheCurrentSize(), 0);
 
     ASSERT_ARCHIVE_EQUIVALENT(ref_archive, archive)
     EXPECT_EQ(archive.getDirentCacheCurrentSize(), 20);
-    EXPECT_EQ(archive.getClusterCacheCurrentSize(), 1);
+    EXPECT_LE(archive.getClusterCacheCurrentSize(), L1_SIZE);
   }
 }
 

--- a/test/istreamreader.cpp
+++ b/test/istreamreader.cpp
@@ -34,17 +34,24 @@ using namespace zim;
 // Implement the IStreamReader interface in the simplest way
 class InfiniteZeroStream : public IStreamReader
 {
-  void readImpl(char* buf, zim::zsize_t nbytes) { memset(buf, 0, nbytes.v); }
+  void readImpl(char* buf, zim::zsize_t nbytes) override { memset(buf, 0, nbytes.v); }
+  size_t getMemorySize() const override {
+    return 0;
+  }
 };
 
 class InfiniteIncreasingStream: public IStreamReader
 {
   zim::offset_type current_offset = 0;
 
-  void readImpl(char* buf, zim::zsize_t nbytes) {
+  void readImpl(char* buf, zim::zsize_t nbytes) override {
     for (size_type i=0; i<nbytes.v; i++) {
       buf[i] = (current_offset++)%256;
     }
+  }
+
+  size_t getMemorySize() const override {
+    return 0;
   }
 };
 
@@ -73,7 +80,7 @@ TEST(IStreamReader, sub_reader_zero)
   EXPECT_EQ(buffer.size().v, N);
   EXPECT_EQ(0, memcmp(buffer.data(), zerobuf, N));
 }
-  
+
 TEST(IStreamReader, read_increasing)
 {
   InfiniteIncreasingStream iis;
@@ -96,7 +103,7 @@ TEST(IStreamReader, sub_reader_increasing)
   auto buffer = subReader->get_buffer(zim::offset_t(0), zim::zsize_t(N));
   EXPECT_EQ(buffer.size().v, N);
   EXPECT_EQ(0, memcmp(buffer.data(), refbuf, N));
-  
+
   buffer = subReader->get_buffer(zim::offset_t(5), zim::zsize_t(N-5));
   EXPECT_EQ(buffer.size().v, N-5);
   EXPECT_EQ(0, memcmp(buffer.data(), refbuf+5, N-5));

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -38,45 +38,108 @@ const unsigned int TEST2_CACHE_CAPACITY = 50u;
 const unsigned int TEST2_CACHE_CAPACITY_SMALL = 10u;
 
 TEST(CacheTest, SimplePut) {
-    zim::lru_cache<int, int> cache_lru(1);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(1);
     cache_lru.put(7, 777);
     EXPECT_TRUE(cache_lru.exists(7));
     EXPECT_EQ(777, cache_lru.get(7));
-    EXPECT_EQ(1u, cache_lru.size());
+    EXPECT_EQ(1u, cache_lru.cost());
 }
 
 TEST(CacheTest, OverwritingPut) {
-    zim::lru_cache<int, int> cache_lru(1);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(1);
     cache_lru.put(7, 777);
     cache_lru.put(7, 222);
     EXPECT_TRUE(cache_lru.exists(7));
     EXPECT_EQ(222, cache_lru.get(7));
-    EXPECT_EQ(1u, cache_lru.size());
+    EXPECT_EQ(1u, cache_lru.cost());
 }
 
 TEST(CacheTest, MissingValue) {
-    zim::lru_cache<int, int> cache_lru(1);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(1);
     EXPECT_TRUE(cache_lru.get(7).miss());
     EXPECT_FALSE(cache_lru.get(7).hit());
     EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
 }
 
 TEST(CacheTest, DropValue) {
-    zim::lru_cache<int, int> cache_lru(3);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(3);
     cache_lru.put(7, 777);
     cache_lru.put(8, 888);
     cache_lru.put(9, 999);
-    EXPECT_EQ(3u, cache_lru.size());
+    EXPECT_EQ(3u, cache_lru.cost());
     EXPECT_TRUE(cache_lru.exists(7));
     EXPECT_EQ(777, cache_lru.get(7));
 
     EXPECT_TRUE(cache_lru.drop(7));
 
-    EXPECT_EQ(2u, cache_lru.size());
+    EXPECT_EQ(2u, cache_lru.cost());
     EXPECT_FALSE(cache_lru.exists(7));
     EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
 
     EXPECT_FALSE(cache_lru.drop(7));
+}
+
+struct IdCost {
+    static size_t cost(size_t value ) {
+        return value;
+    }
+};
+
+TEST(CacheTest, VariableCost) {
+    zim::lru_cache<size_t, size_t, IdCost> cache_lru(100);
+
+    cache_lru.put(1, 11);
+    cache_lru.put(2, 22);
+    cache_lru.put(3, 33);
+    EXPECT_EQ(66u, cache_lru.cost());
+
+    cache_lru.put(4, 44);
+    EXPECT_EQ(99u, cache_lru.cost());
+    EXPECT_FALSE(cache_lru.exists(1));
+    EXPECT_TRUE(cache_lru.exists(2));
+    EXPECT_TRUE(cache_lru.exists(3));
+    EXPECT_TRUE(cache_lru.exists(4));
+
+    cache_lru.put(5, 55);
+    EXPECT_EQ(99u, cache_lru.cost());
+    EXPECT_FALSE(cache_lru.exists(1));
+    EXPECT_FALSE(cache_lru.exists(2));
+    EXPECT_FALSE(cache_lru.exists(3));
+    EXPECT_TRUE(cache_lru.exists(4));
+    EXPECT_TRUE(cache_lru.exists(5));
+
+    cache_lru.put(1, 11);
+    EXPECT_EQ(66u, cache_lru.cost());
+    EXPECT_TRUE(cache_lru.exists(1));
+    EXPECT_FALSE(cache_lru.exists(2));
+    EXPECT_FALSE(cache_lru.exists(3));
+    EXPECT_FALSE(cache_lru.exists(4));
+    EXPECT_TRUE(cache_lru.exists(5));
+}
+
+TEST(CacheTest, TooBigValue) {
+    zim::lru_cache<size_t, size_t, IdCost> cache_lru(10);
+
+    cache_lru.put(1, 11);
+    EXPECT_EQ(11u, cache_lru.cost());
+    EXPECT_TRUE(cache_lru.exists(1));
+
+    cache_lru.put(2, 22);
+    EXPECT_EQ(22u, cache_lru.cost());
+    EXPECT_FALSE(cache_lru.exists(1));
+    EXPECT_TRUE(cache_lru.exists(2));
+
+    cache_lru.put(3, 33);
+    EXPECT_EQ(33u, cache_lru.cost());
+    EXPECT_FALSE(cache_lru.exists(1));
+    EXPECT_FALSE(cache_lru.exists(2));
+    EXPECT_TRUE(cache_lru.exists(3));
+
+    cache_lru.put(1, 11);
+    EXPECT_EQ(11u, cache_lru.cost());
+    EXPECT_TRUE(cache_lru.exists(1));
+    EXPECT_FALSE(cache_lru.exists(2));
+    EXPECT_FALSE(cache_lru.exists(3));
 }
 
 #define EXPECT_RANGE_MISSING_FROM_CACHE(CACHE, START, END) \
@@ -93,7 +156,7 @@ for (unsigned i = START; i  < END; ++i)  {                              \
 
 
 TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
-    zim::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(TEST2_CACHE_CAPACITY);
 
     for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
         cache_lru.put(i, i);
@@ -103,37 +166,37 @@ TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
 
     EXPECT_RANGE_FULLY_IN_CACHE(cache_lru, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY), NUM_OF_TEST2_RECORDS, 1)
 
-    size_t size = cache_lru.size();
+    size_t size = cache_lru.cost();
     EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
 }
 
 TEST(CacheTest1, ChangeCacheCapacity) {
-    zim::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
+    zim::lru_cache<int, int, zim::UnitCostEstimation> cache_lru(TEST2_CACHE_CAPACITY);
 
     for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
         cache_lru.put(i, i);
     }
 
-    EXPECT_EQ(TEST2_CACHE_CAPACITY, cache_lru.size());
+    EXPECT_EQ(TEST2_CACHE_CAPACITY, cache_lru.cost());
     EXPECT_RANGE_MISSING_FROM_CACHE(cache_lru, 0, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY))
     EXPECT_RANGE_FULLY_IN_CACHE(cache_lru, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY), NUM_OF_TEST2_RECORDS, 1)
 
-    cache_lru.setMaxSize(TEST2_CACHE_CAPACITY_SMALL);
-    EXPECT_EQ(TEST2_CACHE_CAPACITY_SMALL, cache_lru.size());
+    cache_lru.setMaxCost(TEST2_CACHE_CAPACITY_SMALL);
+    EXPECT_EQ(TEST2_CACHE_CAPACITY_SMALL, cache_lru.cost());
     EXPECT_RANGE_MISSING_FROM_CACHE(cache_lru, 0, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY_SMALL))
     EXPECT_RANGE_FULLY_IN_CACHE(cache_lru, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY_SMALL), NUM_OF_TEST2_RECORDS, 1)
 
-    cache_lru.setMaxSize(TEST2_CACHE_CAPACITY);
+    cache_lru.setMaxCost(TEST2_CACHE_CAPACITY);
     for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
         cache_lru.put(i, 1000*i);
     }
-    EXPECT_EQ(TEST2_CACHE_CAPACITY, cache_lru.size());
+    EXPECT_EQ(TEST2_CACHE_CAPACITY, cache_lru.cost());
     EXPECT_RANGE_MISSING_FROM_CACHE(cache_lru, 0, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY))
     EXPECT_RANGE_FULLY_IN_CACHE(cache_lru, (NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY), NUM_OF_TEST2_RECORDS, 1000)
 }
 
 TEST(ConcurrentCacheTest, handleException) {
-    zim::ConcurrentCache<int, int> cache(1);
+    zim::ConcurrentCache<int, int, zim::UnitCostEstimation> cache(1);
     auto val = cache.getOrPut(7, []() { return 777; });
     EXPECT_EQ(val, 777);
     EXPECT_THROW(cache.getOrPut(8, []() { throw std::runtime_error("oups"); return 0; }), std::runtime_error);


### PR DESCRIPTION
- Allow the cache to be limited by memory usage instead of number of items
- Make the cluster cache global.

Fix #947 