### PR TITLE
Fix Counter metadata by normalizing MIME types and removing malformed entries (https://github.com/openzim/zim-tools/issues/473)

### DIFF
--- a/src/writer/counterHandler.cpp
+++ b/src/writer/counterHandler.cpp
@@ -19,7 +19,7 @@
 
 #include "counterHandler.h"
 #include "creatordata.h"
-
+#include <regex>
 #include <zim/writer/contentProvider.h>
 #include <zim/blob.h>
 #include <zim/tools.h>


### PR DESCRIPTION
Fixes https://github.com/openzim/libzim/issues/1000

This patch strips MIME parameters (e.g., charset, profile) to normalize MIME types, removes duplicates, and filters out malformed or incomplete entries in the Counter metadata (e.g., entries without =count or invalid type/subtype format).