### PR TITLE
Made lazy decompression of clusters user-controllable

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -710,6 +710,22 @@ namespace zim
        */
       void setDirentCacheMaxSize(size_t nbDirents);
 
+      /** Enable/disable lazy decompression of compressed clusters
+       *
+       * In lazy decompession mode, data in compressed clusters is decompressed
+       * on-demand, i.e. only as much data is decompressed as is needed to
+       * serve item accesses within the cluster. It leads to faster first-time
+       * access to items occurring early in the cluster, but comes at the cost
+       * of increased memory usage since the decompressor's state (whose memory
+       * consumption can exceed the data size of the cluster) is kept around
+       * while the cluster is still loaded.
+       *
+       * Lazy decompression is enabled by default.
+       *
+       * @param enable tells whether lazy decompression should be enabled
+       */
+      void decompressClustersLazily(bool enable);
+
 #ifdef ZIM_PRIVATE
       cluster_index_type getClusterCount() const;
       offset_type getClusterOffset(cluster_index_type idx) const;

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -604,6 +604,11 @@ namespace zim
     return offset_type(m_impl->getClusterOffset(cluster_index_t(idx)));
   }
 
+  void Archive::decompressClustersLazily(bool enable)
+  {
+    m_impl->decompressClustersLazily(enable);
+  }
+
   entry_index_type Archive::getMainEntryIndex() const
   {
     return m_impl->getFileheader().getMainPage();

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -79,7 +79,12 @@ namespace zim
       void checkBlobIndex(blob_index_t n) const;
 
     public:
-      Cluster(std::unique_ptr<IStreamReader> reader, Compression comp, bool isExtended, size_t maxBlobCount);
+      Cluster(std::unique_ptr<IStreamReader> reader,
+              Compression comp,
+              bool isExtended,
+              size_t maxBlobCount,
+              bool decompressOnDemand);
+
       ~Cluster();
       Compression getCompression() const   { return compression; }
       bool isCompressed() const                { return compression != Compression::None; }
@@ -95,7 +100,7 @@ namespace zim
 
       size_t getMemorySize() const;
 
-      static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset, size_t maxBlobCount = size_t(-1));
+      static std::shared_ptr<Cluster> read(const Reader& zimReader, offset_t clusterOffset, size_t maxBlobCount = size_t(-1), bool decompressOnDemand=true);
   };
 
   struct ClusterMemorySize {

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -296,6 +296,11 @@ private: // data
     dropCachedClusters();
   }
 
+  void FileImpl::decompressClustersLazily(bool enable)
+  {
+    m_decompressClustersLazily = enable;
+  }
+
   void FileImpl::dropCachedClusters() const {
     getClusterCache().dropAll([this](const ClusterRef& key) {
         return std::get<0>(key) == this;
@@ -510,7 +515,7 @@ private: // data
     offset_t clusterOffset(getClusterOffset(idx));
     log_debug("read cluster " << idx << " from offset " << clusterOffset);
     const auto maxBlobCountInCluster = getMaxBlobCountInCluster(idx);
-    return Cluster::read(*zimReader, clusterOffset, maxBlobCountInCluster);
+    return Cluster::read(*zimReader, clusterOffset, maxBlobCountInCluster, m_decompressClustersLazily);
   }
 
   ClusterHandle FileImpl::getCluster(cluster_index_t idx) const

--- a/src/fileimpl.h
+++ b/src/fileimpl.h
@@ -100,6 +100,8 @@ namespace zim
       using ByTitleDirentLookup = zim::DirentLookup<ByTitleDirentLookupConfig>;
       std::unique_ptr<ByTitleDirentLookup> m_byTitleDirentLookup;
 
+      bool m_decompressClustersLazily = true;
+
 #ifdef ENABLE_XAPIAN
       std::shared_ptr<XapianDb> mp_xapianDb;
       mutable std::mutex m_xapianDbCreationMutex;
@@ -172,6 +174,8 @@ namespace zim
       size_t getDirentCacheMaxSize() const;
       size_t getDirentCacheCurrentSize() const;
       void setDirentCacheMaxSize(size_t nbDirents);
+
+      void decompressClustersLazily(bool enable);
 
 #ifdef ENABLE_XAPIAN
       std::shared_ptr<XapianDb> loadXapianDb();

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -539,6 +539,19 @@ TEST_F(ZimArchive, MultiZimCache)
   EXPECT_EQ(zim::getClusterCacheCurrentSize(), 0);
 }
 
+TEST_F(ZimArchive, lazyVsEagerClusterDecompression)
+{
+  for (auto& testfile: getDataFilePath("wikipedia_en_climate_change_mini_2024-06.zim")) {
+    zim::Archive lazyArchive(testfile.path);
+    lazyArchive.decompressClustersLazily(true);
+
+    zim::Archive eagerArchive(testfile.path);
+    eagerArchive.decompressClustersLazily(false);
+
+    RefArchiveContent(lazyArchive).test_is_equal(eagerArchive);
+  }
+}
+
 TEST_F(ZimArchive, openDontFallbackOnNonSplitZimArchive)
 {
   const char* fname = "wikibooks_be_all_nopic_2017-02.zim";


### PR DESCRIPTION
Related to kiwix/libkiwix#1265

In lazy decompession mode (introduced by #421), data in compressed clusters is decompressed on-demand, i.e. only as much data is decompressed as is needed to serve item accesses within the cluster. It leads to faster first-time access to items occurring early in the cluster, but comes at the cost of increased memory usage since the decompressor's state (whose memory consumption can exceed the data size of the cluster) is kept around while the cluster is still loaded.

This PR adds a facility to disable lazy/on-demand decompression. Lazy decompression stays on by default, but can be disabled and/or (re-)enabled per individual ZIM archive via a new public API method `zim::Archive::decompressClustersLazily()`.