### PR TITLE
Add explicit conversion to std::string

### DIFF
--- a/src/writer/xapianWorker.cpp
+++ b/src/writer/xapianWorker.cpp
@@ -63,7 +63,7 @@ namespace zim
       std::string fullPath = "C/" + m_path;
       document.set_data(fullPath);
       document.add_value(0, mp_indexData->getTitle());
-      document.add_value(1, Formatter() << mp_indexData->getWordCount());
+      document.add_value(1, std::string{Formatter() << mp_indexData->getWordCount()});
 
       auto geoInfo = mp_indexData->getGeoPosition();
       if (std::get<0>(geoInfo)) {


### PR DESCRIPTION
In Xapian 2.0.x most API methods which previously took std::string or const std::string& now take std::string_view, which can avoid the need to copy data which isn't already in a std::string.

That causes a compilation failure here - the compiler knows how to convert zim::Formatter to std::string and how to convert std::string to std::string_view but it isn't allowed to chain implicit conversions.

We could use https://en.cppreference.com/w/cpp/io/basic_ostringstream/view.html to add a conversion to `std::string_view` to `zim::Formatter`, but that was added in C++20 and `meson.build` currently requires C++17.  I don't see a good way to add a conversion operator which works for older C++ standards.

Incidentally, storing the word count in a value slot in this way doesn't seem the best idea.  Sorting by value performs a string sort, so sorting by word count would currently give e.g. `999999` > `9` > `80` > `700` > `6000` > `50000` > `400000` > `3000000` > `20000000` > `1000000`.

`Xapian::sortable_serialise()` encodes numbers as strings which sorts the same way as the numbers do, but a switch to that would presumably need to consider how to handle existing databases.