### PR TITLE
Lowered the default value of CLUSTER_CACHE_SIZE

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
-option('CLUSTER_CACHE_SIZE', type : 'integer', min: 0, max: 1000000000000, value : 536870912,
-  description : 'set default cluster cache size in bytes (default:512MB)')
+option('CLUSTER_CACHE_SIZE', type : 'integer', min: 0, max: 1000000000000, value : 16777216,
+  description : 'set default cluster cache size in bytes (default:16MiB)')
 option('DIRENT_CACHE_SIZE', type : 'string', value : '512',
   description : 'set dirent cache size to number (default:512)')
 option('DIRENT_LOOKUP_CACHE_SIZE', type : 'string', value : '1024',


### PR DESCRIPTION
!!! IMPORTANT !!!

For this change to take effect when rebuilding/recompiling the project in an existing build directory, the following command must be explicitly executed:

```
meson configure -D CLUSTER_CACHE_SIZE=16777216
```

---

The default value of CLUSTER_CACHE_SIZE was made low-end-device-friendly - the cluster cache max memory size was lowered from 512MiB to 16MiB. For mono-ZIM-file use cases (when a single ZIM-file is open at a time) this approximately returns the memory usage by the cluster cache to how it used to be before the cluster cache was made global (shared across all open ZIM-files).

Note however that there is some ambiguity with respect to what memory usage means - there is virtual memory vs physical memory. Current implementation of cluster cache memory management targets physical memory usage on systems supporting mmap, where allocation of virtual memory by the cluster cache can exceed the actual physical memory usage by a factor of ~5x-9x.

On systems not supporting mmap (or with an implementation of malloc not utilizing mmap for large allocations) the consumption of physical memory should equal the size of allocated virtual memory, and the actual memory usage will exceed the cache memory limit by the said factor, i.e. as much as 144MiB can be consumed by the cluster cache at the default setting.