### PR TITLE
Use windows-2025 CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2022
+          - windows-2025
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
We just have moved on kiwix-build side, see https://github.com/kiwix/kiwix-build/pull/838