### PR TITLE
fix: helper function to strip mime params

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -210,6 +210,10 @@ std::map<std::string, int> zim::read_valuesmap(const std::string &s) {
     return result;
 }
 
+std::string zim::stripMimeParameters(const std::string& rawMimeType) {
+  return rawMimeType.substr(0, rawMimeType.find_first_of("; \t"));
+}
+
 namespace
 {
 // The counter metadata format is a list of item separated by a `;` :

--- a/src/tools.h
+++ b/src/tools.h
@@ -57,6 +57,8 @@ namespace zim {
 
   std::map<std::string, int> read_valuesmap(const std::string& s);
 
+  std::string LIBZIM_PRIVATE_API stripMimeParameters(const std::string& rawMimeType);
+
   using MimeCounterType = std::map<const std::string, zim::entry_index_type>;
   MimeCounterType LIBZIM_PRIVATE_API parseMimetypeCounter(const std::string& counterData);
 

--- a/src/writer/counterHandler.cpp
+++ b/src/writer/counterHandler.cpp
@@ -19,6 +19,7 @@
 
 #include "counterHandler.h"
 #include "creatordata.h"
+#include "../tools.h"
 
 #include <zim/writer/contentProvider.h>
 #include <zim/blob.h>
@@ -72,5 +73,12 @@ void CounterHandler::handle(Dirent* dirent, std::shared_ptr<Item> item)
   if (mimetype.empty()) {
     return;
   }
-  m_mimetypeCounter[mimetype] += 1;
+
+  auto cleanMimetype = zim::stripMimeParameters(mimetype);
+
+  if (cleanMimetype.empty()) {
+    return;
+  }
+
+  m_mimetypeCounter[cleanMimetype] += 1;
 }

--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -60,6 +60,39 @@ namespace {
     ASSERT_THROW(zim::parseIllustrationPathToSize("Illustration_1 28x1 28@1"), std::runtime_error);
   }
 
+  TEST(Tools, stripMimeParameters) {
+    // Basic MIME types without parameters - should be unchanged
+    ASSERT_EQ(zim::stripMimeParameters("text/html"), "text/html");
+    ASSERT_EQ(zim::stripMimeParameters("application/json"), "application/json");
+    ASSERT_EQ(zim::stripMimeParameters("image/png"), "image/png");
+
+    // Empty string
+    ASSERT_EQ(zim::stripMimeParameters(""), "");
+
+    // MIME types with simple parameters - should strip parameter
+    ASSERT_EQ(zim::stripMimeParameters("text/html;charset=utf-8"), "text/html");
+    ASSERT_EQ(zim::stripMimeParameters("text/plain;charset=us-ascii"), "text/plain");
+
+    // MIME types with space before semicolon - should trim trailing whitespace
+    ASSERT_EQ(zim::stripMimeParameters("text/html ;charset=utf-8"), "text/html");
+    ASSERT_EQ(zim::stripMimeParameters("text/html  ;charset=utf-8"), "text/html");
+    ASSERT_EQ(zim::stripMimeParameters("text/html\t;charset=utf-8"), "text/html");
+
+    // Multiple parameters
+    ASSERT_EQ(zim::stripMimeParameters("text/html;charset=utf-8;boundary=something"), "text/html");
+
+    // Edge case: only whitespace before semicolon
+    ASSERT_EQ(zim::stripMimeParameters(" ;charset=utf-8"), "");
+    ASSERT_EQ(zim::stripMimeParameters("  ;charset=utf-8"), "");
+    ASSERT_EQ(zim::stripMimeParameters("\t;charset=utf-8"), "");
+
+    // Edge case: semicolon at start
+    ASSERT_EQ(zim::stripMimeParameters(";charset=utf-8"), "");
+
+    // Edge case: just a semicolon
+    ASSERT_EQ(zim::stripMimeParameters(";"), "");
+  }
+
 #if defined(ENABLE_XAPIAN)
   TEST(Tools, removeAccents) {
     ASSERT_EQ(zim::removeAccents("bépoàǹ"), "bepoan");


### PR DESCRIPTION
Fixes #1000

Basically a helper function that strips MIME-types params.
should fix the article count issue with the regex validation in zim-tools, this in libzim. 