### PR TITLE
Use public Xapian API in preference

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ if host_machine.system() == 'freebsd'
 endif
 
 if get_option('with_xapian')
-    xapian_dep = dependency('xapian-core', static:static_linkage)
+    xapian_dep = dependency('xapian-core', version: '>=1.4.12', static:static_linkage)
 else
     xapian_dep = dependency('', required:false)
 endif

--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -100,7 +100,7 @@ void SuggestionDataBase::initXapianDb() {
 
 bool SuggestionDataBase::hasDatabase() const
 {
-  return !m_database.internal.empty();
+  return m_database.size() != 0;
 }
 
 bool SuggestionDataBase::hasValuesmap() const


### PR DESCRIPTION
Xapian 1.4.12 and later have a Database::size() method which returns the number of shards, so use this instead which fixes a compilation failure with Xapian 2.0.x where the internal object is no longer a std::vector.

For older versions, we still need to peek at the internal object but assuming internal details is less problematic there at least.