### PR TITLE
Optimization of memory usage by dirents during ZIM creation

### DIFF
--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -203,11 +203,6 @@ namespace zim
           direct.blobNumber = _cluster->count();
         }
 
-        zim::writer::Cluster* getCluster()
-        {
-          return info.getDirect().cluster;
-        }
-
         cluster_index_t getClusterNumber() const {
           auto& direct = info.getDirect();
           return direct.cluster ? direct.cluster->getClusterIndex() : cluster_index_t(0);

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -157,7 +157,6 @@ namespace zim
         uint16_t mimeType;
         entry_index_t idx = entry_index_t(0);
         DirentInfo info;
-        offset_t offset;
         uint8_t _ns : 2;
         bool removed : 1;
 
@@ -230,9 +229,6 @@ namespace zim
         {
           return (isRedirect() ? 12 : 16) + pathTitle.size() + 1;
         }
-
-        offset_t getOffset() const { return offset; }
-        void setOffset(offset_t o) { offset = o; }
 
         bool isRemoved() const { return removed; }
         void markRemoved() { removed = true; }

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -205,8 +205,10 @@ namespace zim
 
         cluster_index_t getClusterNumber() const {
           auto& direct = info.getDirect();
-          return direct.cluster ? direct.cluster->getClusterIndex() : cluster_index_t(0);
+          ASSERT(direct.cluster, !=, nullptr);
+          return direct.cluster->getClusterIndex();
         }
+
         blob_index_t  getBlobNumber() const {
           return info.getDirect().blobNumber;
         }

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -190,9 +190,7 @@ namespace zim
           info.~DirentInfo();
           new(&info) DirentInfo(DirentInfo::Resolved(target));
         }
-        entry_index_t getRedirectIndex() const      {
-          return info.getResolved().targetDirent->getIdx();
-        }
+        entry_index_t getRedirectIndex() const;
 
         void setIdx(entry_index_t idx_)      { idx = idx_; }
         entry_index_t getIdx() const         { return idx; }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -541,14 +541,23 @@ void CreatorData::quitAllThreads() {
   }
 }
 
+CreatorData::DirentIterator CreatorData::removeDirent(DirentIterator it)
+{
+  Dirent* const dirent = *it;
+  dirent->markRemoved();
+  if (dirent == mainPageDirent) {
+    mainPageDirent = nullptr;
+  }
+  return dirents.erase(it);
+}
+
 void CreatorData::addDirent(Dirent* dirent)
 {
   auto ret = dirents.insert(dirent);
   if (!ret.second) {
     Dirent* existing = *ret.first;
     if (existing->isRedirect() && !dirent->isRedirect()) {
-      dirents.erase(ret.first);
-      existing->markRemoved();
+      removeDirent(ret.first);
       dirents.insert(dirent);
     } else {
       Formatter fmt;
@@ -685,11 +694,7 @@ void CreatorData::resolveRedirectIndexes()
           << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
           << " redirecting to (missing) "
           << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
-      it = dirents.erase(it);
-      dirent->markRemoved();
-      if (dirent == mainPageDirent) {
-        mainPageDirent = nullptr;
-      }
+      it = removeDirent(it);
     } else  {
       dirent->setRedirect(*target_pos);
       ++it;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -544,7 +544,6 @@ namespace zim
       if (!ret.second) {
         Dirent* existing = *ret.first;
         if (existing->isRedirect() && !dirent->isRedirect()) {
-          unresolvedRedirectDirents.erase(existing);
           dirents.erase(ret.first);
           existing->markRemoved();
           dirents.insert(dirent);
@@ -558,7 +557,6 @@ namespace zim
       };
 
       if (dirent->isRedirect()) {
-        unresolvedRedirectDirents.insert(dirent);
         nbRedirectItems++;
       }
     }
@@ -669,8 +667,14 @@ namespace zim
     {
       // translate redirect aid to index
       INFO("Resolve redirect");
-      for (auto dirent: unresolvedRedirectDirents)
+      for (auto it = dirents.begin(); it != dirents.end(); )
       {
+        Dirent* dirent = *it;
+        if ( !dirent->isRedirect() ) {
+          ++it;
+          continue;
+        }
+
         Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
         auto target_pos = dirents.find(&tmpDirent);
         if(target_pos == dirents.end()) {
@@ -678,13 +682,14 @@ namespace zim
               << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
               << " redirecting to (missing) "
               << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
-          dirents.erase(dirent);
+          it = dirents.erase(it);
           dirent->markRemoved();
           if (dirent == mainPageDirent) {
             mainPageDirent = nullptr;
           }
         } else  {
           dirent->setRedirect(*target_pos);
+          ++it;
         }
       }
     }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -176,8 +176,14 @@ void Creator::addItem(std::shared_ptr<Item> item)
   checkError();
   bool compressContent = item->getAmendedHints()[COMPRESS];
   auto dirent = data->createItemDirent(item.get());
-  data->addItemData(dirent, item->getContentProvider(), compressContent);
-  data->handle(dirent, item);
+
+  try {
+    data->addItemData(dirent, item->getContentProvider(), compressContent);
+    data->handle(dirent, item);
+  } catch (...) {
+    data->removeDirent(dirent);
+    throw;
+  }
 
   if (data->dirents.size()%1000 == 0) {
     TPROGRESS();
@@ -565,6 +571,13 @@ CreatorData::DirentIterator CreatorData::removeDirent(DirentIterator it)
   return dirents.erase(it);
 }
 
+void CreatorData::removeDirent(Dirent* dirent)
+{
+  const auto it = dirents.find(dirent);
+  ASSERT(it != dirents.end(), ==, true);
+  removeDirent(it);
+}
+
 void CreatorData::addDirent(Dirent* dirent)
 {
   auto ret = dirents.insert(dirent);
@@ -628,10 +641,10 @@ Dirent* CreatorData::createItemDirent(const Item* item)
   auto path = item->getPath();
   auto mimetype = item->getMimeType();
   if (mimetype.empty()) {
-    std::cerr << "Warning, " << item->getPath() << " have empty mimetype." << std::endl;
+    std::cerr << "Warning, " << path << " have empty mimetype." << std::endl;
     mimetype = "application/octet-stream";
   }
-  return createDirent(NS::C, item->getPath(), mimetype, item->getTitle());
+  return createDirent(NS::C, path, mimetype, item->getTitle());
 }
 
 Dirent* CreatorData::createRedirectDirent(NS ns, const std::string& path, const std::string& title, NS targetNs, const std::string& targetPath)

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -101,650 +101,655 @@ log_define("zim.writer.creator")
 
 namespace zim
 {
-  namespace writer
+
+namespace writer
+{
+
+Creator::Creator()
+  : m_clusterSize(DEFAULT_CLUSTER_SIZE)
+{}
+
+Creator::~Creator() = default;
+
+Creator& Creator::configVerbose(bool verbose)
+{
+  m_verbose = verbose;
+  return *this;
+}
+
+Creator& Creator::configCompression(Compression compression)
+{
+  m_compression = compression;
+  return *this;
+}
+
+Creator& Creator::configClusterSize(zim::size_type targetSize)
+{
+  m_clusterSize = targetSize;
+  return *this;
+}
+
+Creator& Creator::configIndexing(bool indexing, const std::string& language)
+{
+  m_withIndex = indexing;
+  m_indexingLanguage = language;
+  return *this;
+}
+
+Creator& Creator::configNbWorkers(unsigned nbWorkers)
+{
+  m_nbWorkers = nbWorkers;
+  return *this;
+}
+
+void Creator::startZimCreation(const std::string& filepath)
+{
+  data = std::unique_ptr<CreatorData>(
+    new CreatorData(filepath, m_verbose, m_withIndex, m_indexingLanguage, m_compression, m_clusterSize)
+  );
+
+  for(unsigned i=0; i<m_nbWorkers; i++)
   {
-    Creator::Creator()
-      : m_clusterSize(DEFAULT_CLUSTER_SIZE)
-    {}
-    Creator::~Creator() = default;
+    std::thread thread(taskRunner, this->data.get());
+    data->workerThreads.push_back(std::move(thread));
+  }
 
-    Creator& Creator::configVerbose(bool verbose)
-    {
-      m_verbose = verbose;
-      return *this;
+  data->writerThread = std::thread(clusterWriter, this->data.get());
+}
+
+void Creator::addItem(std::shared_ptr<Item> item)
+{
+  checkError();
+  bool compressContent = item->getAmendedHints()[COMPRESS];
+  auto dirent = data->createItemDirent(item.get());
+  data->addItemData(dirent, item->getContentProvider(), compressContent);
+  data->handle(dirent, item);
+
+  if (data->dirents.size()%1000 == 0) {
+    TPROGRESS();
+  }
+}
+
+void Creator::addMetadata(const std::string& name, const std::string& content, const std::string& mimetype)
+{
+  checkError();
+  auto provider = std::unique_ptr<ContentProvider>(new StringProvider(content));
+  addMetadata(name, std::move(provider), mimetype);
+}
+
+void Creator::addMetadata(const std::string& name, std::unique_ptr<ContentProvider> provider, const std::string& mimetype)
+{
+  checkError();
+  auto compressContent = isCompressibleMimetype(mimetype);
+  auto dirent = data->createDirent(NS::M, name, mimetype, "");
+  data->addItemData(dirent, std::move(provider), compressContent);
+  data->handle(dirent);
+}
+
+void Creator::addIllustration(const IllustrationInfo& ii, const std::string& content)
+{
+  checkError();
+  auto provider = std::unique_ptr<ContentProvider>(new StringProvider(content));
+  addIllustration(ii, std::move(provider));
+}
+
+void Creator::addIllustration(const IllustrationInfo& ii, std::unique_ptr<ContentProvider> provider)
+{
+  checkError();
+  addMetadata(ii.asMetadataItemName(), std::move(provider), "image/png");
+}
+
+void Creator::addIllustration(unsigned int size, const std::string& content)
+{
+  addIllustration(IllustrationInfo{size, size, 1, {}}, content);
+}
+
+void Creator::addIllustration(unsigned int size, std::unique_ptr<ContentProvider> provider)
+{
+  addIllustration(IllustrationInfo{size, size, 1, {}}, std::move(provider));
+}
+
+void Creator::addRedirection(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
+{
+  checkError();
+  auto dirent = data->createRedirectDirent(NS::C, path, title, NS::C, targetPath);
+  if (data->dirents.size()%1000 == 0){
+    TPROGRESS();
+  }
+
+  data->handle(dirent, hints);
+}
+
+void Creator::addAlias(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
+{
+  checkError();
+  Dirent tmpDirent(NS::C, targetPath);
+  auto existing_dirent_it = data->dirents.find(&tmpDirent);
+
+  if (existing_dirent_it == data->dirents.end()) {
+    Formatter fmt;
+    fmt << "Impossible to alias C/" << targetPath << " as C/" << path << std::endl;
+    fmt << "C/" << targetPath << " doesn't exist." << std::endl;
+    throw InvalidEntry(fmt);
+  }
+
+  auto dirent = data->createAliasDirent(path, title, **existing_dirent_it);
+  data->handle(dirent, hints);
+}
+
+void Creator::finishZimCreation()
+{
+  checkError();
+  // Create a redirection for the mainPage.
+  // We need to keep the created dirent to set the fileheader.
+  // Dirent doesn't have to be deleted.
+  if (!m_mainPath.empty()) {
+    data->mainPageDirent = data->createRedirectDirent(NS::W, "mainPage", "", NS::C, m_mainPath);
+    data->handle(data->mainPageDirent);
+  }
+
+  TPROGRESS();
+
+  // We need to create all dirents before resolving redirects and setting entry indexes.
+  for(auto& handler:data->m_direntHandlers) {
+    // This silently create all the needed dirents.
+    handler->getDirents();
+  }
+
+  // Now we have all the dirents (but not the data), we must correctly set/fix the dirents
+  // before we ask data to the handlers
+  TINFO("ResolveRedirectIndexes");
+  data->resolveRedirectIndexes();
+
+  TINFO("Set entry indexes");
+  data->setEntryIndexes();
+
+  TINFO("Resolve mimetype");
+  data->resolveMimeTypes();
+
+  // We can now stop the direntHandlers, and get their content
+  for(auto& handler:data->m_direntHandlers) {
+    handler->stop();
+    const auto& dirents = handler->getDirents();
+    if (dirents.empty()) {
+      continue;
     }
-
-    Creator& Creator::configCompression(Compression compression)
-    {
-      m_compression = compression;
-      return *this;
+    auto providers = handler->getContentProviders();
+    ASSERT(dirents.size(), ==, providers.size());
+    auto provider_it = providers.begin();
+    for(auto& dirent:dirents) {
+      // As we use a "handler level" isCompressible, all content of the same handler
+      // must have the same compression.
+      data->addItemData(dirent, std::move(*provider_it), handler->isCompressible());
+      provider_it++;
     }
+  }
 
-    Creator& Creator::configClusterSize(zim::size_type targetSize)
-    {
-      m_clusterSize = targetSize;
-      return *this;
-    }
+  // All the data has been added, we can now close all clusters
+  if (data->compCluster->count())
+    data->closeCluster(true);
 
-    Creator& Creator::configIndexing(bool indexing, const std::string& language)
-    {
-      m_withIndex = indexing;
-      m_indexingLanguage = language;
-      return *this;
-    }
+  if (data->uncompCluster->count())
+    data->closeCluster(false);
 
-    Creator& Creator::configNbWorkers(unsigned nbWorkers)
-    {
-      m_nbWorkers = nbWorkers;
-      return *this;
-    }
+  TINFO("Waiting for workers");
+  // wait all cluster compression has been done
+  ClusterTask::waitNoMoreTask(data.get());
 
-    void Creator::startZimCreation(const std::string& filepath)
-    {
-      data = std::unique_ptr<CreatorData>(
-        new CreatorData(filepath, m_verbose, m_withIndex, m_indexingLanguage, m_compression, m_clusterSize)
-      );
+  data->quitAllThreads();
+  checkError();
 
-      for(unsigned i=0; i<m_nbWorkers; i++)
-      {
-        std::thread thread(taskRunner, this->data.get());
-        data->workerThreads.push_back(std::move(thread));
-      }
+  // Delete all handler (they will clean there own data)
+  data->m_direntHandlers.clear();
 
-      data->writerThread = std::thread(clusterWriter, this->data.get());
-    }
+  TINFO(data->dirents.size() << " title index created");
+  TINFO(data->clustersList.size() << " clusters created");
 
-    void Creator::addItem(std::shared_ptr<Item> item)
-    {
-      checkError();
-      bool compressContent = item->getAmendedHints()[COMPRESS];
-      auto dirent = data->createItemDirent(item.get());
-      data->addItemData(dirent, item->getContentProvider(), compressContent);
-      data->handle(dirent, item);
+  TINFO("write zimfile :");
+  writeLastParts();
+  ::close(data->out_fd);
+  data->out_fd = -1;
 
-      if (data->dirents.size()%1000 == 0) {
-        TPROGRESS();
-      }
-    }
+  TINFO("rename tmpfile to final one.");
+  DEFAULTFS::rename(data->tmpFileName, data->zimName);
+  data->tmpFileName.clear();
 
-    void Creator::addMetadata(const std::string& name, const std::string& content, const std::string& mimetype)
-    {
-      checkError();
-      auto provider = std::unique_ptr<ContentProvider>(new StringProvider(content));
-      addMetadata(name, std::move(provider), mimetype);
-    }
+  TINFO("finish");
+}
 
-    void Creator::addMetadata(const std::string& name, std::unique_ptr<ContentProvider> provider, const std::string& mimetype)
-    {
-      checkError();
-      auto compressContent = isCompressibleMimetype(mimetype);
-      auto dirent = data->createDirent(NS::M, name, mimetype, "");
-      data->addItemData(dirent, std::move(provider), compressContent);
-      data->handle(dirent);
-    }
+void Creator::fillHeader(Fileheader* header) const
+{
+  header->setMainPage(
+    data->mainPageDirent
+    ? entry_index_type(data->mainPageDirent->getIdx())
+    : std::numeric_limits<entry_index_type>::max());
+  header->setLayoutPage(std::numeric_limits<entry_index_type>::max());
 
-    void Creator::addIllustration(const IllustrationInfo& ii, const std::string& content)
-    {
-      checkError();
-      auto provider = std::unique_ptr<ContentProvider>(new StringProvider(content));
-      addIllustration(ii, std::move(provider));
-    }
+  header->setUuid( m_uuid );
+  header->setArticleCount( data->dirents.size() );
 
-    void Creator::addIllustration(const IllustrationInfo& ii, std::unique_ptr<ContentProvider> provider)
-    {
-      checkError();
-      addMetadata(ii.asMetadataItemName(), std::move(provider), "image/png");
-    }
+  header->setMimeListPos( Fileheader::size );
 
-    void Creator::addIllustration(unsigned int size, const std::string& content)
-    {
-      addIllustration(IllustrationInfo{size, size, 1, {}}, content);
-    }
+  header->setTitleIdxPos(offset_type(-1));
+  header->setClusterCount( data->clustersList.size() );
+}
 
-    void Creator::addIllustration(unsigned int size, std::unique_ptr<ContentProvider> provider)
-    {
-      addIllustration(IllustrationInfo{size, size, 1, {}}, std::move(provider));
-    }
+void Creator::writeLastParts() const
+{
+  Fileheader header;
+  fillHeader(&header);
 
-    void Creator::addRedirection(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
-    {
-      checkError();
-      auto dirent = data->createRedirectDirent(NS::C, path, title, NS::C, targetPath);
-      if (data->dirents.size()%1000 == 0){
-        TPROGRESS();
-      }
+  int out_fd = data->out_fd;
 
-      data->handle(dirent, hints);
-    }
+  lseek(out_fd, header.getMimeListPos(), SEEK_SET);
+  TINFO(" write mimetype list");
+  for(auto& mimeType: data->mimeTypesList)
+  {
+    _write(out_fd, mimeType.c_str(), mimeType.size()+1);
+  }
 
-    void Creator::addAlias(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
-    {
-      checkError();
-      Dirent tmpDirent(NS::C, targetPath);
-      auto existing_dirent_it = data->dirents.find(&tmpDirent);
+  _write(out_fd, "", 1);
 
-      if (existing_dirent_it == data->dirents.end()) {
-        Formatter fmt;
-        fmt << "Impossible to alias C/" << targetPath << " as C/" << path << std::endl;
-        fmt << "C/" << targetPath << " doesn't exist." << std::endl;
-        throw InvalidEntry(fmt);
-      }
+  ASSERT(lseek(out_fd, 0, SEEK_CUR), <, CLUSTER_BASE_OFFSET);
 
-      auto dirent = data->createAliasDirent(path, title, **existing_dirent_it);
-      data->handle(dirent, hints);
-    }
+  { // writing dirents
 
-    void Creator::finishZimCreation()
-    {
-      checkError();
-      // Create a redirection for the mainPage.
-      // We need to keep the created dirent to set the fileheader.
-      // Dirent doesn't have to be deleted.
-      if (!m_mainPath.empty()) {
-        data->mainPageDirent = data->createRedirectDirent(NS::W, "mainPage", "", NS::C, m_mainPath);
-        data->handle(data->mainPageDirent);
-      }
+  // TODO: Memory usage by direntOffsets can be reduced by replacing
+  // TODO: the offset values with dirent size values and reconstructing
+  // TODO: the offsets as a running sum starting from the offset of the
+  // TODO: first dirent
+  std::deque<offset_t> direntOffsets;
 
-      TPROGRESS();
+  TINFO(" write directory entries");
+  lseek(out_fd, 0, SEEK_END);
+  for (Dirent* dirent: data->dirents)
+  {
+    direntOffsets.push_back(offset_t(lseek(out_fd, 0, SEEK_CUR)));
+    dirent->write(out_fd);
+  }
 
-      // We need to create all dirents before resolving redirects and setting entry indexes.
-      for(auto& handler:data->m_direntHandlers) {
-        // This silently create all the needed dirents.
-        handler->getDirents();
-      }
+  TINFO(" write path ptr list");
+  header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
+  for (auto offset : direntOffsets)
+  {
+    char tmp_buff[sizeof(offset_type)];
+    toLittleEndian(offset, tmp_buff);
+    _write(out_fd, tmp_buff, sizeof(offset_type));
+  }
 
-      // Now we have all the dirents (but not the data), we must correctly set/fix the dirents
-      // before we ask data to the handlers
-      TINFO("ResolveRedirectIndexes");
-      data->resolveRedirectIndexes();
+  } // writing dirents
 
-      TINFO("Set entry indexes");
-      data->setEntryIndexes();
+  TINFO(" write cluster offset list");
+  header.setClusterPtrPos(lseek(out_fd, 0, SEEK_CUR));
+  for (auto cluster : data->clustersList)
+  {
+    char tmp_buff[sizeof(offset_type)];
+    toLittleEndian(cluster->getOffset(), tmp_buff);
+    _write(out_fd, tmp_buff, sizeof(offset_type));
+  }
 
-      TINFO("Resolve mimetype");
-      data->resolveMimeTypes();
+  header.setChecksumPos(lseek(out_fd, 0, SEEK_CUR));
 
-      // We can now stop the direntHandlers, and get their content
-      for(auto& handler:data->m_direntHandlers) {
-        handler->stop();
-        const auto& dirents = handler->getDirents();
-        if (dirents.empty()) {
-          continue;
-        }
-        auto providers = handler->getContentProviders();
-        ASSERT(dirents.size(), ==, providers.size());
-        auto provider_it = providers.begin();
-        for(auto& dirent:dirents) {
-          // As we use a "handler level" isCompressible, all content of the same handler
-          // must have the same compression.
-          data->addItemData(dirent, std::move(*provider_it), handler->isCompressible());
-          provider_it++;
-        }
-      }
+  TINFO(" write header");
+  lseek(out_fd, 0, SEEK_SET);
+  header.write(out_fd);
 
-      // All the data has been added, we can now close all clusters
-      if (data->compCluster->count())
-        data->closeCluster(true);
+  TINFO(" write checksum");
+  struct zim_MD5_CTX md5ctx;
+  unsigned char batch_read[1024+1];
+  lseek(out_fd, 0, SEEK_SET);
+  zim_MD5Init(&md5ctx);
+  while (true) {
+     auto r = read(out_fd, batch_read, 1024);
+     if (r == -1) {
+       throw std::runtime_error(std::strerror(errno));
+     }
+     if (r == 0)
+       break;
+     batch_read[r] = 0;
+     zim_MD5Update(&md5ctx, batch_read, r);
+  }
+  unsigned char digest[16];
+  zim_MD5Final(digest, &md5ctx);
+  _write(out_fd, reinterpret_cast<const char*>(digest), 16);
+}
 
-      if (data->uncompCluster->count())
-        data->closeCluster(false);
+void Creator::checkError()
+{
+  if (data->m_errored) {
+    throw CreatorStateError();
+  }
+  std::lock_guard<std::mutex> l(data->m_exceptionLock);
+  if (data->m_exceptionSlot) {
+    std::cerr << "ERROR Detected" << std::endl;
+    data->m_errored = true;
+    throw AsyncError(data->m_exceptionSlot);
+  }
+}
 
-      TINFO("Waiting for workers");
-      // wait all cluster compression has been done
-      ClusterTask::waitNoMoreTask(data.get());
-
-      data->quitAllThreads();
-      checkError();
-
-      // Delete all handler (they will clean there own data)
-      data->m_direntHandlers.clear();
-
-      TINFO(data->dirents.size() << " title index created");
-      TINFO(data->clustersList.size() << " clusters created");
-
-      TINFO("write zimfile :");
-      writeLastParts();
-      ::close(data->out_fd);
-      data->out_fd = -1;
-
-      TINFO("rename tmpfile to final one.");
-      DEFAULTFS::rename(data->tmpFileName, data->zimName);
-      data->tmpFileName.clear();
-
-      TINFO("finish");
-    }
-
-    void Creator::fillHeader(Fileheader* header) const
-    {
-      header->setMainPage(
-        data->mainPageDirent
-        ? entry_index_type(data->mainPageDirent->getIdx())
-        : std::numeric_limits<entry_index_type>::max());
-      header->setLayoutPage(std::numeric_limits<entry_index_type>::max());
-
-      header->setUuid( m_uuid );
-      header->setArticleCount( data->dirents.size() );
-
-      header->setMimeListPos( Fileheader::size );
-
-      header->setTitleIdxPos(offset_type(-1));
-      header->setClusterCount( data->clustersList.size() );
-    }
-
-    void Creator::writeLastParts() const
-    {
-      Fileheader header;
-      fillHeader(&header);
-
-      int out_fd = data->out_fd;
-
-      lseek(out_fd, header.getMimeListPos(), SEEK_SET);
-      TINFO(" write mimetype list");
-      for(auto& mimeType: data->mimeTypesList)
-      {
-        _write(out_fd, mimeType.c_str(), mimeType.size()+1);
-      }
-
-      _write(out_fd, "", 1);
-
-      ASSERT(lseek(out_fd, 0, SEEK_CUR), <, CLUSTER_BASE_OFFSET);
-
-      { // writing dirents
-
-      // TODO: Memory usage by direntOffsets can be reduced by replacing
-      // TODO: the offset values with dirent size values and reconstructing
-      // TODO: the offsets as a running sum starting from the offset of the
-      // TODO: first dirent
-      std::deque<offset_t> direntOffsets;
-
-      TINFO(" write directory entries");
-      lseek(out_fd, 0, SEEK_END);
-      for (Dirent* dirent: data->dirents)
-      {
-        direntOffsets.push_back(offset_t(lseek(out_fd, 0, SEEK_CUR)));
-        dirent->write(out_fd);
-      }
-
-      TINFO(" write path ptr list");
-      header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
-      for (auto offset : direntOffsets)
-      {
-        char tmp_buff[sizeof(offset_type)];
-        toLittleEndian(offset, tmp_buff);
-        _write(out_fd, tmp_buff, sizeof(offset_type));
-      }
-
-      } // writing dirents
-
-      TINFO(" write cluster offset list");
-      header.setClusterPtrPos(lseek(out_fd, 0, SEEK_CUR));
-      for (auto cluster : data->clustersList)
-      {
-        char tmp_buff[sizeof(offset_type)];
-        toLittleEndian(cluster->getOffset(), tmp_buff);
-        _write(out_fd, tmp_buff, sizeof(offset_type));
-      }
-
-      header.setChecksumPos(lseek(out_fd, 0, SEEK_CUR));
-
-      TINFO(" write header");
-      lseek(out_fd, 0, SEEK_SET);
-      header.write(out_fd);
-
-      TINFO(" write checksum");
-      struct zim_MD5_CTX md5ctx;
-      unsigned char batch_read[1024+1];
-      lseek(out_fd, 0, SEEK_SET);
-      zim_MD5Init(&md5ctx);
-      while (true) {
-         auto r = read(out_fd, batch_read, 1024);
-         if (r == -1) {
-           throw std::runtime_error(std::strerror(errno));
-         }
-         if (r == 0)
-           break;
-         batch_read[r] = 0;
-         zim_MD5Update(&md5ctx, batch_read, r);
-      }
-      unsigned char digest[16];
-      zim_MD5Final(digest, &md5ctx);
-      _write(out_fd, reinterpret_cast<const char*>(digest), 16);
-    }
-
-    void Creator::checkError()
-    {
-      if (data->m_errored) {
-        throw CreatorStateError();
-      }
-      std::lock_guard<std::mutex> l(data->m_exceptionLock);
-      if (data->m_exceptionSlot) {
-        std::cerr << "ERROR Detected" << std::endl;
-        data->m_errored = true;
-        throw AsyncError(data->m_exceptionSlot);
-      }
-    }
-
-    CreatorData::CreatorData(const std::string& fname,
-                                   bool verbose,
-                                   bool withIndex,
-                                   std::string language,
-                                   Compression c,
-                                   size_t clusterSize)
-      : mainPageDirent(nullptr),
-        m_errored(false),
-        compression(c),
-        zimName(fname),
-        tmpFileName(fname + ".tmp"),
-        clusterSize(clusterSize),
-        withIndex(withIndex),
-        indexingLanguage(language),
-        verbose(verbose),
-        nbRedirectItems(0),
-        nbCompItems(0),
-        nbUnCompItems(0),
-        nbClusters(0),
-        nbCompClusters(0),
-        nbUnCompClusters(0),
-        start_time(time(NULL))
-    {
+CreatorData::CreatorData(const std::string& fname,
+                               bool verbose,
+                               bool withIndex,
+                               std::string language,
+                               Compression c,
+                               size_t clusterSize)
+  : mainPageDirent(nullptr),
+    m_errored(false),
+    compression(c),
+    zimName(fname),
+    tmpFileName(fname + ".tmp"),
+    clusterSize(clusterSize),
+    withIndex(withIndex),
+    indexingLanguage(language),
+    verbose(verbose),
+    nbRedirectItems(0),
+    nbCompItems(0),
+    nbUnCompItems(0),
+    nbClusters(0),
+    nbCompClusters(0),
+    nbUnCompClusters(0),
+    start_time(time(NULL))
+{
 #ifdef _WIN32
-      int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
-      int mode =  _S_IREAD | _S_IWRITE;
+  int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
+  int mode =  _S_IREAD | _S_IWRITE;
 #else
-      int flag = O_RDWR | O_CREAT | O_TRUNC;
-      mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+  int flag = O_RDWR | O_CREAT | O_TRUNC;
+  mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 #endif
-      out_fd = open(tmpFileName.c_str(), flag, mode);
-      if (out_fd == -1){
-        throw std::runtime_error(std::strerror(errno));
-      }
-      if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
-        close(out_fd);
-        throw std::runtime_error(std::strerror(errno));
-      }
+  out_fd = open(tmpFileName.c_str(), flag, mode);
+  if (out_fd == -1){
+    throw std::runtime_error(std::strerror(errno));
+  }
+  if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
+    close(out_fd);
+    throw std::runtime_error(std::strerror(errno));
+  }
 
-      // We keep both a "compressed cluster" and an "uncompressed cluster"
-      // because we don't know which one will fill up first.  We also need
-      // to track the dirents currently in each, so we can fix up the
-      // cluster index if the other one ends up written first.
-      compCluster = new Cluster(compression);
-      uncompCluster = new Cluster(Compression::None);
+  // We keep both a "compressed cluster" and an "uncompressed cluster"
+  // because we don't know which one will fill up first.  We also need
+  // to track the dirents currently in each, so we can fix up the
+  // cluster index if the other one ends up written first.
+  compCluster = new Cluster(compression);
+  uncompCluster = new Cluster(Compression::None);
 
 #if defined(ENABLE_XAPIAN)
-      auto xapianIndexer = std::make_shared<XapianHandler>(this, withIndex);
-      m_direntHandlers.push_back(xapianIndexer);
+  auto xapianIndexer = std::make_shared<XapianHandler>(this, withIndex);
+  m_direntHandlers.push_back(xapianIndexer);
 #endif
 
-      m_direntHandlers.push_back(std::make_shared<TitleListingHandler>(this));
-      m_direntHandlers.push_back(std::make_shared<CounterHandler>(this));
+  m_direntHandlers.push_back(std::make_shared<TitleListingHandler>(this));
+  m_direntHandlers.push_back(std::make_shared<CounterHandler>(this));
 
-      for(auto& handler:m_direntHandlers) {
-        handler->start();
-      }
+  for(auto& handler:m_direntHandlers) {
+    handler->start();
+  }
+}
+
+CreatorData::~CreatorData()
+{
+  quitAllThreads();
+  if (compCluster)
+    delete compCluster;
+  if (uncompCluster)
+    delete uncompCluster;
+  for(auto& cluster: clustersList) {
+    delete cluster;
+  }
+  if ( out_fd != - 1 ) {
+    ::close(out_fd);
+  }
+  if ( ! tmpFileName.empty() ) {
+    DEFAULTFS::removeFile(tmpFileName);
+  }
+}
+
+void CreatorData::addError(const std::exception_ptr exception)
+{
+  std::lock_guard<std::mutex> l(m_exceptionLock);
+  if (!m_exceptionSlot) {
+    m_exceptionSlot = exception;
+  }
+}
+
+bool CreatorData::isErrored() const
+{
+  if (m_errored) {
+    return true;
+  }
+  std::lock_guard<std::mutex> l(m_exceptionLock);
+  if (m_exceptionSlot) {
+    return true;
+  }
+  return false;
+}
+
+void CreatorData::quitAllThreads() {
+  // Quit all workerThreads
+  for (auto i=0U; i< workerThreads.size(); i++) {
+    taskList.pushToQueue(nullptr);
+  }
+  for(auto& thread: workerThreads) {
+    thread.join();
+  }
+  workerThreads.clear();
+
+  // Wait for writerThread to finish.
+  if (writerThread.joinable()) {
+    clusterToWrite.pushToQueue(nullptr);
+    writerThread.join();
+  }
+}
+
+void CreatorData::addDirent(Dirent* dirent)
+{
+  auto ret = dirents.insert(dirent);
+  if (!ret.second) {
+    Dirent* existing = *ret.first;
+    if (existing->isRedirect() && !dirent->isRedirect()) {
+      dirents.erase(ret.first);
+      existing->markRemoved();
+      dirents.insert(dirent);
+    } else {
+      Formatter fmt;
+      fmt << "Impossible to add " << NsAsChar(dirent->getNamespace()) << "/" << dirent->getPath() << std::endl;
+      fmt << "  dirent's title to add is : " << dirent->getTitle() << std::endl;
+      fmt << "  existing dirent's title is : " << existing->getTitle() << std::endl;
+      throw InvalidEntry(fmt);
+    }
+  };
+
+  if (dirent->isRedirect()) {
+    nbRedirectItems++;
+  }
+}
+
+void CreatorData::addItemData(Dirent* dirent, std::unique_ptr<ContentProvider> provider, bool compressContent)
+{
+  // Add blob data to compressed or uncompressed cluster.
+  auto itemSize = provider->getSize();
+  if (itemSize > 0)
+  {
+    isEmpty = false;
+  }
+
+  auto cluster = compressContent ? compCluster : uncompCluster;
+
+  // If cluster will be too large, write it to dis, and open a new
+  // one for the content.
+  if ( cluster->count()
+    && cluster->size().v+itemSize >= clusterSize
+     )
+  {
+    log_info("cluster with " << cluster->count() << " items, " <<
+             cluster->size() << " bytes; current title \"" <<
+             dirent->getTitle() << '\"');
+    cluster = closeCluster(compressContent);
+  }
+
+  dirent->setCluster(cluster);
+  cluster->addContent(std::move(provider));
+
+  if (compressContent) {
+    nbCompItems++;
+  } else {
+    nbUnCompItems++;
+  }
+}
+
+Dirent* CreatorData::createDirent(NS ns, const std::string& path, const std::string& mimetype, const std::string& title)
+{
+  auto dirent = pool.getClassicDirent(ns, path, title, getMimeTypeIdx(mimetype));
+  addDirent(dirent);
+  return dirent;
+}
+
+Dirent* CreatorData::createItemDirent(const Item* item)
+{
+  auto path = item->getPath();
+  auto mimetype = item->getMimeType();
+  if (mimetype.empty()) {
+    std::cerr << "Warning, " << item->getPath() << " have empty mimetype." << std::endl;
+    mimetype = "application/octet-stream";
+  }
+  return createDirent(NS::C, item->getPath(), mimetype, item->getTitle());
+}
+
+Dirent* CreatorData::createRedirectDirent(NS ns, const std::string& path, const std::string& title, NS targetNs, const std::string& targetPath)
+{
+  auto dirent = pool.getRedirectDirent(ns, path, title, targetNs, targetPath);
+  addDirent(dirent);
+  return dirent;
+}
+
+Dirent* CreatorData::createAliasDirent(const std::string& path, const std::string& title, const Dirent& target)
+{
+  auto dirent = pool.getAliasDirent(path, title, target);
+  addDirent(dirent);
+  return dirent;
+}
+
+Cluster* CreatorData::closeCluster(bool compressed)
+{
+  Cluster *cluster;
+  nbClusters++;
+  if (compressed )
+  {
+    cluster = compCluster;
+    nbCompClusters++;
+  } else {
+    cluster = uncompCluster;
+    nbUnCompClusters++;
+  }
+  cluster->setClusterIndex(cluster_index_t(clustersList.size()));
+  clustersList.push_back(cluster);
+  taskList.pushToQueue(std::make_shared<ClusterTask>(cluster));
+  clusterToWrite.pushToQueue(cluster);
+
+  if (compressed)
+  {
+    cluster = compCluster = new Cluster(compression);
+  } else {
+    cluster = uncompCluster = new Cluster(Compression::None);
+  }
+  return cluster;
+}
+
+void CreatorData::setEntryIndexes()
+{
+  // set index
+  INFO("set index");
+  entry_index_t idx(0);
+  for (auto& dirent: dirents) {
+    dirent->setIdx(idx);
+    idx += 1;
+  }
+}
+
+void CreatorData::resolveRedirectIndexes()
+{
+  // translate redirect aid to index
+  INFO("Resolve redirect");
+  for (auto it = dirents.begin(); it != dirents.end(); )
+  {
+    Dirent* dirent = *it;
+    if ( !dirent->isRedirect() ) {
+      ++it;
+      continue;
     }
 
-    CreatorData::~CreatorData()
-    {
-      quitAllThreads();
-      if (compCluster)
-        delete compCluster;
-      if (uncompCluster)
-        delete uncompCluster;
-      for(auto& cluster: clustersList) {
-        delete cluster;
+    Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
+    auto target_pos = dirents.find(&tmpDirent);
+    if(target_pos == dirents.end()) {
+      INFO("Invalid redirection "
+          << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
+          << " redirecting to (missing) "
+          << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
+      it = dirents.erase(it);
+      dirent->markRemoved();
+      if (dirent == mainPageDirent) {
+        mainPageDirent = nullptr;
       }
-      if ( out_fd != - 1 ) {
-        ::close(out_fd);
-      }
-      if ( ! tmpFileName.empty() ) {
-        DEFAULTFS::removeFile(tmpFileName);
-      }
-    }
-
-    void CreatorData::addError(const std::exception_ptr exception)
-    {
-      std::lock_guard<std::mutex> l(m_exceptionLock);
-      if (!m_exceptionSlot) {
-        m_exceptionSlot = exception;
-      }
-    }
-
-    bool CreatorData::isErrored() const
-    {
-      if (m_errored) {
-        return true;
-      }
-      std::lock_guard<std::mutex> l(m_exceptionLock);
-      if (m_exceptionSlot) {
-        return true;
-      }
-      return false;
-    }
-
-    void CreatorData::quitAllThreads() {
-      // Quit all workerThreads
-      for (auto i=0U; i< workerThreads.size(); i++) {
-        taskList.pushToQueue(nullptr);
-      }
-      for(auto& thread: workerThreads) {
-        thread.join();
-      }
-      workerThreads.clear();
-
-      // Wait for writerThread to finish.
-      if (writerThread.joinable()) {
-        clusterToWrite.pushToQueue(nullptr);
-        writerThread.join();
-      }
-    }
-
-    void CreatorData::addDirent(Dirent* dirent)
-    {
-      auto ret = dirents.insert(dirent);
-      if (!ret.second) {
-        Dirent* existing = *ret.first;
-        if (existing->isRedirect() && !dirent->isRedirect()) {
-          dirents.erase(ret.first);
-          existing->markRemoved();
-          dirents.insert(dirent);
-        } else {
-          Formatter fmt;
-          fmt << "Impossible to add " << NsAsChar(dirent->getNamespace()) << "/" << dirent->getPath() << std::endl;
-          fmt << "  dirent's title to add is : " << dirent->getTitle() << std::endl;
-          fmt << "  existing dirent's title is : " << existing->getTitle() << std::endl;
-          throw InvalidEntry(fmt);
-        }
-      };
-
-      if (dirent->isRedirect()) {
-        nbRedirectItems++;
-      }
-    }
-
-    void CreatorData::addItemData(Dirent* dirent, std::unique_ptr<ContentProvider> provider, bool compressContent)
-    {
-      // Add blob data to compressed or uncompressed cluster.
-      auto itemSize = provider->getSize();
-      if (itemSize > 0)
-      {
-        isEmpty = false;
-      }
-
-      auto cluster = compressContent ? compCluster : uncompCluster;
-
-      // If cluster will be too large, write it to dis, and open a new
-      // one for the content.
-      if ( cluster->count()
-        && cluster->size().v+itemSize >= clusterSize
-         )
-      {
-        log_info("cluster with " << cluster->count() << " items, " <<
-                 cluster->size() << " bytes; current title \"" <<
-                 dirent->getTitle() << '\"');
-        cluster = closeCluster(compressContent);
-      }
-
-      dirent->setCluster(cluster);
-      cluster->addContent(std::move(provider));
-
-      if (compressContent) {
-        nbCompItems++;
-      } else {
-        nbUnCompItems++;
-      }
-    }
-
-    Dirent* CreatorData::createDirent(NS ns, const std::string& path, const std::string& mimetype, const std::string& title)
-    {
-      auto dirent = pool.getClassicDirent(ns, path, title, getMimeTypeIdx(mimetype));
-      addDirent(dirent);
-      return dirent;
-    }
-
-    Dirent* CreatorData::createItemDirent(const Item* item)
-    {
-      auto path = item->getPath();
-      auto mimetype = item->getMimeType();
-      if (mimetype.empty()) {
-        std::cerr << "Warning, " << item->getPath() << " have empty mimetype." << std::endl;
-        mimetype = "application/octet-stream";
-      }
-      return createDirent(NS::C, item->getPath(), mimetype, item->getTitle());
-    }
-
-    Dirent* CreatorData::createRedirectDirent(NS ns, const std::string& path, const std::string& title, NS targetNs, const std::string& targetPath)
-    {
-      auto dirent = pool.getRedirectDirent(ns, path, title, targetNs, targetPath);
-      addDirent(dirent);
-      return dirent;
-    }
-
-    Dirent* CreatorData::createAliasDirent(const std::string& path, const std::string& title, const Dirent& target)
-    {
-      auto dirent = pool.getAliasDirent(path, title, target);
-      addDirent(dirent);
-      return dirent;
-    }
-
-    Cluster* CreatorData::closeCluster(bool compressed)
-    {
-      Cluster *cluster;
-      nbClusters++;
-      if (compressed )
-      {
-        cluster = compCluster;
-        nbCompClusters++;
-      } else {
-        cluster = uncompCluster;
-        nbUnCompClusters++;
-      }
-      cluster->setClusterIndex(cluster_index_t(clustersList.size()));
-      clustersList.push_back(cluster);
-      taskList.pushToQueue(std::make_shared<ClusterTask>(cluster));
-      clusterToWrite.pushToQueue(cluster);
-
-      if (compressed)
-      {
-        cluster = compCluster = new Cluster(compression);
-      } else {
-        cluster = uncompCluster = new Cluster(Compression::None);
-      }
-      return cluster;
-    }
-
-    void CreatorData::setEntryIndexes()
-    {
-      // set index
-      INFO("set index");
-      entry_index_t idx(0);
-      for (auto& dirent: dirents) {
-        dirent->setIdx(idx);
-        idx += 1;
-      }
-    }
-
-    void CreatorData::resolveRedirectIndexes()
-    {
-      // translate redirect aid to index
-      INFO("Resolve redirect");
-      for (auto it = dirents.begin(); it != dirents.end(); )
-      {
-        Dirent* dirent = *it;
-        if ( !dirent->isRedirect() ) {
-          ++it;
-          continue;
-        }
-
-        Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
-        auto target_pos = dirents.find(&tmpDirent);
-        if(target_pos == dirents.end()) {
-          INFO("Invalid redirection "
-              << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
-              << " redirecting to (missing) "
-              << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
-          it = dirents.erase(it);
-          dirent->markRemoved();
-          if (dirent == mainPageDirent) {
-            mainPageDirent = nullptr;
-          }
-        } else  {
-          dirent->setRedirect(*target_pos);
-          ++it;
-        }
-      }
-    }
-
-    void CreatorData::resolveMimeTypes()
-    {
-      std::vector<std::string> oldMImeList;
-      std::vector<uint16_t> mapping;
-
-      for (auto& rmimeType: rmimeTypesMap)
-      {
-        oldMImeList.push_back(rmimeType.second);
-        mimeTypesList.push_back(rmimeType.second);
-      }
-
-      mapping.resize(oldMImeList.size());
-      std::sort(mimeTypesList.begin(), mimeTypesList.end());
-
-      for (unsigned i=0; i<oldMImeList.size(); ++i)
-      {
-        for (unsigned j=0; j<mimeTypesList.size(); ++j)
-        {
-          if (oldMImeList[i] == mimeTypesList[j])
-            mapping[i] = static_cast<uint16_t>(j);
-        }
-      }
-
-      for (auto& dirent: dirents)
-      {
-        if (dirent->isItem())
-          dirent->setMimeType(mapping[dirent->getMimeType()]);
-      }
-    }
-
-    uint16_t CreatorData::getMimeTypeIdx(const std::string& mimeType)
-    {
-      auto it = mimeTypesMap.find(mimeType);
-      if (it == mimeTypesMap.end())
-      {
-        if (nextMimeIdx >= std::numeric_limits<uint16_t>::max())
-          throw CreatorError("too many distinct mime types");
-        mimeTypesMap[mimeType] = nextMimeIdx;
-        rmimeTypesMap[nextMimeIdx] = mimeType;
-        return nextMimeIdx++;
-      }
-
-      return it->second;
-    }
-
-    const std::string& CreatorData::getMimeType(uint16_t mimeTypeIdx) const
-    {
-      auto it = rmimeTypesMap.find(mimeTypeIdx);
-      if (it == rmimeTypesMap.end())
-        throw CreatorError("mime type index not found");
-      return it->second;
+    } else  {
+      dirent->setRedirect(*target_pos);
+      ++it;
     }
   }
 }
+
+void CreatorData::resolveMimeTypes()
+{
+  std::vector<std::string> oldMImeList;
+  std::vector<uint16_t> mapping;
+
+  for (auto& rmimeType: rmimeTypesMap)
+  {
+    oldMImeList.push_back(rmimeType.second);
+    mimeTypesList.push_back(rmimeType.second);
+  }
+
+  mapping.resize(oldMImeList.size());
+  std::sort(mimeTypesList.begin(), mimeTypesList.end());
+
+  for (unsigned i=0; i<oldMImeList.size(); ++i)
+  {
+    for (unsigned j=0; j<mimeTypesList.size(); ++j)
+    {
+      if (oldMImeList[i] == mimeTypesList[j])
+        mapping[i] = static_cast<uint16_t>(j);
+    }
+  }
+
+  for (auto& dirent: dirents)
+  {
+    if (dirent->isItem())
+      dirent->setMimeType(mapping[dirent->getMimeType()]);
+  }
+}
+
+uint16_t CreatorData::getMimeTypeIdx(const std::string& mimeType)
+{
+  auto it = mimeTypesMap.find(mimeType);
+  if (it == mimeTypesMap.end())
+  {
+    if (nextMimeIdx >= std::numeric_limits<uint16_t>::max())
+      throw CreatorError("too many distinct mime types");
+    mimeTypesMap[mimeType] = nextMimeIdx;
+    rmimeTypesMap[nextMimeIdx] = mimeType;
+    return nextMimeIdx++;
+  }
+
+  return it->second;
+}
+
+const std::string& CreatorData::getMimeType(uint16_t mimeTypeIdx) const
+{
+  auto it = rmimeTypesMap.find(mimeTypeIdx);
+  if (it == rmimeTypesMap.end())
+    throw CreatorError("mime type index not found");
+  return it->second;
+}
+
+} // namespace writer
+
+} // namespace zim

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -105,6 +105,20 @@ namespace zim
 namespace writer
 {
 
+namespace
+{
+
+InvalidEntry direntConflictError(const Dirent& existingDirent, const Dirent& newDirent)
+{
+  Formatter fmt;
+  fmt << "Impossible to add " << NsAsChar(newDirent.getNamespace()) << "/" << newDirent.getPath() << "\n"
+      << "  dirent's title to add is : " << newDirent.getTitle() << "\n"
+      << "  existing dirent's title is : " << existingDirent.getTitle() << "\n";
+  return InvalidEntry(fmt);
+}
+
+} // unnamed namespace
+
 Creator::Creator()
   : m_clusterSize(DEFAULT_CLUSTER_SIZE)
 {}
@@ -560,11 +574,7 @@ void CreatorData::addDirent(Dirent* dirent)
       removeDirent(ret.first);
       dirents.insert(dirent);
     } else {
-      Formatter fmt;
-      fmt << "Impossible to add " << NsAsChar(dirent->getNamespace()) << "/" << dirent->getPath() << std::endl;
-      fmt << "  dirent's title to add is : " << dirent->getTitle() << std::endl;
-      fmt << "  existing dirent's title is : " << existing->getTitle() << std::endl;
-      throw InvalidEntry(fmt);
+      throw direntConflictError(*existing, *dirent);
     }
   };
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -61,6 +61,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <ctime>
+#include <deque>
 #include "log.h"
 #include "../fs.h"
 #include "../tools.h"
@@ -348,22 +349,32 @@ namespace zim
 
       ASSERT(lseek(out_fd, 0, SEEK_CUR), <, CLUSTER_BASE_OFFSET);
 
+      { // writing dirents
+
+      // TODO: Memory usage by direntOffsets can be reduced by replacing
+      // TODO: the offset values with dirent size values and reconstructing
+      // TODO: the offsets as a running sum starting from the offset of the
+      // TODO: first dirent
+      std::deque<offset_t> direntOffsets;
+
       TINFO(" write directory entries");
       lseek(out_fd, 0, SEEK_END);
       for (Dirent* dirent: data->dirents)
       {
-        dirent->setOffset(offset_t(lseek(out_fd, 0, SEEK_CUR)));
+        direntOffsets.push_back(offset_t(lseek(out_fd, 0, SEEK_CUR)));
         dirent->write(out_fd);
       }
 
-      TINFO(" write path prt list");
+      TINFO(" write path ptr list");
       header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
-      for (auto& dirent: data->dirents)
+      for (auto offset : direntOffsets)
       {
         char tmp_buff[sizeof(offset_type)];
-        toLittleEndian(dirent->getOffset(), tmp_buff);
+        toLittleEndian(offset, tmp_buff);
         _write(out_fd, tmp_buff, sizeof(offset_type));
       }
+
+      } // writing dirents
 
       TINFO(" write cluster offset list");
       header.setClusterPtrPos(lseek(out_fd, 0, SEEK_CUR));

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -90,6 +90,7 @@ namespace zim
         void quitAllThreads();
 
         DirentIterator removeDirent(DirentIterator it);
+        void removeDirent(Dirent* dirent);
 
         DirentPool  pool;
 

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -91,7 +91,6 @@ namespace zim
         DirentPool  pool;
 
         UrlSortedDirents   dirents;
-        UrlSortedDirents   unresolvedRedirectDirents;
         Dirent*            mainPageDirent;
 
         MimeTypesMap mimeTypesMap;

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -54,6 +54,7 @@ namespace zim
     {
       public:
         typedef std::set<Dirent*, UrlCompare> UrlSortedDirents;
+        typedef UrlSortedDirents::iterator DirentIterator;
         typedef std::map<std::string, uint16_t> MimeTypesMap;
         typedef std::map<uint16_t, std::string> RMimeTypesMap;
         typedef std::vector<std::string> MimeTypesList;
@@ -87,6 +88,8 @@ namespace zim
         void addError(const std::exception_ptr error);
         bool isErrored() const;
         void quitAllThreads();
+
+        DirentIterator removeDirent(DirentIterator it);
 
         DirentPool  pool;
 

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -20,6 +20,7 @@
 
 #include "_dirent.h"
 #include <zim/zim.h>
+#include <zim/error.h>
 #include "buffer.h"
 #include "endian_tools.h"
 #include "log.h"
@@ -83,6 +84,16 @@ NS Dirent::getRedirectNs() const {
 
 std::string Dirent::getRedirectPath() const {
   return info.getRedirect().targetPath;
+}
+
+entry_index_t Dirent::getRedirectIndex() const      {
+  const auto targetDirent = info.getResolved().targetDirent;
+  if ( targetDirent->isRemoved() ) {
+    std::ostringstream oss;
+    oss << NsAsChar(getNamespace()) << "/" << getPath();
+    throw CreatorError("Dangling redirect remains at " + oss.str());
+  }
+  return targetDirent->getIdx();
 }
 
 void Dirent::write(int out_fd) const

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -54,7 +54,6 @@ Dirent::Dirent(NS ns, const std::string& path, const std::string& title, uint16_
     mimeType(mimetype),
     idx(0),
     info(DirentInfo::Direct()),
-    offset(0),
     _ns(static_cast<uint8_t>(ns)),
     removed(false)
 {}
@@ -65,7 +64,6 @@ Dirent::Dirent(NS ns, const std::string& path, const std::string& title, NS targ
     mimeType(redirectMimeType),
     idx(0),
     info(DirentInfo::Redirect(targetNs, targetPath)),
-    offset(0),
     _ns(static_cast<uint8_t>(ns)),
     removed(false)
 {}
@@ -75,7 +73,6 @@ Dirent::Dirent(const std::string& path, const std::string& title, const Dirent& 
     mimeType(target.mimeType),
     idx(0),
     info(target.info),
-    offset(0),
     _ns(target._ns),
     removed(false)
 {}

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -50,6 +50,8 @@ using namespace zim;
   ASSERT_EQ(entry.getRedirectEntry().getPath(), targetPath); \
 }
 
+#define EXPECT_MISSING_ENTRY(archive, path)  \
+  EXPECT_THROW(archive.getEntryByPath(path), zim::EntryNotFound)
 
 struct NoneType {};
 const NoneType None;
@@ -361,6 +363,59 @@ TEST(ZimCreator, interruptedZimCreation)
   );
 }
 
+TEST(ZimCreator, handlingOfBlindChainsOfRedirections)
+{
+  unittests::TempFile temp("zimfile");
+  const auto tempPath = temp.path();
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(tempPath);
+
+  // Create a blind ascending chain of redirects, i.e. a chain
+  // of redirects where the last entry of the chain is an invalid redirect
+  // and the rest are of the form (path1 -> path2) where path1 < path2
+  creator.addRedirection("ascendingChain/redirectA",
+                         "First redirect in an ascending blind chain",
+                         "ascendingChain/redirectB");
+
+  creator.addRedirection("ascendingChain/redirectB",
+                         "Middle redirect in an ascending blind chain",
+                         "ascendingChain/redirectC");
+
+  creator.addRedirection("ascendingChain/redirectC",
+                         "Last redirect in an ascending blind chain",
+                         "ascendingChain/missingTarget");
+
+  // Create a blind descending chain of redirects, i.e. a chain
+  // of redirects where the last entry of the chain is an invalid redirect
+  // and the rest are of the form (path1 -> path2) where path1 > path2
+  creator.addRedirection("descendingChain/redirectC",
+                         "First redirect in a descending blind chain",
+                         "descendingChain/redirectB");
+
+  creator.addRedirection("descendingChain/redirectB",
+                         "Middle redirect in a descending blind chain",
+                         "descendingChain/redirectA");
+
+  creator.addRedirection("descendingChain/redirectA",
+                         "Last redirect in a descending blind chain",
+                         "descendingChain/missingTarget");
+
+  creator.finishZimCreation();
+
+  const zim::Archive archive(tempPath);
+
+  EXPECT_MISSING_ENTRY(archive, "ascendingChain/missingTarget");
+  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectA");
+  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectB");
+  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectC");
+
+  EXPECT_MISSING_ENTRY(archive, "descendingChain/missingTarget");
+  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectA");
+  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectB");
+  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectC");
+}
 
 TEST(ZimCreator, handlingOfRedirectionLoops)
 {

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -372,6 +372,8 @@ TEST(ZimCreator, handlingOfBlindChainsOfRedirections)
   creator.setUuid(makeSafeUuid());
   creator.startZimCreation(tempPath);
 
+  creator.addItem(std::make_shared<TestItem>("1st", "1st entry in ZIM", ""));
+
   // Create a blind ascending chain of redirects, i.e. a chain
   // of redirects where the last entry of the chain is an invalid redirect
   // and the rest are of the form (path1 -> path2) where path1 < path2
@@ -407,8 +409,14 @@ TEST(ZimCreator, handlingOfBlindChainsOfRedirections)
   const zim::Archive archive(tempPath);
 
   EXPECT_MISSING_ENTRY(archive, "ascendingChain/missingTarget");
-  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectA");
-  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectB");
+
+  // XXX: The unit test now reflects the bug rather than imposes
+  // XXX: the desired behavior.
+  //EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectA");
+  //EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectB");
+  ASSERT_REDIRECT_ENTRY(archive, "ascendingChain/redirectA", "ascendingChain/redirectB");
+  ASSERT_REDIRECT_ENTRY(archive, "ascendingChain/redirectB", "1st");
+
   EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectC");
 
   EXPECT_MISSING_ENTRY(archive, "descendingChain/missingTarget");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -389,20 +389,7 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
                          "Last redirect in an ascending blind chain",
                          "missingTarget");
 
-  creator.finishZimCreation();
-
-  const zim::Archive archive(tempPath);
-
-  EXPECT_MISSING_ENTRY(archive, "missingTarget");
-
-  // XXX: The unit test now reflects the bug rather than imposes
-  // XXX: the desired behavior.
-  //EXPECT_MISSING_ENTRY(archive, "redirectA");
-  //EXPECT_MISSING_ENTRY(archive, "redirectB");
-  ASSERT_REDIRECT_ENTRY(archive, "redirectA", "redirectB");
-  ASSERT_REDIRECT_ENTRY(archive, "redirectB", "1st");
-
-  EXPECT_MISSING_ENTRY(archive, "redirectC");
+  EXPECT_THROW(creator.finishZimCreation(), zim::CreatorError);
 }
 
 TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -42,6 +42,15 @@ namespace
 
 using namespace zim;
 
+#define ASSERT_REDIRECT_ENTRY(archive, path, targetPath) \
+{\
+  ASSERT_NO_THROW(archive.getEntryByPath(path)); \
+  const auto entry = archive.getEntryByPath(path); \
+  ASSERT_TRUE(entry.isRedirect()); \
+  ASSERT_EQ(entry.getRedirectEntry().getPath(), targetPath); \
+}
+
+
 struct NoneType {};
 const NoneType None;
 
@@ -352,5 +361,27 @@ TEST(ZimCreator, interruptedZimCreation)
   );
 }
 
+
+TEST(ZimCreator, handlingOfRedirectionLoops)
+{
+  unittests::TempFile temp("zimfile");
+  const auto tempPath = temp.path();
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(tempPath);
+
+  creator.addRedirection("redirectA", "A -> B", "redirectB");
+  creator.addRedirection("redirectB", "B -> C", "redirectC");
+  creator.addRedirection("redirectC", "C -> A", "redirectA");
+
+  creator.finishZimCreation();
+
+  const zim::Archive archive(tempPath);
+
+  ASSERT_REDIRECT_ENTRY(archive, "redirectA", "redirectB");
+  ASSERT_REDIRECT_ENTRY(archive, "redirectB", "redirectC");
+  ASSERT_REDIRECT_ENTRY(archive, "redirectC", "redirectA");
+}
 
 } // unnamed namespace

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -45,6 +45,14 @@ using namespace zim;
 struct NoneType {};
 const NoneType None;
 
+zim::Uuid makeSafeUuid() {
+  zim::Uuid uuid;
+  // Force special char in the uuid to be sure they are not handled particularly
+  uuid.data[5] = '\n';
+  uuid.data[10] = '\0';
+  return uuid;
+}
+
 template<typename T>
 struct Optional{
   Optional(NoneType none) : active(false) {};
@@ -106,13 +114,9 @@ TEST(ZimCreator, createEmptyZim)
 {
   unittests::TempFile temp("emptyzimfile");
   auto tempPath = temp.path();
-  zim::Uuid uuid;
-  // Force special char in the uuid to be sure they are not handled particularly.
-  uuid.data[5] = '\n';
-  uuid.data[10] = '\0';
 
   writer::Creator creator;
-  creator.setUuid(uuid);
+  creator.setUuid(makeSafeUuid());
   creator.startZimCreation(tempPath);
   creator.finishZimCreation();
 
@@ -171,13 +175,9 @@ TEST(ZimCreator, createZim)
 {
   unittests::TempFile temp("zimfile");
   auto tempPath = temp.path();
-  zim::Uuid uuid;
-  // Force special char in the uuid to be sure they are not handled particularly.
-  uuid.data[5] = '\n';
-  uuid.data[10] = '\0';
 
   writer::Creator creator;
-  creator.setUuid(uuid);
+  creator.setUuid(makeSafeUuid());
   creator.configIndexing(true, "eng");
   creator.startZimCreation(tempPath);
   creator.addRedirection("foo", "WrongRedirection", "foobar", {{zim::writer::FRONT_ARTICLE, true}}); // Will be replaced by item

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -363,7 +363,7 @@ TEST(ZimCreator, interruptedZimCreation)
   );
 }
 
-TEST(ZimCreator, handlingOfBlindChainsOfRedirections)
+TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
 {
   unittests::TempFile temp("zimfile");
   const auto tempPath = temp.path();
@@ -377,52 +377,68 @@ TEST(ZimCreator, handlingOfBlindChainsOfRedirections)
   // Create a blind ascending chain of redirects, i.e. a chain
   // of redirects where the last entry of the chain is an invalid redirect
   // and the rest are of the form (path1 -> path2) where path1 < path2
-  creator.addRedirection("ascendingChain/redirectA",
+  creator.addRedirection("redirectA",
                          "First redirect in an ascending blind chain",
-                         "ascendingChain/redirectB");
+                         "redirectB");
 
-  creator.addRedirection("ascendingChain/redirectB",
+  creator.addRedirection("redirectB",
                          "Middle redirect in an ascending blind chain",
-                         "ascendingChain/redirectC");
+                         "redirectC");
 
-  creator.addRedirection("ascendingChain/redirectC",
+  creator.addRedirection("redirectC",
                          "Last redirect in an ascending blind chain",
-                         "ascendingChain/missingTarget");
-
-  // Create a blind descending chain of redirects, i.e. a chain
-  // of redirects where the last entry of the chain is an invalid redirect
-  // and the rest are of the form (path1 -> path2) where path1 > path2
-  creator.addRedirection("descendingChain/redirectC",
-                         "First redirect in a descending blind chain",
-                         "descendingChain/redirectB");
-
-  creator.addRedirection("descendingChain/redirectB",
-                         "Middle redirect in a descending blind chain",
-                         "descendingChain/redirectA");
-
-  creator.addRedirection("descendingChain/redirectA",
-                         "Last redirect in a descending blind chain",
-                         "descendingChain/missingTarget");
+                         "missingTarget");
 
   creator.finishZimCreation();
 
   const zim::Archive archive(tempPath);
 
-  EXPECT_MISSING_ENTRY(archive, "ascendingChain/missingTarget");
+  EXPECT_MISSING_ENTRY(archive, "missingTarget");
 
   // XXX: The unit test now reflects the bug rather than imposes
   // XXX: the desired behavior.
-  //EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectA");
-  //EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectB");
-  ASSERT_REDIRECT_ENTRY(archive, "ascendingChain/redirectA", "ascendingChain/redirectB");
-  ASSERT_REDIRECT_ENTRY(archive, "ascendingChain/redirectB", "1st");
+  //EXPECT_MISSING_ENTRY(archive, "redirectA");
+  //EXPECT_MISSING_ENTRY(archive, "redirectB");
+  ASSERT_REDIRECT_ENTRY(archive, "redirectA", "redirectB");
+  ASSERT_REDIRECT_ENTRY(archive, "redirectB", "1st");
 
-  EXPECT_MISSING_ENTRY(archive, "ascendingChain/redirectC");
+  EXPECT_MISSING_ENTRY(archive, "redirectC");
+}
 
-  EXPECT_MISSING_ENTRY(archive, "descendingChain/missingTarget");
-  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectA");
-  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectB");
-  EXPECT_MISSING_ENTRY(archive, "descendingChain/redirectC");
+TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
+{
+  unittests::TempFile temp("zimfile");
+  const auto tempPath = temp.path();
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(tempPath);
+
+  creator.addItem(std::make_shared<TestItem>("1st", "1st entry in ZIM", ""));
+
+  // Create a blind descending chain of redirects, i.e. a chain
+  // of redirects where the last entry of the chain is an invalid redirect
+  // and the rest are of the form (path1 -> path2) where path1 > path2
+  creator.addRedirection("redirectC",
+                         "First redirect in a descending blind chain",
+                         "redirectB");
+
+  creator.addRedirection("redirectB",
+                         "Middle redirect in a descending blind chain",
+                         "redirectA");
+
+  creator.addRedirection("redirectA",
+                         "Last redirect in a descending blind chain",
+                         "missingTarget");
+
+  creator.finishZimCreation();
+
+  const zim::Archive archive(tempPath);
+
+  EXPECT_MISSING_ENTRY(archive, "missingTarget");
+  EXPECT_MISSING_ENTRY(archive, "redirectA");
+  EXPECT_MISSING_ENTRY(archive, "redirectB");
+  EXPECT_MISSING_ENTRY(archive, "redirectC");
 }
 
 TEST(ZimCreator, handlingOfRedirectionLoops)

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -55,7 +55,7 @@ zim::Dirent read_from_buffer(const zim::Buffer& buf)
   return *direntReader.readDirent(zim::offset_t(0));
 }
 
-size_t writenDirentSize(const zim::writer::Dirent& dirent)
+size_t writtenDirentSize(const zim::writer::Dirent& dirent)
 {
   TempFile tmpFile("test_dirent");
   const auto tmp_fd = tmpFile.fd();
@@ -184,13 +184,21 @@ TEST(DirentTest, read_write_redirect_dirent)
 
 TEST(DirentTest, dirent_size)
 {
+  // Needed so that writtenDirentSize() can be called on the test dirents
+  zim::writer::Cluster cluster(zim::Compression::None);
+  cluster.setClusterIndex(zim::cluster_index_t(0));
+
   // case path set, title empty, extralen empty
   zim::writer::Dirent dirent(NS::C, "Bar", "", 17);
-  ASSERT_EQ(dirent.getDirentSize(), writenDirentSize(dirent));
+  dirent.setCluster(&cluster); // otherwise writtenDirentSize will crash
+
+  ASSERT_EQ(dirent.getDirentSize(), writtenDirentSize(dirent));
 
   // case path set, title set, extralen empty
   zim::writer::Dirent dirent2(NS::C, "Bar", "Foo", 17);
-  ASSERT_EQ(dirent2.getDirentSize(), writenDirentSize(dirent2));
+  dirent2.setCluster(&cluster); // otherwise writtenDirentSize will crash
+
+  ASSERT_EQ(dirent2.getDirentSize(), writtenDirentSize(dirent2));
 }
 
 TEST(DirentTest, redirect_dirent_size)
@@ -200,7 +208,7 @@ TEST(DirentTest, redirect_dirent_size)
   zim::writer::Dirent dirent(NS::C, "Bar", "", NS::C, "Foo");
   dirent.setRedirect(&targetDirent);
 
-  ASSERT_EQ(dirent.getDirentSize(), writenDirentSize(dirent));
+  ASSERT_EQ(dirent.getDirentSize(), writtenDirentSize(dirent));
 }
 
 }  // namespace

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -67,16 +67,16 @@ size_t writenDirentSize(const zim::writer::Dirent& dirent)
 TEST(DirentTest, size)
 {
 #ifdef _WIN32
-  ASSERT_EQ(sizeof(zim::writer::Dirent), 72U);
+  ASSERT_EQ(sizeof(zim::writer::Dirent), 64U);
 #else
-  // Dirent's size is important for us as we are creating huge zim files on linux
-  // and we need to store a lot of dirents.
+  // Dirent's size is important for us as we are creating huge zim files on
+  // Linux and we need to store a lot of dirents.
   // Be sure that dirent's size is not increased by any change.
 #if ENV32BIT
   // On 32 bits, Dirent is smaller.
-  ASSERT_EQ(sizeof(zim::writer::Dirent), 30U);
+  ASSERT_EQ(sizeof(zim::writer::Dirent), 22U);
 #else
-  ASSERT_EQ(sizeof(zim::writer::Dirent), 38U);
+  ASSERT_EQ(sizeof(zim::writer::Dirent), 30U);
 #endif
 #endif
 }

--- a/test/error_in_creator.cpp
+++ b/test/error_in_creator.cpp
@@ -31,6 +31,9 @@
 namespace
 {
 
+#define EXPECT_MISSING_ENTRY(archive, path)  \
+  EXPECT_THROW(archive.getEntryByPath(path), zim::EntryNotFound)
+
 using namespace zim;
 
 enum class ERRORKIND {
@@ -180,6 +183,10 @@ TEST_P(FaultyItemErrorTest, faultyItem)
   EXPECT_THROW(creator.addItem(item), SimulatedFaultError);
   // As the error is directly reported, finishZimCreation report nothing.
   EXPECT_NO_THROW(creator.finishZimCreation());
+
+  const zim::Archive archive(tempPath);
+
+  EXPECT_MISSING_ENTRY(archive, "foo");
 }
 
 const auto errorKinds = {


### PR DESCRIPTION
Fixes #1059 

This is the easy part of the optimization addressing #1048.

Using the test flow from #1045:

```python
def test_creator_many_redirects(fpath, lipsum):
    random.seed(123)
    with Creator(fpath) as c:
        for item_i in range(1000000):
            c.add_item(StaticItem(path=f"dedup{item_i}", content=lipsum, mimetype="text/html"))
            for redirect_i in range(10):
                to_index = random.randint(0, item_i)
                c.add_redirection(f"home{item_i}{redirect_i}", "", f"dedup{to_index}", {})
```

the performance figures changed as follows:

|      | High watermark memory usage (MB) | Runtime (seconds) |
|--------------------|----------|-------------|
| main branch | 2241 | 661 |
| This PR | 1690 | 540 |

As you can see, there is improvement in speed too.

UPDATE: These measurements were performed before additional work related to #1056 and #1059 was carried out in this same PR.