### PR TITLE
Follow up of PR#1029

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -137,12 +137,23 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
     }
   }
 
-  zsize_t Cluster::getBlobSize(blob_index_t n) const
+  void Cluster::checkBlobIndex(blob_index_t n) const
   {
       if (blob_index_type(n)+1 >= m_blobOffsets.size()) {
         throw ZimFileFormatError("blob index out of range");
       }
+  }
+
+  zsize_t Cluster::getBlobSize(blob_index_t n) const
+  {
+      checkBlobIndex(n);
       return zsize_t(m_blobOffsets[blob_index_type(n)+1].v - m_blobOffsets[blob_index_type(n)].v);
+  }
+
+  offset_t Cluster::getBlobOffset(blob_index_t n) const
+  {
+      checkBlobIndex(n);
+      return offset_t(1) + m_blobOffsets[blob_index_type(n)];
   }
 
   const Reader& Cluster::getReader(blob_index_t n) const

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -76,6 +76,8 @@ namespace zim
       void read_header(size_t maxBlobCount);
       const Reader& getReader(blob_index_t n) const;
 
+      void checkBlobIndex(blob_index_t n) const;
+
     public:
       Cluster(std::unique_ptr<IStreamReader> reader, Compression comp, bool isExtended, size_t maxBlobCount);
       ~Cluster();
@@ -86,7 +88,8 @@ namespace zim
 
       zsize_t getBlobSize(blob_index_t n) const;
 
-      offset_t getBlobOffset(blob_index_t n) const { return offset_t(1) + m_blobOffsets[blob_index_type(n)]; }
+      offset_t getBlobOffset(blob_index_t n) const;
+
       Blob getBlob(blob_index_t n) const;
       Blob getBlob(blob_index_t n, offset_t offset, zsize_t size) const;
 

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -796,10 +796,12 @@ TEST_F(ZimArchive, validate)
      "Error parsing cluster. Offset of the first blob is too small.\n"
   )
 
+#if defined(ENABLE_XAPIAN)
   TEST_BROKEN_ZIM_NAME(
     "invalid.too_small_offset_of_first_blob_in_cluster_4.zim",
-     "Error parsing cluster. Offset of the first blob is too small.\n"
+     "blob index out of range\n"
   )
+#endif
 
   TEST_BROKEN_ZIM_NAME(
     "invalid.too_small_offset_of_first_blob_in_cluster_7.zim",


### PR DESCRIPTION
PR #1029 was merged prematurely and broke the CI. This PR fixes the issues introduces by #1029, but also eliminates a pre-existing loophole for a crash scenario. 