### PR TITLE
Fix build with ICU 76

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,8 +78,14 @@ endif
 
 if xapian_dep.found()
     icu_dep = dependency('icu-i18n', static:static_linkage)
+    if icu_dep.version().version_compare('>= 76')
+        icu_dep = [icu_dep, dependency('icu-uc', static:static_linkage)]
+    endif
 else
-    icu_dep = dependency('icu-i18n', required:false, static:static_linkage)
+    icu_dep = dependency('icu-i18n', 'required:false', static:static_linkage)
+    if icu_dep.version().version_compare('>= 76')
+        icu_dep = [icu_dep, dependency('icu-uc', 'required:false', static:static_linkage)]
+    endif
 endif
 
 gtest_dep = dependency('gtest', version: '>=1.10.0', main:true, fallback:['gtest', 'gtest_main_dep'], required:false)


### PR DESCRIPTION
Due to unicode-org/icu@199bc82, ICU 76 no longer adds `icu-uc` by default. This causes linker errors for undefined symbols like `icu_76::UnicodeString::doReplace(...)`, referenced from: `zim::removeAccents(...)` in tools.cpp.o.

Meson will automatically flatten the dependencies list as documented at https://mesonbuild.com/Reference-manual_functions.html#build_target

This PR superseeds #936 