### PR TITLE
Protection against too long single word titles

### DIFF
--- a/src/writer/xapianIndexer.cpp
+++ b/src/writer/xapianIndexer.cpp
@@ -130,9 +130,12 @@ size_t getTermCount(const Xapian::Document& d)
 
 void XapianIndexer::indexTitle(const std::string& path, const std::string& title, const std::string& targetPath)
 {
+  const size_t MAX_WORD_LENGTH = 64;
+
   assert(indexingMode == IndexingMode::TITLE);
   Xapian::Stem stemmer;
   Xapian::TermGenerator indexer;
+  indexer.set_max_word_length(MAX_WORD_LENGTH);
   indexer.set_flags(Xapian::TermGenerator::FLAG_CJK_NGRAM);
   try {
     stemmer = Xapian::Stem(stemmer_language);
@@ -162,7 +165,9 @@ void XapianIndexer::indexTitle(const std::string& path, const std::string& title
       // only ANCHOR_TERM was added, hence unaccentedTitle is made solely of
       // non-word characters. Then add entire title as a single term.
       currentDocument.remove_term(*currentDocument.termlist_begin());
-      currentDocument.add_term(unaccentedTitle);
+      if ( unaccentedTitle.size() <= MAX_WORD_LENGTH ) {
+        currentDocument.add_term(unaccentedTitle);
+      }
     }
   }
 

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -694,6 +694,16 @@ TEST(Suggestion, CJK) {
   );
 }
 
+std::string makeLongWord(size_t n) {
+  std::ostringstream oss;
+  oss << "awordthatis" << n << "characterslong";
+  const std::string s = oss.str();
+  if ( s.size() > n )
+    throw std::runtime_error("That is not a request for a long enough word!");
+
+  return s + std::string(n - s.size(), s.back());
+}
+
 TEST(Suggestion, titleEdgeCases) {
   TempZimArchive tza("testZim");
   zim::writer::Creator creator;
@@ -708,6 +718,14 @@ TEST(Suggestion, titleEdgeCases) {
 
   // No title
   creator.addItem(makeHtmlItem("Without", ""));
+
+  // Titles containing long words
+  const std::string w64 = makeLongWord(64);
+  const std::string w65 = makeLongWord(65);
+  creator.addItem(makeHtmlItem("toolongword1", "Is " + w64 + " too long?"));
+  creator.addItem(makeHtmlItem("toolongword2", "Is " + w65 + " too long?"));
+  creator.addItem(makeHtmlItem("toolongsingleword1", w64));
+  creator.addItem(makeHtmlItem("toolongsingleword2", w65));
 
   // Non edge cases
   creator.addItem(makeHtmlItem("Stout", "About Rex Stout"));
@@ -734,6 +752,19 @@ TEST(Suggestion, titleEdgeCases) {
 
   EXPECT_SUGGESTION_RESULTS(archive, "hang"
       /* nothing */
+  );
+
+  EXPECT_SUGGESTION_RESULTS(archive, "long",
+      "Is " + w65 + " too long?",
+      "Is " + w64 + " too long?"
+  );
+
+  EXPECT_SUGGESTION_RESULTS(archive, "awordthatis",
+      w65, // a very long word slips in when it is the only word of a title
+      w64,
+      "Is " + w64 + " too long?"
+      // "Is " + w65 + " too long?" isn't included because w65 has been ignored
+      //                            during indexing
   );
 }
 } // unnamed namespace

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -760,11 +760,10 @@ TEST(Suggestion, titleEdgeCases) {
   );
 
   EXPECT_SUGGESTION_RESULTS(archive, "awordthatis",
-      w65, // a very long word slips in when it is the only word of a title
       w64,
       "Is " + w64 + " too long?"
-      // "Is " + w65 + " too long?" isn't included because w65 has been ignored
-      //                            during indexing
+      // w65 and "Is " + w65 + " too long?" aren't included because w65 has
+      //                                    been ignored during indexing
   );
 }
 } // unnamed namespace


### PR DESCRIPTION
Fixes #992

Xapian's parser discards words/terms longer than a certain limit (default: 64). However our workaround for handling titles that are made fully of non-word characters has created a loophole for words of arbitrary length to slip in. That leads to crashes if Xapian's
hard limit on the length of a term (max 245 bytes) is exceeded.

This PR closes the described loophole and validates the fix with a new unit test.

Note that an alternative fix is possible (indexing the truncated title instead of discarding it completel) but that would complicate the verification of the bug fix (because the potentially dangerous title would remain in the expected output of the unit test and the unit test would have to be converted into a less explicit crash/no-crash variant).