### PR TITLE
Backward compatibility of title index v0 removal

### DIFF
--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -124,6 +124,15 @@ namespace zim
     sanity_check();
   }
 
+  bool Fileheader::hasTitleListingV0() const {
+    // A non-released version of libzim existed which signaled the absence of
+    // the title index v0 by setting titleIdxPos to 0 (instead of 0xff..ff).
+    // Such ZIM files are buggy since they cannot be opened by earlier version
+    // of libzim, but we temporarily acknowledge their existence until they are
+    // removed from zim-testing-suite.
+    return titleIdxPos != 0 && titleIdxPos != offset_type(-1);
+  }
+
   void Fileheader::sanity_check() const {
     if (!!articleCount != !!clusterCount) {
       throw ZimFileFormatError("No article <=> No cluster");
@@ -136,9 +145,11 @@ namespace zim
     if (pathPtrPos < mimeListPos) {
       throw ZimFileFormatError("pathPtrPos must be > mimelistPos.");
     }
-    if (titleIdxPos != 0 && titleIdxPos < mimeListPos) {
+
+    if (hasTitleListingV0() && titleIdxPos < mimeListPos) {
       throw ZimFileFormatError("titleIdxPos must be > mimelistPos.");
     }
+
     if (clusterPtrPos < mimeListPos) {
       throw ZimFileFormatError("clusterPtrPos must be > mimelistPos.");
     }

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -79,7 +79,7 @@ namespace zim
       entry_index_type getArticleCount() const            { return articleCount; }
       void      setArticleCount(entry_index_type s)       { articleCount = s; }
 
-      bool hasTitleListingV0() const               { return titleIdxPos != 0; }
+      bool hasTitleListingV0() const;
       offset_type getTitleIdxPos() const           { return titleIdxPos; }
       void        setTitleIdxPos(offset_type p)    { titleIdxPos = p; }
 

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -329,9 +329,8 @@ private: // data
   offset_type FileImpl::getMimeListEndUpperLimit() const
   {
     offset_type result(header.getPathPtrPos());
-    auto titleIdxPos = header.getTitleIdxPos();
-    if (titleIdxPos != 0) {
-      result = std::min(result, titleIdxPos);
+    if (header.hasTitleListingV0()) {
+      result = std::min(result, header.getTitleIdxPos());
     }
     result = std::min(result, header.getClusterPtrPos());
     if ( getCountArticles().v != 0 ) {
@@ -566,11 +565,11 @@ private: // data
 
     struct zim_MD5_CTX md5ctx;
     zim_MD5Init(&md5ctx);
-    
+
     unsigned char ch[CHUNK_SIZE];
     offset_type checksumPos = header.getChecksumPos();
     offset_type toRead = checksumPos;
-    
+
     for(auto part = zimFile->begin();
         part != zimFile->end();
         part++) {
@@ -580,7 +579,7 @@ private: // data
         zim_MD5Update(&md5ctx, ch, CHUNK_SIZE);
         toRead-=CHUNK_SIZE;
       }
-      
+
       // Previous read was good, so we have exited the previous `while` because
       // `toRead<CHUNK_SIZE`. Let's try to read `toRead` chars and process them later.
       // Else, the previous `while` exited because we didn't succeed to read
@@ -589,12 +588,12 @@ private: // data
       if(stream.good()){
         stream.read(reinterpret_cast<char*>(ch),toRead);
       }
-      
+
       // It updates the checksum with the remaining amount of data when we
       // reach the end of the file or part
       zim_MD5Update(&md5ctx, ch, stream.gcount());
       toRead-=stream.gcount();
-    
+
       if (stream.bad()) {
         perror("error while reading file");
         return false;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -317,7 +317,7 @@ namespace zim
 
       header->setMimeListPos( Fileheader::size );
 
-      header->setTitleIdxPos(0);
+      header->setTitleIdxPos(offset_type(-1));
       header->setClusterCount( data->clustersList.size() );
     }
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -305,7 +305,7 @@ TEST(ZimCreator, createZim)
   ASSERT_EQ(cluster->getCompression(), Cluster::Compression::None);
   ASSERT_EQ(cluster->count(), blob_index_t(nb_entry-8)); // 7 entries are either compressed or redirections + 1 entry is a clone of content
 
-  ASSERT_EQ(header.getTitleIdxPos(), 0);
+  ASSERT_EQ(header.getTitleIdxPos(), 0xffffffffffffffffUL);
 
   blob = cluster->getBlob(v1BlobIndex);
   ASSERT_EQ(blob.size(), 3*sizeof(title_index_t));


### PR DESCRIPTION
Fixes #800

Absence of the title index v0 is now signaled via the titleIdxPos set to 0xffffffffffffffff instead of 0 since the latter resulted in ZIM files incompatible with older versions of libzim. Several such ZIM files have found home in zim-testing-suite (v 0.7.0) and have to be replaced. In theory, each of those ZIM files could be patched with a few bytes in two locations (titleIdxPos in the ZIM file header and the checksum at the end of the file). An easier solution is to recreate them, but I don't want it to be done with a locally built version of zim-tools (like it was done in openzim/zim-testing-suite#13 which references a libzim commit that was eventually edited/replaced during the review/rebase of PR #949 and is no longer part of the main branch).  That's why
`Fileheader::hasTitleListingV0()` considers the `titleIdxPos == 0` case too. Once this PR is merged and we have an official CI build we can use it to update zim-testing-suite, whereupon the `titleIdxPos == 0` test can be dropped from `Fileheader::hasTitleListingV0()` (in a separate PR).