### PR TITLE
Quick detection of corruption of 1st blob offset in cluster

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -73,23 +73,23 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
 
 } // unnamed namespace
 
-  std::shared_ptr<Cluster> Cluster::read(const Reader& zimReader, offset_t clusterOffset)
+  std::shared_ptr<Cluster> Cluster::read(const Reader& zimReader, offset_t clusterOffset, size_t maxBlobCount)
   {
     Compression comp;
     bool extended;
     auto reader = getClusterReader(zimReader, clusterOffset, &comp, &extended);
-    return std::make_shared<Cluster>(std::move(reader), comp, extended);
+    return std::make_shared<Cluster>(std::move(reader), comp, extended, maxBlobCount);
   }
 
-  Cluster::Cluster(std::unique_ptr<IStreamReader> reader_, Compression comp, bool isExtended)
+  Cluster::Cluster(std::unique_ptr<IStreamReader> reader_, Compression comp, bool isExtended, size_t maxBlobCount)
     : compression(comp),
       isExtended(isExtended),
       m_reader(std::move(reader_))
   {
     if (isExtended) {
-      read_header<uint64_t>();
+      read_header<uint64_t>(maxBlobCount);
     } else {
-      read_header<uint32_t>();
+      read_header<uint32_t>(maxBlobCount);
     }
   }
 
@@ -97,7 +97,7 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
 
   /* This return the number of char read */
   template<typename OFFSET_TYPE>
-  void Cluster::read_header()
+  void Cluster::read_header(size_t maxBlobCount)
   {
     // read first offset, which specifies, how many offsets we need to read
     OFFSET_TYPE offset = m_reader->read<OFFSET_TYPE>();
@@ -110,6 +110,10 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
 
     if ( n_offset * sizeof(OFFSET_TYPE) != offset ) {
         throw zim::ZimFileFormatError("Error parsing cluster. Offset of the first blob is not properly aligned.");
+    }
+
+    if ( n_offset > maxBlobCount + 1 ) {
+        throw zim::ZimFileFormatError("Error parsing cluster. Offset of the first blob is too large.");
     }
 
     // read offsets

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -73,11 +73,11 @@ namespace zim
 
 
       template<typename OFFSET_TYPE>
-      void read_header();
+      void read_header(size_t maxBlobCount);
       const Reader& getReader(blob_index_t n) const;
 
     public:
-      Cluster(std::unique_ptr<IStreamReader> reader, Compression comp, bool isExtended);
+      Cluster(std::unique_ptr<IStreamReader> reader, Compression comp, bool isExtended, size_t maxBlobCount);
       ~Cluster();
       Compression getCompression() const   { return compression; }
       bool isCompressed() const                { return compression != Compression::None; }
@@ -92,7 +92,7 @@ namespace zim
 
       size_t getMemorySize() const;
 
-      static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset);
+      static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset, size_t maxBlobCount);
   };
 
   struct ClusterMemorySize {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -500,11 +500,17 @@ private: // data
     return entry_index_t(m_articleListByCluster[idx.v]);
   }
 
+  size_t FileImpl::getMaxBlobCountInCluster(cluster_index_t idx) const
+  {
+    return getCountArticles().v;
+  }
+
   ClusterHandle FileImpl::readCluster(cluster_index_t idx) const
   {
     offset_t clusterOffset(getClusterOffset(idx));
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
-    return Cluster::read(*zimReader, clusterOffset);
+    const auto maxBlobCountInCluster = getMaxBlobCountInCluster(idx);
+    return Cluster::read(*zimReader, clusterOffset, maxBlobCountInCluster);
   }
 
   ClusterHandle FileImpl::getCluster(cluster_index_t idx) const

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -192,6 +192,7 @@ namespace zim
       offset_type getMimeListEndUpperLimit() const;
       void readMimeTypes();
       void quickCheckForCorruptFile();
+      size_t getMaxBlobCountInCluster(cluster_index_t idx) const;
 
       bool checkChecksum();
       bool checkDirentPtrs();

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -822,6 +822,11 @@ TEST_F(ZimArchive, validate)
   )
 
   TEST_BROKEN_ZIM_NAME(
+    "invalid.too_large_offset_of_first_blob_in_cluster.zim",
+     "Error parsing cluster. Offset of the first blob is too large.\n"
+  )
+
+  TEST_BROKEN_ZIM_NAME(
     "invalid.offset_in_cluster.zim",
      "Error parsing cluster. Offsets are not ordered.\n"
   )


### PR DESCRIPTION
This is a partial fix for openzim/libzim#1025.

Depends on openzim/zim-testing-suite#15

The fix detects only such unreasonable values for the corrupted offset of the 1st blob in a cluster which can be checked without scanning the entire ZIM file.

Assuming that corruption affects only the offset of the first blob in a cluster
- If its value decreases but stays properly aligned (i.e. a multiple of 4 for normal clusters and a multiple of 8 for extended clusters) and above the minimal meaningful value then corruption won't be detected and some garbage data will be prepended to the first blob, and one or more blobs toward the end of the cluster will be returned as empty.

- If its value increases but stays properly aligned and below the upper limit imposed by the count of articles in the ZIM file and the size of the first blob, corruption may be detected by a different check requiring that blob offsets increase monotonously. However in case if the underlying misinterpreted bits of data slip through that check, part of the first blob will be lost.