### PR TITLE
fix: clamp pread() size to avoid EINVAL on macOS for large reads

### DIFF
--- a/src/fs_unix.cpp
+++ b/src/fs_unix.cpp
@@ -46,7 +46,9 @@ zsize_t FD::readAt(char* dest, zsize_t size, offset_t offset) const
   auto current_offset = offset.v;
   errno = 0;
   while (size_to_read > 0) {
-    auto size_read = PREAD(m_fd, dest, size_to_read, current_offset);
+    // Clamp per-call size to 1 GiB — macOS pread() fails above INT32_MAX
+    const auto chunk = std::min(zim::size_type(1ULL << 30), size_to_read);
+    const auto size_read = PREAD(m_fd, dest, chunk, current_offset);
     if (size_read == 0) {
       throw std::runtime_error("Cannot read past the end of the file");
     }


### PR DESCRIPTION
## Problem

ZIM files with more than ~268 million entries fail to open on macOS with:

```
Cannot read chars.
 - Reading offset at 120075518264
 - size is 3049426704
 - error is Cannot read file: Invalid argument
```

On macOS, `pread()` returns `EINVAL` when the requested size exceeds `INT32_MAX` (~2.1 GB). The URL pointer table is `entry_count * 8` bytes — at 381 million entries this is 3.05 GB, triggering the failure.

## Fix

Clamp each `pread()` call to 1 GB. The existing read loop in `FD::readAt()` already handles partial reads and iterates until the full request is satisfied, so the remaining data is read in subsequent iterations.

## Testing

Tested on macOS 26.3 (Apple Silicon) with a 381-million-entry, 117 GB ZIM file (world OpenStreetMap build with vector tiles, terrain-RGB tiles, and a full-text search index). Before the fix, `zim::Archive()` throws immediately. After the fix, the archive opens and all entries are accessible.

The Kiwix macOS app (3.13.0) reports "cannot be opened" for any ZIM exceeding this threshold. This is the same root cause.