### PR TITLE
Remove SORTPP_PASS which breaks modern Windows SDKs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,6 @@ public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
 
 if build_machine.system() == 'windows'
     win_deps = declare_dependency(
-        compile_args: ['-DSORTPP_PASS'],
         link_args: ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-lshlwapi']
     )
 else


### PR DESCRIPTION
Removes `SORTPP_PASS` which appears to be an internal Windows SDK macro they use when they aren't expecting to be input to a normal C++ compiler. This results in errors like:

```console
C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\um\winuser.h(15585): error C2208: 'TOUCHPAD_PARAMETERS_V1': no members defined using this type
[18/35] "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/arm64/cl.exe" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-Isrc\zim-9.dll.p" "-Isrc" "-I..\src\9.4.0-27eaac216a.clean\src" "-Iinclude" "-I..\src\9.4.0-27eaac216a.clean\include" "-ID:/installed/arm64-windows/debug/../include" "-ID:/installed/arm64-windows/include" "/MDd" "/nologo" "/showIncludes" "/utf-8" "/Zc:__cplusplus" "/W2" "/EHsc" "/std:c++17" "/permissive-" "/Zi" "-DNOMINMAX" "-DLIBZIM_EXPORT_PRIVATE_DLL" "-nologo" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-DSORTPP_PASS" "/Fdsrc\zim-9.dll.p\uuid.cpp.pdb" /Fosrc/zim-9.dll.p/uuid.cpp.obj "/c" ../src/9.4.0-27eaac216a.clean/src/uuid.cpp
FAILED: [code=2] src/zim-9.dll.p/uuid.cpp.obj 
"C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/arm64/cl.exe" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-Isrc\zim-9.dll.p" "-Isrc" "-I..\src\9.4.0-27eaac216a.clean\src" "-Iinclude" "-I..\src\9.4.0-27eaac216a.clean\include" "-ID:/installed/arm64-windows/debug/../include" "-ID:/installed/arm64-windows/include" "/MDd" "/nologo" "/showIncludes" "/utf-8" "/Zc:__cplusplus" "/W2" "/EHsc" "/std:c++17" "/permissive-" "/Zi" "-DNOMINMAX" "-DLIBZIM_EXPORT_PRIVATE_DLL" "-nologo" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-DSORTPP_PASS" "/Fdsrc\zim-9.dll.p\uuid.cpp.pdb" /Fosrc/zim-9.dll.p/uuid.cpp.obj "/c" ../src/9.4.0-27eaac216a.clean/src/uuid.cpp
cl : Command line warning D9025 : overriding '/Z7' with '/Zi'
cl : Command line warning D9025 : overriding '/Zi' with '/Z7'
C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\um\winuser.h(15585): error C2208: 'TOUCHPAD_PARAMETERS_V1': no members defined using this type
[19/35] "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/arm64/cl.exe" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-Isrc\zim-9.dll.p" "-Isrc" "-I..\src\9.4.0-27eaac216a.clean\src" "-Iinclude" "-I..\src\9.4.0-27eaac216a.clean\include" "-ID:/installed/arm64-windows/debug/../include" "-ID:/installed/arm64-windows/include" "/MDd" "/nologo" "/showIncludes" "/utf-8" "/Zc:__cplusplus" "/W2" "/EHsc" "/std:c++17" "/permissive-" "/Zi" "-DNOMINMAX" "-DLIBZIM_EXPORT_PRIVATE_DLL" "-nologo" "-DWIN32" "-D_WINDOWS" "-utf-8" "-GR" "-EHsc" "-MP" "-MDd" "-Z7" "-Ob0" "-Od" "-RTC1" "-DSORTPP_PASS" "/Fdsrc\zim-9.dll.p\suggestion_iterator.cpp.pdb" /Fosrc/zim-9.dll.p/suggestion_iterator.cpp.obj "/c" ../src/9.4.0-27eaac216a.clean/src/suggestion_iterator.cpp
cl : Command line warning D9025 : overriding '/Z7' with '/Zi'
cl : Command line warning D9025 : overriding '/Zi' with '/Z7'
```

due to this block in WinUser.h:

```c++
#if defined(__cplusplus) && !defined(SORTPP_PASS)
typedef struct tagTOUCHPAD_PARAMETERS_V2 : public TOUCHPAD_PARAMETERS_V1 {
#else
typedef struct tagTOUCHPAD_PARAMETERS_V2 {
    TOUCHPAD_PARAMETERS_V1;
#endif
    BOOL button1Supported            : 1;
    BOOL button2Supported            : 1;
    BOOL button3Supported            : 1;
    BOOL Reserved3                   : 29;
} TOUCHPAD_PARAMETERS_V2, *PTOUCHPAD_PARAMETERS_V2;
```

which becomes malformed C++ with that macro.