### PR TITLE
More stable Log.concurrencyOrchestration unittest

### DIFF
--- a/test/log.cpp
+++ b/test/log.cpp
@@ -80,15 +80,15 @@ TEST(Log, concurrencyOrchestration) {
   using namespace std::chrono_literals;
 
   const auto oddFlow = [](){
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(10ms);
     log_debug("Humpty Dumpty sat on a wall.");
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(10ms);
     log_debug("All the king's horses and all the king's men");
   };
 
   const auto evenFlow = [](){
     log_debug("Humpty Dumpty had a great fall.");
-    std::this_thread::sleep_for(150ms);
+    std::this_thread::sleep_for(15ms);
     log_debug("Couldn't put Humpty together again.");
   };
 

--- a/test/log.cpp
+++ b/test/log.cpp
@@ -76,19 +76,27 @@ TEST(Log, inMemLogInANamedThread) {
 
 #include <chrono>
 
-TEST(Log, concurrencyOrchestration) {
+void millisleep(unsigned milliseconds) {
+  // Pause the current thread for a given number of milliseconds
+  // in multiple 1ms shots. This gives the scheduler higher probability
+  // of waking up the concurrent thread at the right time under high load.
   using namespace std::chrono_literals;
 
+  for ( unsigned i = 0; i < milliseconds; ++i )
+    std::this_thread::sleep_for(1ms);
+}
+
+TEST(Log, concurrencyOrchestration) {
   const auto oddFlow = [](){
-    std::this_thread::sleep_for(10ms);
+    millisleep(10);
     log_debug("Humpty Dumpty sat on a wall.");
-    std::this_thread::sleep_for(10ms);
+    millisleep(10);
     log_debug("All the king's horses and all the king's men");
   };
 
   const auto evenFlow = [](){
     log_debug("Humpty Dumpty had a great fall.");
-    std::this_thread::sleep_for(15ms);
+    millisleep(15);
     log_debug("Couldn't put Humpty together again.");
   };
 


### PR DESCRIPTION
Should fix #986

The effect of this PR on the `kiwix-build` CI was tested in kiwix/kiwix-build#825. There were two successful workflow runs ([1](https://github.com/kiwix/kiwix-build/actions/runs/14858923355/attempts/1?pr=825), [2](https://github.com/kiwix/kiwix-build/actions/runs/14858923355?pr=825)) suggesting that the fix works.