### PR TITLE
Fix #954. safe_memcmp in tinystring.

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -22,6 +22,8 @@
 #ifndef OPENZIM_LIBZIM_TOOLS_H
 #define OPENZIM_LIBZIM_TOOLS_H
 
+#include <cstddef> // size_t
+#include <cstring> // memcmp
 #include <string>
 #include <tuple>
 #include <map>
@@ -71,6 +73,17 @@ namespace zim {
       }
     }
     return count;
+  }
+
+  // Work around for errors reported by too picky UB sanitizer tools on std::memcmp()
+  // being called with a nullptr pointer argument even though count==0. Explicit
+  // nullptr checks to satisfy other picky compilers.
+  template <typename T>
+  int safe_memcmp(T const *const lhs, T const *const rhs, std::size_t count) noexcept {
+      if(count == 0UL || lhs == nullptr || rhs == nullptr) {
+          return 0;
+      }
+      return std::memcmp(lhs, rhs, count);
   }
 
 // Xapian based tools

--- a/src/writer/tinyString.h
+++ b/src/writer/tinyString.h
@@ -20,6 +20,7 @@
 #ifndef ZIM_WRITER_TINYSTRING_H
 #define ZIM_WRITER_TINYSTRING_H
 
+#include "../tools.h"
 #include "../zim_types.h"
 #include <cstring>
 
@@ -69,11 +70,11 @@ namespace zim
         size_t size() const { return m_size; }
         const char* const data() const { return m_data; }
         bool operator==(const TinyString& other) const {
-          return (m_size == other.m_size) && (std::memcmp(m_data, other.m_data, m_size) == 0);
+          return (m_size == other.m_size) && (safe_memcmp(m_data, other.m_data, m_size) == 0);
         }
         bool operator<(const TinyString& other) const {
-          auto min_size = std::min(m_size, other.m_size);
-          auto ret = std::memcmp(m_data, other.m_data, min_size);
+          const auto min_size = std::min(m_size, other.m_size);
+          const auto ret = safe_memcmp(m_data, other.m_data, min_size);
           if (ret == 0) {
             return m_size < other.m_size;
           } else {


### PR DESCRIPTION
This is PR to reintroduce safer memcopy, Unfortunately it seems because of problem with noble (and the compiler) we had to remove it. When all the CI is green (including deb packaging) we could reintroduce it.

See https://github.com/openzim/libzim/issues/962

UBSan was complaining about std::memcmp being called with nullptr arguments even when the count == 0. This adds a "safe" wrapper that will just return 0 if the count is 0 or if either of the pointers are nullptr.