### PR TITLE
Preload Xapian database

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,8 +12,8 @@ which is always derived from std::exception.
 
 All classes are defined in the namespace zim.
 Copying is allowed and tried to make as cheap as possible.
-The reading part of the libzim is most of the time thread safe.
-Searching and creating part are not. You have to serialize access to the class yourself.
+The reading part of the libzim (including search) is most of the time thread safe.
+Creating part is not. You have to serialize access to the Creator class yourself.
 
 The main class, which accesses a archive is |Archive|.
 It has actually a reference to an implementation, so that copies of the class just references the same file.

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -148,7 +148,19 @@ namespace zim
     public:
       template<EntryOrder order> class EntryRange;
       template<EntryOrder order> class iterator;
-      static const OpenConfig DEFAULT_OPEN_CONFIG;
+
+      /** Archive constructor.
+       *
+       *  Construct an archive from a filename.
+       *  The file is open readonly.
+       *
+       *  The filename is the "logical" path.
+       *  So if you want to open a split zim file (foo.zimaa, foo.zimab, ...)
+       *  you must pass the `foo.zim` path.
+       *
+       *  @param fname The filename to the file to open (utf8 encoded)
+       */
+      explicit Archive(const std::string& fname);
 
       /** Archive constructor.
        *
@@ -162,7 +174,7 @@ namespace zim
        *  @param fname The filename to the file to open (utf8 encoded)
        *  @param openConfig The open configuration to use.
        */
-      Archive(const std::string& fname, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
+      Archive(const std::string& fname, OpenConfig openConfig);
 
 #ifndef _WIN32
       /** Archive constructor.
@@ -174,9 +186,38 @@ namespace zim
        *  Note: This function is not available under Windows.
        *
        *  @param fd The descriptor of a seekable file representing a ZIM archive
+       */
+      explicit Archive(int fd);
+
+      /** Archive constructor.
+       *
+       *  Construct an archive from a file descriptor.
+       *  Fd is used only at Archive creation.
+       *  Ownership of the fd is not taken and it must be closed by caller.
+       *
+       *  Note: This function is not available under Windows.
+       *
+       *  @param fd The descriptor of a seekable file representing a ZIM archive
        *  @param openConfig The open configuration to use.
        */
-      Archive(int fd, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
+      Archive(int fd, OpenConfig openConfig);
+
+      /** Archive constructor.
+       *
+       *  Construct an archive from a descriptor of a file with an embedded ZIM
+       *  archive inside.
+       *  Fd is used only at Archive creation.
+       *  Ownership of the fd is not taken and it must be closed by caller.
+       *
+       *  Note: This function is not available under Windows.
+       *
+       *  @param fd The descriptor of a seekable file with a continuous segment
+       *  representing a complete ZIM archive.
+       *  @param offset The offset of the ZIM archive relative to the beginning
+       *  of the file (rather than the current position associated with fd).
+       *  @param size The size of the ZIM archive.
+       */
+       Archive(int fd, offset_type offset, size_type size);
 
       /** Archive constructor.
        *
@@ -194,7 +235,21 @@ namespace zim
        *  @param size The size of the ZIM archive.
        *  @param openConfig The open configuration to use.
        */
-       Archive(int fd, offset_type offset, size_type size, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
+       Archive(int fd, offset_type offset, size_type size, OpenConfig openConfig);
+
+      /** Archive constructor.
+       *
+       *  Construct an archive from a descriptor of a file with an embedded ZIM
+       *  archive inside.
+       *  Fd is used only at Archive creation.
+       *  Ownership of the fd is not taken and it must be closed by caller.
+       *
+       *  Note: This function is not available under Windows.
+       *
+       *  @param fd A FdInput (tuple) containing the fd (int), offset (offset_type) and size (size_type)
+       *            referencing a continuous segment representing a complete ZIM archive.
+       */
+      explicit Archive(FdInput fd);
 
       /** Archive constructor.
        *
@@ -209,7 +264,22 @@ namespace zim
        *            referencing a continuous segment representing a complete ZIM archive.
        *  @param openConfig The open configuration to use.
        */
-      Archive(FdInput fd, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
+      Archive(FdInput fd, OpenConfig openConfig);
+
+      /** Archive constructor.
+       *
+       *  Construct an archive from several file descriptors.
+       *  Each part may be embedded in a file.
+       *  Fds are used only at Archive creation.
+       *  Ownership of the fds is not taken and they must be closed by caller.
+       *  Fds (int) can be the same between FdInput if the parts belong to the same file.
+       *
+       *  Note: This function is not available under Windows.
+       *
+       *  @param fds A vector of FdInput (tuple) containing the fd (int), offset (offset_type) and size (size_type)
+       *             referencing a series of segments representing a complete ZIM archive.
+       */
+      explicit Archive(const std::vector<FdInput>& fds);
 
       /** Archive constructor.
        *
@@ -225,7 +295,7 @@ namespace zim
        *             referencing a series of segments representing a complete ZIM archive.
        *  @param openConfig The open configuration to use.
        */
-      Archive(const std::vector<FdInput>& fds, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
+      Archive(const std::vector<FdInput>& fds, OpenConfig openConfig);
 #endif
 
       /** Return the filename of the zim file.

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -43,6 +43,75 @@ namespace zim
   };
 
   /**
+   * Configuration to pass to archive constructors.
+   *
+   * Some configuration option specifying how to open a zim archive.
+   * For now, it is only related to preload data but it may change in the future.
+   *
+   * Archive may preload few data to speedup future accessing.
+   * However, this preload itself can take times.
+   *
+   * OpenConfig allow user to define how Archive should preload data.
+   */
+  struct LIBZIM_API OpenConfig {
+     /**
+      * Default configuration.
+      *
+      * - Dirent ranges is activated.
+      * - Xapian preloading is activated.
+      */
+     OpenConfig();
+
+     /**
+      * Configure xapian preloading.
+      *
+      * This method modify the configuration and return itelf.
+      */
+     OpenConfig& preloadXapianDb(bool load) { m_preloadXapianDb = load; return *this; }
+
+     /**
+      * Configure xapian preloading.
+      *
+      * This method create a new configuration with the new value.
+      */
+     OpenConfig preloadXapianDb(bool load) const {
+      auto other = *this;
+      other.m_preloadXapianDb = load;
+      return other;
+     }
+
+     /**
+      * Configure direntRanges preloading.
+      *
+      * libzim will load `nbRanges + 1` dirents to create `nbRanges` dirent ranges.
+      * This will be used to speedup dirent lookup. This is an extra layer on top of
+      * classic dirent cache.
+      *
+      * This method modify the configuration and return itelf.
+      */
+     OpenConfig& preloadDirentRanges(int nbRanges) { m_preloadDirentRanges = nbRanges; return *this; }
+
+     /**
+      * Configure direntRanges preloading.
+      *
+      * libzim will load `nbRanges + 1` dirents to create `nbRanges` dirent ranges.
+      * This will be used to speedup dirent lookup. This is an extra layer on top of
+      * classic dirent cache.
+      *
+      * This method create a new configuration with the new value.
+      */
+     OpenConfig preloadDirentRanges(int nbRanges) const {
+      auto other = *this;
+      other.m_preloadDirentRanges = nbRanges;
+      return other;
+     }
+
+     bool m_preloadXapianDb;
+     int  m_preloadDirentRanges;
+  };
+
+
+  /**
    * The Archive class to access content in a zim file.
    *
    * The `Archive` is the main class to access content in a zim file.
@@ -79,6 +148,7 @@ namespace zim
     public:
       template<EntryOrder order> class EntryRange;
       template<EntryOrder order> class iterator;
+      static const OpenConfig DEFAULT_OPEN_CONFIG;
 
       /** Archive constructor.
        *
@@ -90,8 +160,9 @@ namespace zim
        *  you must pass the `foo.zim` path.
        *
        *  @param fname The filename to the file to open (utf8 encoded)
+       *  @param openConfig The open configuration to use.
        */
-      explicit Archive(const std::string& fname);
+      Archive(const std::string& fname, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
 
 #ifndef _WIN32
       /** Archive constructor.
@@ -103,8 +174,9 @@ namespace zim
        *  Note: This function is not available under Windows.
        *
        *  @param fd The descriptor of a seekable file representing a ZIM archive
+       *  @param openConfig The open configuration to use.
        */
-      explicit Archive(int fd);
+      Archive(int fd, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
 
       /** Archive constructor.
        *
@@ -120,8 +192,9 @@ namespace zim
        *  @param offset The offset of the ZIM archive relative to the beginning
        *  of the file (rather than the current position associated with fd).
        *  @param size The size of the ZIM archive.
+       *  @param openConfig The open configuration to use.
        */
-       Archive(int fd, offset_type offset, size_type size);
+       Archive(int fd, offset_type offset, size_type size, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
 
       /** Archive constructor.
        *
@@ -134,8 +207,9 @@ namespace zim
        *
        *  @param fd A FdInput (tuple) containing the fd (int), offset (offset_type) and size (size_type)
        *            referencing a continuous segment representing a complete ZIM archive.
+       *  @param openConfig The open configuration to use.
        */
-      explicit Archive(FdInput fd);
+      Archive(FdInput fd, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
 
       /** Archive constructor.
        *
@@ -149,8 +223,9 @@ namespace zim
        *
        *  @param fds A vector of FdInput (tuple) containing the fd (int), offset (offset_type) and size (size_type)
        *             referencing a series of segments representing a complete ZIM archive.
+       *  @param openConfig The open configuration to use.
        */
-      explicit Archive(const std::vector<FdInput>& fds);
+      Archive(const std::vector<FdInput>& fds, OpenConfig openConfig=DEFAULT_OPEN_CONFIG);
 #endif
 
       /** Return the filename of the zim file.
@@ -575,28 +650,6 @@ namespace zim
        * @param nbDirents The maximum number of dirents stored in the cache.
        */
       void setDirentCacheMaxSize(size_t nbDirents);
-
-      /** Get the size of the dirent lookup cache.
-       *
-       * The returned size returns the default size or the last set size.
-       * This may not correspond to the actual size of the dirent lookup cache.
-       * See `set_dirent_lookup_cache_max_size` for more information.
-       *
-       * @return The maximum number of sub ranges created in the lookup cache.
-       */
-      size_t getDirentLookupCacheMaxSize() const;
-
-      /** Set the size of the dirent lookup cache.
-       *
-       * Contrary to other `set_<foo>_cache_max_size`, this method is useless once
-       * the lookup cache is created.
-       * The lookup cache is created at first access to a entry in the archive.
-       * So this method must be called before any access to content (including metadata).
-       * It is best to call this method first, just after the archive creation.
-       *
-       * @param nbRanges The maximum number of sub ranges created in the lookup cache.
-       */
-      void setDirentLookupCacheMaxSize(size_t nbRanges);
 
 #ifdef ZIM_PRIVATE
       cluster_index_type getClusterCount() const;

--- a/include/zim/entry.h
+++ b/include/zim/entry.h
@@ -39,7 +39,7 @@ namespace zim
   class LIBZIM_API Entry
   {
     public:
-      explicit Entry(std::shared_ptr<FileImpl> file_, entry_index_type idx_);
+      explicit Entry(std::shared_ptr<const FileImpl> file_, entry_index_type idx_);
 
       bool isRedirect() const;
       std::string getTitle() const;
@@ -84,7 +84,7 @@ namespace zim
       entry_index_type getIndex() const   { return m_idx; }
 
     protected: // so that Item can be implemented as a wrapper over Entry
-      std::shared_ptr<FileImpl> m_file;
+      std::shared_ptr<const FileImpl> m_file;
       entry_index_type m_idx;
       std::shared_ptr<const Dirent> m_dirent;
   };

--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -81,7 +81,7 @@ namespace zim
        *         If it is not possible to have direct access for this item,
        *         return a pair of `{"", 0}`
        */
-      zim::DirectAccessInfo getDirectAccessInformation() const;
+      zim::ItemDataDirectAccessInfo getDirectAccessInformation() const;
 
       entry_index_type getIndex() const   { return Entry::getIndex(); }
 

--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -38,9 +38,6 @@ namespace zim
    */
   class LIBZIM_API Item : private Entry
   {
-    public: // types
-      typedef std::pair<std::string, offset_type> DirectAccessInfo;
-
     public: // functions
       std::string getTitle() const { return Entry::getTitle(); }
       std::string getPath() const  { return Entry::getPath(); }
@@ -84,7 +81,7 @@ namespace zim
        *         If it is not possible to have direct access for this item,
        *         return a pair of `{"", 0}`
        */
-      DirectAccessInfo getDirectAccessInformation() const;
+      zim::DirectAccessInfo getDirectAccessInformation() const;
 
       entry_index_type getIndex() const   { return Entry::getIndex(); }
 

--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -26,7 +26,6 @@
 #include "archive.h"
 #include <vector>
 #include <string>
-#include <map>
 
 namespace Xapian {
   class Enquire;
@@ -48,10 +47,8 @@ class SearchResultSet;
  * A Searcher is mainly used to create new `Search`
  * Internaly, this is mainly a wrapper around a Xapian database.
  *
- * You should consider that all search operations are NOT threadsafe.
- * It is up to you to protect your calls to avoid race competition.
- * However, Searcher (and subsequent classes) do not maintain a global/share state.
- * You can create several Searchers and use them in different threads.
+ * All search (at exception of SearchIterator) operation are thread safe.
+ * You can freely create several Search from one Searcher and use them in different threads.
  */
 class LIBZIM_API Searcher
 {

--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -25,7 +25,6 @@
 #include <memory>
 #include <iterator>
 #include "entry.h"
-#include "archive.h"
 #include "uuid.h"
 
 namespace zim
@@ -34,6 +33,12 @@ class SearchResultSet;
 
 /**
  * A interator on search result (an Entry)
+ *
+ * SearchIterator are mostly thread safe:
+ * - Manipulating the iterator itself (increment it, ...) is not thread safe.
+ *   You should not share an iterator between different thread (and you probably don't have use case for that)
+ * - Reading from two iterators (getPath, ...) from two differents thread is ok.
+ *   (ie: You can pass iterator from one thread to the other one)
  *
  * Be aware that the referenced/pointed Entry is generated and stored
  * in the iterator itself.

--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -137,7 +137,42 @@ namespace zim
     COUNT
   };
 
-  typedef std::pair<std::string, offset_type> DirectAccessInfo;
+  /**
+   * Information needed to directly access to an item data, bypassing libzim library.
+   *
+   * Some items may have their data store uncompressed in the zim archive.
+   * In such case, an user can read the item data directly by (re)opening the file and
+   * seek at the right offset.
+   */
+  struct ItemDataDirectAccessInfo {
+
+     /**
+      * The filename to open.
+      */
+     std::string filename;
+
+     /**
+      * The offset to seek to before reading.
+      */
+     offset_type offset;
+
+     explicit ItemDataDirectAccessInfo()
+       : filename(),
+         offset()
+     {}
+
+     ItemDataDirectAccessInfo(const std::string& filename, offset_type offset)
+       : filename(filename),
+         offset(offset)
+     {}
+
+     /**
+      * Return if the ItemDataDirectAccessInfo is valid
+      */
+     bool isValid() const {
+      return !filename.empty();
+     }
+  };
 }
 
 #endif // ZIM_ZIM_H

--- a/include/zim/zim.h
+++ b/include/zim/zim.h
@@ -23,6 +23,7 @@
 #define ZIM_ZIM_H
 
 #include <cstdint>
+#include <string>
 
 #ifdef __GNUC__
 #define DEPRECATED __attribute__((deprecated))
@@ -135,6 +136,8 @@ namespace zim
      */
     COUNT
   };
+
+  typedef std::pair<std::string, offset_type> DirectAccessInfo;
 }
 
 #endif // ZIM_ZIM_H

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -33,25 +33,32 @@ log_define("zim.archive")
 
 namespace zim
 {
-  Archive::Archive(const std::string& fname)
-    : m_impl(new FileImpl(fname))
+  const OpenConfig Archive::DEFAULT_OPEN_CONFIG;
+
+  OpenConfig::OpenConfig()
+      : m_preloadXapianDb(true),
+        m_preloadDirentRanges(DIRENT_LOOKUP_CACHE_SIZE)
+    { }
+
+  Archive::Archive(const std::string& fname, OpenConfig openConfig)
+    : m_impl(new FileImpl(fname, openConfig))
     { }
 
 #ifndef _WIN32
-  Archive::Archive(int fd)
-    : m_impl(new FileImpl(fd))
+  Archive::Archive(int fd, OpenConfig openConfig)
+    : m_impl(new FileImpl(fd, openConfig))
     { }
 
-  Archive::Archive(FdInput fd)
-    : m_impl(new FileImpl(fd))
-    { }
-
-  Archive::Archive(int fd, offset_type offset, size_type size)
-    : Archive(FdInput(fd, offset, size))
+  Archive::Archive(FdInput fd, OpenConfig openConfig)
+    : m_impl(new FileImpl(fd, openConfig))
   {}
 
-  Archive::Archive(const std::vector<FdInput>& fds)
-    : m_impl(new FileImpl(fds))
+  Archive::Archive(int fd, offset_type offset, size_type size, OpenConfig openConfig)
+    : Archive(FdInput(fd, offset, size), openConfig)
+    { }
+
+  Archive::Archive(const std::vector<FdInput>& fds, OpenConfig openConfig)
+    : m_impl(new FileImpl(fds, openConfig))
     { }
 #endif
 
@@ -532,17 +539,6 @@ namespace zim
   void Archive::setDirentCacheMaxSize(size_t nbDirents)
   {
     m_impl->setDirentCacheMaxSize(nbDirents);
-  }
-
-
-  size_t Archive::getDirentLookupCacheMaxSize() const
-  {
-    return m_impl->getDirentLookupCacheMaxSize();
-  }
-
-  void Archive::setDirentLookupCacheMaxSize(size_t nbRanges)
-  {
-    m_impl->setDirentLookupCacheMaxSize(nbRanges);
   }
 
   cluster_index_type Archive::getClusterCount() const

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -334,7 +334,7 @@ namespace zim
     auto entry = Entry(m_impl, entry_index_type(r.second));
     auto item = entry.getItem(true);
     auto accessInfo = item.getDirectAccessInformation();
-    return accessInfo.second;
+    return accessInfo.isValid();
   }
 
   bool Archive::hasTitleIndex() const {
@@ -345,7 +345,7 @@ namespace zim
     auto entry = Entry(m_impl, entry_index_type(r.second));
     auto item = entry.getItem(true);
     auto accessInfo = item.getDirectAccessInformation();
-    return accessInfo.second;
+    return accessInfo.isValid();
   }
 
   Archive::EntryRange<EntryOrder::pathOrder> Archive::iterByPath() const

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -36,7 +36,8 @@ namespace zim
   const OpenConfig Archive::DEFAULT_OPEN_CONFIG;
 
   OpenConfig::OpenConfig()
-      : m_preloadXapianDb(true),
+    :
+        m_preloadXapianDb(true),
         m_preloadDirentRanges(DIRENT_LOOKUP_CACHE_SIZE)
     { }
 

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -142,7 +142,7 @@ namespace zim
 
   Item Archive::getMetadataItem(const std::string& name) const
   {
-    auto r = m_impl->findx('M', name);
+    auto r = m_impl->findxMetadata(name);
     if (!r.first) {
       throw EntryNotFound("Cannot find metadata");
     }

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -33,12 +33,14 @@ log_define("zim.archive")
 
 namespace zim
 {
-  const OpenConfig Archive::DEFAULT_OPEN_CONFIG;
-
   OpenConfig::OpenConfig()
-    :
+    : 
         m_preloadXapianDb(true),
         m_preloadDirentRanges(DIRENT_LOOKUP_CACHE_SIZE)
+    { }
+
+  Archive::Archive(const std::string& fname)
+    : Archive(fname, OpenConfig())
     { }
 
   Archive::Archive(const std::string& fname, OpenConfig openConfig)
@@ -46,16 +48,32 @@ namespace zim
     { }
 
 #ifndef _WIN32
+  Archive::Archive(int fd)
+    : Archive(fd, OpenConfig())
+    { }
+
   Archive::Archive(int fd, OpenConfig openConfig)
     : m_impl(new FileImpl(fd, openConfig))
     { }
 
+  Archive::Archive(FdInput fd)
+    : Archive(fd, OpenConfig())
+    { }
+
   Archive::Archive(FdInput fd, OpenConfig openConfig)
     : m_impl(new FileImpl(fd, openConfig))
-  {}
+    { }
+
+  Archive::Archive(int fd, offset_type offset, size_type size)
+    : Archive(FdInput(fd, offset, size), OpenConfig())
+    { }
 
   Archive::Archive(int fd, offset_type offset, size_type size, OpenConfig openConfig)
     : Archive(FdInput(fd, offset, size), openConfig)
+    { }
+
+  Archive::Archive(const std::vector<FdInput>& fds)
+    : Archive(fds, OpenConfig())
     { }
 
   Archive::Archive(const std::vector<FdInput>& fds, OpenConfig openConfig)

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -29,7 +29,7 @@ log_define("zim.entry")
 
 using namespace zim;
 
-Entry::Entry(std::shared_ptr<FileImpl> file, entry_index_type idx)
+Entry::Entry(std::shared_ptr<const FileImpl> file, entry_index_type idx)
   : m_file(file),
     m_idx(idx),
     m_dirent(file->getDirent(entry_index_t(idx)))

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -263,6 +263,8 @@ private: // data
     }
     m_byTitleDirentLookup.reset(new ByTitleDirentLookup(mp_titleDirentAccessor.get()));
 
+    mp_xapianDb = loadXapianDb(tmpDirentLookup);
+
     readMimeTypes();
   }
 
@@ -857,11 +859,11 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
     return cluster->getBlob(dirent.getBlobNumber(), offset, size);
   }
 
-  std::shared_ptr<XapianDb> FileImpl::getXapianDb() {
+  std::shared_ptr<XapianDb> FileImpl::loadXapianDb(DirentLookup& direntLookup) {
     FileImpl::FindxResult r;
-    r = direntLookup().find('X', "fulltext/xapian");
+    r = direntLookup.find('X', "fulltext/xapian");
     if (!r.first) {
-      r = direntLookup().find('Z', "/fulltextIndex/xapian");
+      r = direntLookup.find('Z', "/fulltextIndex/xapian");
     }
     if (!r.first) {
       return nullptr;
@@ -888,7 +890,7 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
       // So we need a language, let's use the one of the zim.
       // If zimfile has no language metadata, we can't do lot more here :/
       try {
-        r = direntLookup().find('M', "Language");
+        r = direntLookup.find('M', "Language");
         if (r.first) {
           auto langDirent = getDirent(r.second);
           while (langDirent->isRedirect()) {
@@ -903,5 +905,9 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
       // Do nothing
     }
     return nullptr;
+  }
+
+  std::shared_ptr<XapianDb> FileImpl::getXapianDb() {
+    return mp_xapianDb;
   }
 }

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -840,4 +840,18 @@ bool checkTitleListing(const IndirectDirentAccessor& accessor, entry_index_type 
     const auto physical_local_offset = logical_local_offset + part->offset().v;
     return ItemDataDirectAccessInfo(part->filename(), physical_local_offset);
   }
+
+  Blob FileImpl::getBlob(const Dirent& dirent, offset_t offset) const
+  {
+    auto cluster = getCluster(dirent.getClusterNumber());
+    auto blobIdx = dirent.getBlobNumber();
+    auto size = zsize_t(cluster->getBlobSize(blobIdx).v - offset.v);
+    return cluster->getBlob(blobIdx, offset, size);
+  }
+
+  Blob FileImpl::getBlob(const Dirent& dirent, offset_t offset, zsize_t size) const
+  {
+    auto cluster = getCluster(dirent.getClusterNumber());
+    return cluster->getBlob(dirent.getBlobNumber(), offset, size);
+  }
 }

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -380,12 +380,12 @@ private: // data
     }
   }
 
-  FileImpl::FindxResult FileImpl::findx(char ns, const std::string& path)
+  FileImpl::FindxResult FileImpl::findx(char ns, const std::string& path) const
   {
     return direntLookup().find(ns, path);
   }
 
-  FileImpl::FindxResult FileImpl::findx(const std::string& longPath)
+  FileImpl::FindxResult FileImpl::findx(const std::string& longPath) const
   {
     char ns;
     std::string path;
@@ -402,17 +402,17 @@ private: // data
   }
 
   FileCompound::PartRange
-  FileImpl::getFileParts(offset_t offset, zsize_t size)
+  FileImpl::getFileParts(offset_t offset, zsize_t size) const
   {
     return zimFile->locate(offset, size);
   }
 
-  std::shared_ptr<const Dirent> FileImpl::getDirent(entry_index_t idx)
+  std::shared_ptr<const Dirent> FileImpl::getDirent(entry_index_t idx) const
   {
     return mp_pathDirentAccessor->getDirent(idx);
   }
 
-  std::shared_ptr<const Dirent> FileImpl::getDirentByTitle(title_index_t idx)
+  std::shared_ptr<const Dirent> FileImpl::getDirentByTitle(title_index_t idx) const
   {
     return mp_titleDirentAccessor->getDirent(idx);
   }
@@ -464,14 +464,14 @@ private: // data
     return entry_index_t(m_articleListByCluster[idx.v]);
   }
 
-  FileImpl::ClusterHandle FileImpl::readCluster(cluster_index_t idx)
+  FileImpl::ClusterHandle FileImpl::readCluster(cluster_index_t idx) const
   {
     offset_t clusterOffset(getClusterOffset(idx));
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
     return Cluster::read(*zimReader, clusterOffset);
   }
 
-  std::shared_ptr<const Cluster> FileImpl::getCluster(cluster_index_t idx)
+  std::shared_ptr<const Cluster> FileImpl::getCluster(cluster_index_t idx) const
   {
     if (idx >= getCountClusters())
       throw ZimFileFormatError("cluster index out of range");
@@ -503,7 +503,7 @@ private: // data
     return readOffset(*clusterOffsetReader, idx.v);
   }
 
-  offset_t FileImpl::getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx)
+  offset_t FileImpl::getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx) const
   {
     auto cluster = getCluster(clusterIdx);
     if (cluster->isCompressed())

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -36,6 +36,7 @@
 #include "file_reader.h"
 #include "file_compound.h"
 #include "fileheader.h"
+#include "search_internal.h"
 #include "zim_types.h"
 #include "direntreader.h"
 
@@ -165,6 +166,8 @@ namespace zim
       void setDirentCacheMaxSize(size_t nbDirents);
       size_t getDirentLookupCacheMaxSize() const;
       void setDirentLookupCacheMaxSize(size_t nbRanges) { m_direntLookupSize = nbRanges; };
+
+      std::shared_ptr<XapianDb> getXapianDb();
   private:
       explicit FileImpl(std::shared_ptr<FileCompound> zimFile);
       FileImpl(std::shared_ptr<FileCompound> zimFile, offset_t offset, zsize_t size);

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -126,6 +126,9 @@ namespace zim
       FindxResult findx(const std::string &path) const;
       FindxTitleResult findxByTitle(char ns, const std::string& title);
 
+      Blob getBlob(const Dirent& dirent, offset_t offset = offset_t(0)) const;
+      Blob getBlob(const Dirent& dirent, offset_t offset, zsize_t size) const;
+
       std::shared_ptr<const Cluster> getCluster(cluster_index_t idx) const;
       cluster_index_t getCountClusters() const       { return cluster_index_t(header.getClusterCount()); }
       offset_t getClusterOffset(cluster_index_t idx) const;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -130,6 +130,7 @@ namespace zim
       cluster_index_t getCountClusters() const       { return cluster_index_t(header.getClusterCount()); }
       offset_t getClusterOffset(cluster_index_t idx) const;
       offset_t getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx) const;
+      ItemDataDirectAccessInfo getDirectAccessInformation(cluster_index_t clusterIdx, blob_index_t blobIdx) const;
 
       entry_index_t getNamespaceBeginOffset(char ch) const;
       entry_index_t getNamespaceEndOffset(char ch) const;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -55,7 +55,7 @@ namespace zim
       std::unique_ptr<const IndirectDirentAccessor> mp_titleDirentAccessor;
 
       typedef std::shared_ptr<const Cluster> ClusterHandle;
-      ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
+      mutable ConcurrentCache<cluster_index_type, ClusterHandle> clusterCache;
 
       const bool m_hasFrontArticlesIndex;
       const entry_index_t m_startUserEntry;
@@ -115,21 +115,21 @@ namespace zim
       bool hasNewNamespaceScheme() const { return header.useNewNamespaceScheme(); }
       bool hasFrontArticlesIndex() const { return m_hasFrontArticlesIndex; }
 
-      FileCompound::PartRange getFileParts(offset_t offset, zsize_t size);
-      std::shared_ptr<const Dirent> getDirent(entry_index_t idx);
-      std::shared_ptr<const Dirent> getDirentByTitle(title_index_t idx);
+      FileCompound::PartRange getFileParts(offset_t offset, zsize_t size) const;
+      std::shared_ptr<const Dirent> getDirent(entry_index_t idx) const;
+      std::shared_ptr<const Dirent> getDirentByTitle(title_index_t idx) const;
       entry_index_t getIndexByTitle(title_index_t idx) const;
       entry_index_t getIndexByClusterOrder(entry_index_t idx) const;
       entry_index_t getCountArticles() const { return entry_index_t(header.getArticleCount()); }
 
-      FindxResult findx(char ns, const std::string &path);
-      FindxResult findx(const std::string &path);
+      FindxResult findx(char ns, const std::string &path) const;
+      FindxResult findx(const std::string &path) const;
       FindxTitleResult findxByTitle(char ns, const std::string& title);
 
-      std::shared_ptr<const Cluster> getCluster(cluster_index_t idx);
+      std::shared_ptr<const Cluster> getCluster(cluster_index_t idx) const;
       cluster_index_t getCountClusters() const       { return cluster_index_t(header.getClusterCount()); }
       offset_t getClusterOffset(cluster_index_t idx) const;
-      offset_t getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx);
+      offset_t getBlobOffset(cluster_index_t clusterIdx, blob_index_t blobIdx) const;
 
       entry_index_t getNamespaceBeginOffset(char ch) const;
       entry_index_t getNamespaceEndOffset(char ch) const;
@@ -170,7 +170,7 @@ namespace zim
 
       void prepareArticleListByCluster() const;
       DirentLookup& direntLookup() const;
-      ClusterHandle readCluster(cluster_index_t idx);
+      ClusterHandle readCluster(cluster_index_t idx) const;
       offset_type getMimeListEndUpperLimit() const;
       void readMimeTypes();
       void quickCheckForCorruptFile();

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -131,6 +131,7 @@ namespace zim
 
       FindxResult findx(char ns, const std::string &path) const;
       FindxResult findx(const std::string &path) const;
+      FindxResult findxMetadata(const std::string &name) const;
       FindxTitleResult findxByTitle(char ns, const std::string& title);
 
       Blob getBlob(const Dirent& dirent, offset_t offset = offset_t(0)) const;

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -97,6 +97,8 @@ namespace zim
       using ByTitleDirentLookup = zim::DirentLookup<ByTitleDirentLookupConfig>;
       std::unique_ptr<ByTitleDirentLookup> m_byTitleDirentLookup;
 
+      std::shared_ptr<XapianDb> mp_xapianDb;
+
     public:
       using FindxResult = std::pair<bool, entry_index_t>;
       using FindxTitleResult = std::pair<bool, title_index_t>;
@@ -167,6 +169,7 @@ namespace zim
       size_t getDirentLookupCacheMaxSize() const;
       void setDirentLookupCacheMaxSize(size_t nbRanges) { m_direntLookupSize = nbRanges; };
 
+      std::shared_ptr<XapianDb> loadXapianDb(DirentLookup& direntLookup);
       std::shared_ptr<XapianDb> getXapianDb();
   private:
       explicit FileImpl(std::shared_ptr<FileCompound> zimFile);

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -36,11 +36,13 @@
 #include "file_reader.h"
 #include "file_compound.h"
 #include "fileheader.h"
-#include "search_internal.h"
 #include "zim/archive.h"
 #include "zim_types.h"
 #include "direntreader.h"
 
+#ifdef ENABLE_XAPIAN
+#include "search_internal.h"
+#endif
 
 namespace zim
 {
@@ -95,10 +97,11 @@ namespace zim
       using ByTitleDirentLookup = zim::DirentLookup<ByTitleDirentLookupConfig>;
       std::unique_ptr<ByTitleDirentLookup> m_byTitleDirentLookup;
 
+#ifdef ENABLE_XAPIAN
       std::shared_ptr<XapianDb> mp_xapianDb;
       mutable std::mutex m_xapianDbCreationMutex;
       mutable std::atomic_bool m_xapianDbCreated;
-
+#endif
 
     public:
       using FindxResult = std::pair<bool, entry_index_t>;
@@ -168,8 +171,10 @@ namespace zim
       size_t getDirentCacheCurrentSize() const;
       void setDirentCacheMaxSize(size_t nbDirents);
 
+#ifdef ENABLE_XAPIAN
       std::shared_ptr<XapianDb> loadXapianDb();
       std::shared_ptr<XapianDb> getXapianDb();
+#endif
   private:
       FileImpl(std::shared_ptr<FileCompound> zimFile, OpenConfig openConfig);
       FileImpl(std::shared_ptr<FileCompound> zimFile, offset_t offset, zsize_t size, OpenConfig openConfig);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -64,25 +64,7 @@ size_type Item::getSize() const
 
 ItemDataDirectAccessInfo Item::getDirectAccessInformation() const
 {
-  auto cluster = m_file->getCluster(m_dirent->getClusterNumber());
-  if (cluster->isCompressed()) {
-    return ItemDataDirectAccessInfo();
-  }
-
-  auto full_offset = m_file->getBlobOffset(m_dirent->getClusterNumber(),
-                                         m_dirent->getBlobNumber());
-
-  auto part_its = m_file->getFileParts(full_offset, zsize_t(getSize()));
-  auto first_part = part_its.first;
-  if (++part_its.first != part_its.second) {
-   // The content is split on two parts. We cannot have direct access
-    return ItemDataDirectAccessInfo();
-  }
-  auto range = first_part->first;
-  auto part = first_part->second;
-  const offset_type logical_local_offset(full_offset - range.min);
-  const auto physical_local_offset = logical_local_offset + part->offset().v;
-  return ItemDataDirectAccessInfo(part->filename(), physical_local_offset);
+  return m_file->getDirectAccessInformation(m_dirent->getClusterNumber(), m_dirent->getBlobNumber());
 }
 
 cluster_index_type Item::getClusterIndex() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -21,6 +21,7 @@
 #define ZIM_PRIVATE
 #include <zim/item.h>
 #include "cluster.h"
+#include "zim/zim.h"
 #include "fileimpl.h"
 #include "log.h"
 
@@ -61,11 +62,11 @@ size_type Item::getSize() const
   return size_type(cluster->getBlobSize(m_dirent->getBlobNumber()));
 }
 
-std::pair<std::string, offset_type> Item::getDirectAccessInformation() const
+ItemDataDirectAccessInfo Item::getDirectAccessInformation() const
 {
   auto cluster = m_file->getCluster(m_dirent->getClusterNumber());
   if (cluster->isCompressed()) {
-    return std::make_pair("", 0);
+    return ItemDataDirectAccessInfo();
   }
 
   auto full_offset = m_file->getBlobOffset(m_dirent->getClusterNumber(),
@@ -75,13 +76,13 @@ std::pair<std::string, offset_type> Item::getDirectAccessInformation() const
   auto first_part = part_its.first;
   if (++part_its.first != part_its.second) {
    // The content is split on two parts. We cannot have direct access
-    return std::make_pair("", 0);
+    return ItemDataDirectAccessInfo();
   }
   auto range = first_part->first;
   auto part = first_part->second;
   const offset_type logical_local_offset(full_offset - range.min);
   const auto physical_local_offset = logical_local_offset + part->offset().v;
-  return std::make_pair(part->filename(), physical_local_offset);
+  return ItemDataDirectAccessInfo(part->filename(), physical_local_offset);
 }
 
 cluster_index_type Item::getClusterIndex() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -44,16 +44,12 @@ std::string Item::getMimetype() const
 
 Blob Item::getData(offset_type offset) const
 {
-  auto size = getSize()-offset;
-  return getData(offset, size);
+  return m_file->getBlob(*m_dirent, offset_t(offset));
 }
 
 Blob Item::getData(offset_type offset, size_type size) const
 {
-  auto cluster = m_file->getCluster(m_dirent->getClusterNumber());
-  return cluster->getBlob(m_dirent->getBlobNumber(),
-                          offset_t(offset),
-                          zsize_t(size));
+  return m_file->getBlob(*m_dirent, offset_t(offset), zsize_t(size));
 }
 
 size_type Item::getSize() const

--- a/src/lock.h
+++ b/src/lock.h
@@ -1,0 +1,57 @@
+#ifndef ZIM_LOCK_H
+#define ZIM_LOCK_H
+
+#include <algorithm>
+#include <mutex>
+#include <system_error>
+#include <vector>
+
+class MultiMutex {
+  public:
+    explicit MultiMutex()
+     : m_mutexes()
+     {}
+    explicit MultiMutex(const std::vector<std::recursive_mutex*>& mutexes)
+     : m_mutexes(mutexes) {
+    // By sorting the mutex, we avoid the simple case when 3 concurrent multi lock:
+    // - (A, B)
+    // - (B, C)
+    // - (C, A)
+    // As we sort, we will have :
+    // - (A, B)
+    // - (B, C)
+    // - (A, C)
+    //
+    // And no deadlock can occurs.
+       std::sort(m_mutexes.begin(), m_mutexes.end());
+     }
+
+    void lock() {
+      auto lockedCount = 0;
+      for (auto mutex:m_mutexes) {
+        try {
+          mutex->lock();
+          lockedCount += 1;
+        } catch(const std::system_error& e) {
+          unwindLock(lockedCount);
+          throw;
+        }
+      }
+    }
+
+    void unlock() {
+      unwindLock(m_mutexes.size());
+    }
+
+
+  private:
+    std::vector<std::recursive_mutex*> m_mutexes;
+
+    void unwindLock(size_t lockedCount) {
+      while (lockedCount) {
+        m_mutexes[--lockedCount]->unlock();
+      }
+    }
+};
+
+#endif // ZIM_LOCK_H

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -113,7 +113,7 @@ InternalDataBase::InternalDataBase(const std::vector<Archive>& archives, bool ve
         }
         auto xapianEntry = Entry(impl, entry_index_type(r.second));
         auto accessInfo = xapianEntry.getItem().getDirectAccessInformation();
-        if (accessInfo.second == 0) {
+        if (!accessInfo.isValid()) {
             continue;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -143,7 +143,6 @@ InternalDataBase::InternalDataBase(const std::vector<Archive>& archives, bool ve
                 first = false;
             }
             m_database.add_database(database.m_db);
-            m_xapianDatabases.push_back(std::move(database));
             m_archives.push_back(archive);
         } catch( Xapian::DatabaseError& e ) {
             // [TODO] Ignore the database or raise a error ?
@@ -155,7 +154,7 @@ InternalDataBase::InternalDataBase(const std::vector<Archive>& archives, bool ve
 
 bool InternalDataBase::hasDatabase() const
 {
-  return !m_xapianDatabases.empty();
+  return !m_archives.empty();
 }
 
 bool InternalDataBase::hasValuesmap() const

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -94,9 +94,6 @@ class InternalDataBase {
     // The (main) database we will search on (wrapping other xapian databases).
     Xapian::Database m_database;
 
-    // The real databases.
-    std::vector<XapianDb> m_xapianDatabases;
-
     // The archives we are searching on.
     std::vector<Archive> m_archives;
 

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -26,6 +26,7 @@
 #include <xapian.h>
 
 #include <zim/archive.h>
+#include <zim/search.h>
 #include <zim/entry.h>
 #include <zim/error.h>
 

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -34,13 +34,13 @@ namespace zim {
  */
 class InternalDataBase {
   public: // methods
-    InternalDataBase(const std::vector<Archive>& archives, bool verbose);
+    InternalDataBase(const std::vector<zim::Archive>& archives, bool verbose);
     bool hasDatabase() const;
     bool hasValuesmap() const;
     bool hasValue(const std::string& valueName) const;
     int  valueSlot(const std::string&  valueName) const;
 
-    Xapian::Query parseQuery(const Query& query);
+    Xapian::Query parseQuery(const zim::Query& query);
 
   public: // data
     // The (main) database we will search on (wrapping other xapian databases).

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -34,10 +34,7 @@ namespace zim {
 class XapianDbMetadata {
   public: // methods
     XapianDbMetadata() = default;
-    XapianDbMetadata(XapianDbMetadata&&) = default;
-
     XapianDbMetadata(const Xapian::Database& db, std::string defaultLanguage);
-    XapianDbMetadata& operator=(XapianDbMetadata&& other) = default;
 
     // Return a newly allocated stopper.
     // This stopper can (and should to be properly deleted) be directly passed to xapian
@@ -70,6 +67,16 @@ class XapianDbMetadata {
     std::string m_stopwords;
 };
 
+class XapianDb {
+  public: // method
+    XapianDb(const Xapian::Database& db, std::string defaultLanguage);
+
+  public: // data
+    XapianDbMetadata m_metadata;
+
+    Xapian::Database m_db;
+};
+
 /**
  * A class to encapsulate a xapian database and all the information we can gather from it.
  */
@@ -88,7 +95,7 @@ class InternalDataBase {
     Xapian::Database m_database;
 
     // The real databases.
-    std::vector<Xapian::Database> m_xapianDatabases;
+    std::vector<XapianDb> m_xapianDatabases;
 
     // The archives we are searching on.
     std::vector<Archive> m_archives;

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -23,6 +23,8 @@
 #define ZIM_SEARCH_INTERNAL_H
 
 #include "tools.h"
+#include "lock.h"
+#include <mutex>
 #include <xapian.h>
 
 #include <zim/archive.h>
@@ -76,6 +78,8 @@ class XapianDb {
     XapianDbMetadata m_metadata;
 
     Xapian::Database m_db;
+
+    std::recursive_mutex m_mutex;
 };
 
 /**
@@ -90,6 +94,8 @@ class InternalDataBase {
     int  valueSlot(const std::string&  valueName) const;
 
     Xapian::Query parseQuery(const zim::Query& query);
+
+    std::lock_guard<MultiMutex> lock();
 
   public: // data
     // The (main) database we will search on (wrapping other xapian databases).
@@ -107,6 +113,9 @@ class InternalDataBase {
 
     // The metadata of the db
     XapianDbMetadata m_metadata;
+
+    // The MultiMutex associated to the multi db
+    MultiMutex m_mutexes;
 
     // Verbosity of operations.
     bool m_verbose;
@@ -203,6 +212,7 @@ struct SearchIterator::InternalData {
 };
 
 
+#define LOCK_SEARCH(InternalDataBase) auto&& lock = (InternalDataBase)->lock(); (void) lock;
 
 }; //namespace zim
 

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -182,7 +182,7 @@ std::string SearchIterator::getSnippet() const {
             } catch (...) {}
             return internal->mp_mset->snippet(htmlParser.dump,
                                               /*length=*/500,
-                                              /*stemmer=*/internal->mp_internalDb->m_stemmer,
+                                              /*stemmer=*/internal->mp_internalDb->m_metadata.m_stemmer,
                                               /*flags=*/0);
         } catch (...) {
           return "";

--- a/src/search_iterator.cpp
+++ b/src/search_iterator.cpp
@@ -107,6 +107,7 @@ std::string SearchIterator::getPath() const {
         return "";
     }
 
+    LOCK_SEARCH(internal->mp_internalDb);
     try {
         std::string path = internal->get_document().get_data();
         bool hasNewNamespaceScheme = internal->mp_internalDb->m_archives.at(getFileIndex()).hasNewNamespaceScheme();
@@ -132,6 +133,7 @@ std::string SearchIterator::getDbData() const {
         return "";
     }
 
+    LOCK_SEARCH(internal->mp_internalDb);
     return internal->get_document().get_data();
 }
 
@@ -139,6 +141,7 @@ std::string SearchIterator::getTitle() const {
     if ( ! internal ) {
         return "";
     }
+    LOCK_SEARCH(internal->mp_internalDb);
     return internal->get_entry().getTitle();
 }
 
@@ -146,6 +149,7 @@ int SearchIterator::getScore() const {
     if ( ! internal ) {
         return 0;
     }
+    LOCK_SEARCH(internal->mp_internalDb);
     return internal->iterator().get_percent();
 }
 
@@ -154,6 +158,7 @@ std::string SearchIterator::getSnippet() const {
         return "";
     }
 
+    LOCK_SEARCH(internal->mp_internalDb);
     try {
         // Generate full text snippet
         if ( ! internal->mp_internalDb->hasValuesmap() )
@@ -200,6 +205,7 @@ int SearchIterator::getWordCount() const {
     if ( ! internal ) {
         return -1;
     }
+    LOCK_SEARCH(internal->mp_internalDb);
     try {
         if ( ! internal->mp_internalDb->hasValuesmap() )
         {
@@ -238,6 +244,7 @@ SearchIterator::reference SearchIterator::operator*() const {
     if (! internal ) {
         throw std::runtime_error("Cannot get a entry for a uninitialized iterator");
     }
+    LOCK_SEARCH(internal->mp_internalDb);
     return internal->get_entry();
 }
 

--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -63,7 +63,7 @@ void SuggestionDataBase::initXapianDb() {
 
   auto xapianEntry = Entry(impl, entry_index_type(r.second));
   auto accessInfo = xapianEntry.getItem().getDirectAccessInformation();
-  if (accessInfo.second == 0) {
+  if (!accessInfo.isValid()) {
       return;
   }
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -275,19 +275,19 @@ std::string zim::removeAccents(const std::string& text)
   return unaccentedText;
 }
 
-bool zim::getDbFromAccessInfo(zim::DirectAccessInfo accessInfo, Xapian::Database& database) {
+bool zim::getDbFromAccessInfo(zim::ItemDataDirectAccessInfo accessInfo, Xapian::Database& database) {
   zim::DEFAULTFS::FD databasefd;
   try {
-      databasefd = zim::DEFAULTFS::openFile(accessInfo.first);
+      databasefd = zim::DEFAULTFS::openFile(accessInfo.filename);
   } catch (...) {
-      std::cerr << "Impossible to open " << accessInfo.first << std::endl;
+      std::cerr << "Impossible to open " << accessInfo.filename << std::endl;
       std::cerr << strerror(errno) << std::endl;
       return false;
   }
-  if (!databasefd.seek(zim::offset_t(accessInfo.second))) {
+  if (!databasefd.seek(zim::offset_t(accessInfo.offset))) {
       std::cerr << "Something went wrong seeking databasedb "
-                << accessInfo.first << std::endl;
-      std::cerr << "dbOffest = " << accessInfo.second << std::endl;
+                << accessInfo.filename << std::endl;
+      std::cerr << "dbOffest = " << accessInfo.offset << std::endl;
       return false;
   }
 
@@ -295,8 +295,8 @@ bool zim::getDbFromAccessInfo(zim::DirectAccessInfo accessInfo, Xapian::Database
       database = Xapian::Database(databasefd.release());
   } catch( Xapian::DatabaseError& e) {
       std::cerr << "Something went wrong opening xapian database for zimfile "
-                << accessInfo.first << std::endl;
-      std::cerr << "dbOffest = " << accessInfo.second << std::endl;
+                << accessInfo.filename << std::endl;
+      std::cerr << "dbOffest = " << accessInfo.offset << std::endl;
       std::cerr << "error = " << e.get_msg() << std::endl;
       return false;
   }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -275,7 +275,7 @@ std::string zim::removeAccents(const std::string& text)
   return unaccentedText;
 }
 
-bool zim::getDbFromAccessInfo(zim::Item::DirectAccessInfo accessInfo, Xapian::Database& database) {
+bool zim::getDbFromAccessInfo(zim::DirectAccessInfo accessInfo, Xapian::Database& database) {
   zim::DEFAULTFS::FD databasefd;
   try {
       databasefd = zim::DEFAULTFS::openFile(accessInfo.first);

--- a/src/tools.h
+++ b/src/tools.h
@@ -79,7 +79,7 @@ namespace zim {
 // Xapian based tools
 #if defined(ENABLE_XAPIAN)
   std::string LIBZIM_PRIVATE_API removeAccents(const std::string& text);
-  bool getDbFromAccessInfo(zim::DirectAccessInfo accessInfo, Xapian::Database& database);
+  bool getDbFromAccessInfo(zim::ItemDataDirectAccessInfo accessInfo, Xapian::Database& database);
 #endif
 }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -79,7 +79,7 @@ namespace zim {
 // Xapian based tools
 #if defined(ENABLE_XAPIAN)
   std::string LIBZIM_PRIVATE_API removeAccents(const std::string& text);
-  bool getDbFromAccessInfo(Item::DirectAccessInfo accessInfo, Xapian::Database& database);
+  bool getDbFromAccessInfo(zim::DirectAccessInfo accessInfo, Xapian::Database& database);
 #endif
 }
 

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -865,11 +865,11 @@ TEST(ZimArchive, openZIMFileMultiPartEmbeddedInAnotherFile)
 
 
 #if WITH_TEST_DATA
-zim::Blob readItemData(const zim::DirectAccessInfo& dai, zim::size_type size)
+zim::Blob readItemData(const zim::ItemDataDirectAccessInfo& dai, zim::size_type size)
 {
-  zim::DEFAULTFS::FD fd(zim::DEFAULTFS::openFile(dai.first));
+  zim::DEFAULTFS::FD fd(zim::DEFAULTFS::openFile(dai.filename));
   std::shared_ptr<char> data(new char[size], std::default_delete<char[]>());
-  fd.readAt(data.get(), zim::zsize_t(size), zim::offset_t(dai.second));
+  fd.readAt(data.get(), zim::zsize_t(size), zim::offset_t(dai.offset));
   return zim::Blob(data, size);
 }
 
@@ -883,7 +883,7 @@ TEST(ZimArchive, getDirectAccessInformation)
         const TestContext ctx{ {"entry", entry.getPath() } };
         const auto item = entry.getItem();
         const auto dai = item.getDirectAccessInformation();
-        if ( dai.first != "" ) {
+        if ( dai.isValid() ) {
           ++checkedItemCount;
           EXPECT_EQ(item.getData(), readItemData(dai, item.getSize())) << ctx;
         }
@@ -905,7 +905,7 @@ TEST(ZimArchive, getDirectAccessInformationInAnArchiveOpenedByFD)
         const TestContext ctx{ {"entry", entry.getPath() } };
         const auto item = entry.getItem();
         const auto dai = item.getDirectAccessInformation();
-        if ( dai.first != "" ) {
+        if ( dai.isValid() ) {
           ++checkedItemCount;
           EXPECT_EQ(item.getData(), readItemData(dai, item.getSize())) << ctx;
         }
@@ -931,7 +931,7 @@ TEST(ZimArchive, getDirectAccessInformationFromEmbeddedArchive)
         const TestContext ctx{ {"entry", entry.getPath() } };
         const auto item = entry.getItem();
         const auto dai = item.getDirectAccessInformation();
-        if ( dai.first != "" ) {
+        if ( dai.isValid() ) {
           ++checkedItemCount;
           EXPECT_EQ(item.getData(), readItemData(dai, item.getSize())) << ctx;
         }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -334,13 +334,11 @@ TEST(ZimArchive, cacheDontImpactReading)
     auto ref_archive = zim::Archive(testfile.path);
 
     for (auto cacheConfig: cacheConfigs) {
-      auto test_archive = zim::Archive(testfile.path);
+      auto test_archive = zim::Archive(testfile.path, zim::OpenConfig().preloadDirentRanges(cacheConfig.direntLookupCacheSize));
       test_archive.setDirentCacheMaxSize(cacheConfig.direntCacheSize);
-      test_archive.setDirentLookupCacheMaxSize(cacheConfig.direntLookupCacheSize);
       test_archive.setClusterCacheMaxSize(cacheConfig.clusterCacheSize);
 
       EXPECT_EQ(test_archive.getDirentCacheMaxSize(), cacheConfig.direntCacheSize);
-      EXPECT_EQ(test_archive.getDirentLookupCacheMaxSize(), cacheConfig.direntLookupCacheSize);
       EXPECT_EQ(test_archive.getClusterCacheMaxSize(), cacheConfig.clusterCacheSize);
 
       ASSERT_ARCHIVE_EQUIVALENT(ref_archive, test_archive)

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -865,7 +865,7 @@ TEST(ZimArchive, openZIMFileMultiPartEmbeddedInAnotherFile)
 
 
 #if WITH_TEST_DATA
-zim::Blob readItemData(const zim::Item::DirectAccessInfo& dai, zim::size_type size)
+zim::Blob readItemData(const zim::DirectAccessInfo& dai, zim::size_type size)
 {
   zim::DEFAULTFS::FD fd(zim::DEFAULTFS::openFile(dai.first));
   std::shared_ptr<char> data(new char[size], std::default_delete<char[]>());


### PR DESCRIPTION
Fix https://github.com/openzim/libzim/issues/617 (preloading xapian database)

Numbers do not show a strong win (not a lost neither) but this PR also introduce nice improvement as side effect and so is a good preparatory work for next project about multi zim and multi lang issues.

Globally this PR does:
- Move xapian metadata out of internalDataBase
- Separate xapian database (and metadata) from internalDataBase. `XapianDb` is about a specific database stored in a zim file. `InternalDataBase` is about a database we search in (which "include" `XapianDb`s)
- Move opening of xapian database in fileImpl (on the archive side instead of on the search side)
- Open only on xapian db per archive. This as the side effect that searching is now thread safe. (We introduce mutex lock system to do so)
- We introduce a new public method `Archive::preloadXapianDb` to explicitly load the xapian db.

### The numbers

Globally, what is taking time is loading the data from fs into memory. And this is the purpose of this PR to load this data upfront.
So there is two use case to evaluate: a cold one (data is not loading) and warm one (data is loaded).
On top of that, locating the xapian db or using the search results imply loading entries from zim file to get the title. Accessing zim dirent will activate our dirent lookup cache and we will need to populate it (and we know it can take some time, that was the purpose of #950 to be able to deactivate it)

Numbers are obtained by instrumenting zimsearch and running `zimsearch wikispecies_en_all_maxi_2020-06.zim home` (and taking the mean of 3 runs).
Numbers are in milliseconds. Main number is cold. Number is parentheses is warm.
`Search (w getTitle)` is the time to do the search and use it. It include the time to get the title (from zim dirents) of all results (`getTitle`). `Search (wo getTitle)` is simply the difference between both, this is the real time taken by xapian to do the search.


Opening  | no preload | preload  
-- | -- | --
no cache | 13 (1) | 13 (1)
cache | 13 (1) | 13 (1)

Preloading  | no preload | preload  
-- | -- | --
no cache | 0 | 2 (0.6)
cache | 0 | 155 (8)


Create search | no preload | preload  
-- | -- | --
no cache | 2 (0.7) | 0.1 (0.1)
cache | 170 (10) | 0.1 (0.1)

Search (w getTitle) | no preload | preload  
-- | -- | --
no cache | 224 (21) | 250 (20)
cache | 147 (19) | 107 (16)


getTitle  | no preload | preload  
-- | -- | --
no cache | 209 (9) | 235 (9)
cache | 132 (9) | 94 (8)


Search (wo getTitle)  | no preload | preload  
-- | -- | --
no cache | 15 (11) | 14 (11)
cache | 15 (10) | 13 (8)

Total | no preload | preload  
-- | -- | --
no cache | 240 (22) | 265 (22)
cache | 330 (31) | 276 (25)

From `Preloading` table, we can see that loading the xapian DB itself is pretty fast, only 2ms.
When dirent lookup is activated, it take 155ms but this is mostly the time to populate the dirent lookup cache. We found those numbers in `Create search` (no preload) as we load the xapian db (and populate the dirent lookup cache) when we start the search.

The search performance itself is not really changed. Warm run is a bit faster but not a game changer.

Exploiting the search result (`getTitle`) also shows mitigated results:
- dirent lookup improve dirent search
- preload of xapian db has different impact depending of dirent lookup activated or not. However, it should have no impact at all.

For the `Total`, preloading and dirent lookup cache also shows strange results (preloading should not impact the total, dirent lookup cache should have the same impact, what ever preloading is)

At the end, it seem that most of the time spend during a search is about loading the dirent from zim file (either at dirent lookup population or at get title), not from xapian.
As said in the introduction, this PR is still interresting for its side effects:
- Thread safe search
- Only one xapian db open per zim file

