### PR TITLE
Revert "Fix #954. safe_memcmp in tinystring."

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -22,8 +22,6 @@
 #ifndef OPENZIM_LIBZIM_TOOLS_H
 #define OPENZIM_LIBZIM_TOOLS_H
 
-#include <cstddef> // size_t
-#include <cstring> // memcmp
 #include <string>
 #include <tuple>
 #include <map>
@@ -71,17 +69,6 @@ namespace zim {
       }
     }
     return count;
-  }
-
-  // Work around for errors reported by too picky UB sanitizer tools on std::memcmp()
-  // being called with a nullptr pointer argument even though count==0. Explicit
-  // nullptr checks to satisfy other picky compilers.
-  template <typename T>
-  int safe_memcmp(T const *const lhs, T const *const rhs, std::size_t count) noexcept {
-      if(count == 0UL || lhs == nullptr || rhs == nullptr) {
-          return 0;
-      }
-      return std::memcmp(lhs, rhs, count);
   }
 
   namespace writer {

--- a/src/writer/tinyString.h
+++ b/src/writer/tinyString.h
@@ -20,7 +20,6 @@
 #ifndef ZIM_WRITER_TINYSTRING_H
 #define ZIM_WRITER_TINYSTRING_H
 
-#include "../tools.h"
 #include "../zim_types.h"
 #include <cstring>
 
@@ -67,11 +66,11 @@ namespace zim
         size_t size() const { return m_size; }
         const char* const data() const { return m_data; }
         bool operator==(const TinyString& other) const {
-          return (m_size == other.m_size) && (safe_memcmp(m_data, other.m_data, m_size) == 0);
+          return (m_size == other.m_size) && (std::memcmp(m_data, other.m_data, m_size) == 0);
         }
         bool operator<(const TinyString& other) const {
-          const auto min_size = std::min(m_size, other.m_size);
-          const auto ret = safe_memcmp(m_data, other.m_data, min_size);
+          auto min_size = std::min(m_size, other.m_size);
+          auto ret = std::memcmp(m_data, other.m_data, min_size);
           if (ret == 0) {
             return m_size < other.m_size;
           } else {


### PR DESCRIPTION
This reverts commit e152b1daa73a0b372b4788a1e5b1cb36d651f45c.

Fixes #962