### PR TITLE
Updated architecture name for linux-aarch64-dyn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,8 @@ jobs:
             coverage: false
           - target: linux-aarch64-dyn
             image_variant: jammy
-            lib_postfix: '/aarch64-linux-gnu'
-            arch_name: aarch64-linux-gnu
+            lib_postfix: '/aarch64-rpi3-linux-gnu'
+            arch_name: aarch64-rpi3-linux-gnu
             run_test: false
             coverage: false
           - target: android-arm


### PR DESCRIPTION
Fixes #1021 

The architecture name of aarch64 cross-builds on Linux has been changed by kiwix/kiwix-build#863 (more precisely, commit https://github.com/kiwix/kiwix-build/pull/863/changes/6090de1ffcc67cacf499af6314aa6374142ab555).