### PR TITLE
User-configurable mode for handling dangling redirects during ZIM creation 

### DIFF
--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -336,7 +336,7 @@ namespace zim
         size_t m_clusterSize;
         std::string m_indexingLanguage;
         unsigned m_nbWorkers = 4;
-        ProblemHandlingMode m_danglingRedirectHandlingMode = ELIMINATE;
+        ProblemHandlingMode m_danglingRedirectHandlingMode = DEFER;
 
         // zim data
         std::string m_mainPath;

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -35,6 +35,20 @@ namespace zim
     class CreatorData;
 
     /**
+     * During ZIM file creation certain problematic situations may arise
+     * (for example, dangling redirects may remain). The `ProblemHandlingMode`
+     * enum type is intended to tell the `Creator` how to deal with such
+     * situations.
+     */
+    enum ProblemHandlingMode
+    {
+      /**
+       * The source of the problematic situation must be eliminated.
+       */
+      ELIMINATE
+    };
+
+    /**
      * The `Creator` is responsible to create a zim file.
      *
      * Once the `Creator` is instantiated, it can be configured with the
@@ -141,6 +155,17 @@ namespace zim
          * @return a reference to itself.
          */
         Creator& configNbWorkers(unsigned nbWorkers);
+
+        /**
+         * Define what to do about dangling redirects.
+         *
+         * - `ELIMINATE`: eliminate any dangling redirects remaining by the end
+         *   of ZIM creation.
+         *
+         * @param mode the mode to use with regard to dangling redirects
+         * @return a reference to itself.
+         */
+        Creator& configDanglingRedirectHandling(ProblemHandlingMode mode);
 
         /**
          * Start the zim creation.
@@ -289,6 +314,7 @@ namespace zim
         size_t m_clusterSize;
         std::string m_indexingLanguage;
         unsigned m_nbWorkers = 4;
+        ProblemHandlingMode m_danglingRedirectHandlingMode = ELIMINATE;
 
         // zim data
         std::string m_mainPath;

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -49,6 +49,11 @@ namespace zim
       PREVENT,
 
       /**
+       * The problematic situation must be deferred until the finalization step.
+       */
+      DEFER,
+
+      /**
        * The source of the problematic situation must be eliminated.
        */
       ELIMINATE
@@ -167,6 +172,9 @@ namespace zim
          *
          * - `PREVENT`: an attempt to add a redirect with a non-existent target
          *   is rejected right away.
+         *
+         * - `DEFER`: dangling redirects must be checked and reported (via an
+         *   exception) by `finishZimCreation()`.
          *
          * - `ELIMINATE`: eliminate any dangling redirects remaining by the end
          *   of ZIM creation.

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -43,6 +43,12 @@ namespace zim
     enum ProblemHandlingMode
     {
       /**
+       * The problematic situation must be prevented from being introduced even
+       * if it can be corrected by subsequent operations.
+       */
+      PREVENT,
+
+      /**
        * The source of the problematic situation must be eliminated.
        */
       ELIMINATE
@@ -159,6 +165,9 @@ namespace zim
         /**
          * Define what to do about dangling redirects.
          *
+         * - `PREVENT`: an attempt to add a redirect with a non-existent target
+         *   is rejected right away.
+         *
          * - `ELIMINATE`: eliminate any dangling redirects remaining by the end
          *   of ZIM creation.
          *
@@ -243,6 +252,11 @@ namespace zim
          * Hints (especially FRONT_ARTICLE) can be used to put the redirection
          * in the front articles list.
          * By default, redirections are not front article.
+         *
+         * If the [mode](@ref configDanglingRedirectHandling()) of handling of
+         * dangling redirects is set to `PREVENT`, an attempt to add a
+         * redirection to a non-existent target will throw a
+         * `zim::InvalidEntry` exception.
          *
          * @param path the path of the redirection.
          * @param title the title of the redirection.

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -238,6 +238,13 @@ void Creator::addIllustration(unsigned int size, std::unique_ptr<ContentProvider
 void Creator::addRedirection(const std::string& path, const std::string& title, const std::string& targetPath, const Hints& hints)
 {
   checkError();
+  if ( m_danglingRedirectHandlingMode == PREVENT ) {
+    Dirent tmpDirent(NS::C, targetPath);
+    if ( data->dirents.find(&tmpDirent) == data->dirents.end() ) {
+      throw zim::InvalidEntry("C/" + targetPath + " doesn't exist");
+    }
+  }
+
   auto dirent = data->createRedirectDirent(NS::C, path, title, NS::C, targetPath);
   if (data->dirents.size()%1000 == 0){
     TPROGRESS();

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -292,7 +292,7 @@ void Creator::finishZimCreation()
   // Now we have all the dirents (but not the data), we must correctly set/fix the dirents
   // before we ask data to the handlers
   TINFO("ResolveRedirectIndexes");
-  data->resolveRedirectIndexes();
+  data->resolveRedirectIndexes(m_danglingRedirectHandlingMode == ELIMINATE);
 
   TINFO("Set entry indexes");
   data->setEntryIndexes();
@@ -711,7 +711,7 @@ void CreatorData::setEntryIndexes()
   }
 }
 
-void CreatorData::resolveRedirectIndexes()
+void CreatorData::resolveRedirectIndexes(bool dropDanglingRedirects)
 {
   // translate redirect aid to index
   INFO("Resolve redirect");
@@ -726,11 +726,17 @@ void CreatorData::resolveRedirectIndexes()
     Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
     auto target_pos = dirents.find(&tmpDirent);
     if(target_pos == dirents.end()) {
-      INFO("Invalid redirection "
+      Formatter fmt;
+      fmt << "Invalid redirection "
           << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
           << " redirecting to (missing) "
-          << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
-      it = removeDirent(it);
+          << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath();
+      if ( dropDanglingRedirects ) {
+        INFO(fmt);
+        it = removeDirent(it);
+      } else {
+        throw zim::InvalidEntry(fmt);
+      }
     } else  {
       dirent->setRedirect(*target_pos);
       ++it;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -156,6 +156,12 @@ Creator& Creator::configNbWorkers(unsigned nbWorkers)
   return *this;
 }
 
+Creator& Creator::configDanglingRedirectHandling(ProblemHandlingMode mode)
+{
+  m_danglingRedirectHandlingMode = mode;
+  return *this;
+}
+
 void Creator::startZimCreation(const std::string& filepath)
 {
   data = std::unique_ptr<CreatorData>(

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -79,7 +79,7 @@ namespace zim
         Cluster* closeCluster(bool compressed);
 
         void setEntryIndexes();
-        void resolveRedirectIndexes();
+        void resolveRedirectIndexes(bool dropDanglingRedirects);
         void resolveMimeTypes();
 
         uint16_t getMimeTypeIdx(const std::string& mimeType);

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -183,7 +183,6 @@ TEST_F(ZimArchive, openCreatedArchive)
   creator.addIllustration(zim::IllustrationInfo{96, 96, 1, {}}, "PNGBinaryContent96");
   creator.setMainPath("foo");
   creator.addRedirection("foo3", "FooRedirection", "foo"); // No a front article.
-  creator.addRedirection("foo4", "FooRedirection", "NoExistant"); // Invalid redirection, must be removed by creator
   creator.finishZimCreation();
 
   zim::Archive archive(tempPath);

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -384,6 +384,34 @@ void testAutoEliminationOfDanglingRedirects(zim::writer::Creator& creator, const
   EXPECT_MISSING_ENTRY(archive, "bad_redirect");
 }
 
+void testDelayedRejectionOfDanglingRedirects(zim::writer::Creator& creator, const std::string& zimPath)
+{
+  creator.setUuid(makeSafeUuid());
+
+  creator.startZimCreation(zimPath);
+
+  creator.addItem(std::make_shared<TestItem>("1st", "1st entry in ZIM", ""));
+
+  EXPECT_NO_THROW(creator.addRedirection("good_redirect", "title", "1st"));
+
+  EXPECT_NO_THROW(
+      creator.addRedirection("bad_redirect", "title", "nonexistent/target/path")
+  );
+
+  EXPECT_THROW(creator.finishZimCreation(), zim::InvalidEntry);
+}
+
+TEST(ZimCreator, delayedRejectionOfDanglingRedirects)
+{
+  unittests::TempFile temp("zimfile");
+
+  writer::Creator creator;
+
+  creator.configDanglingRedirectHandling(zim::writer::DEFER);
+
+  testDelayedRejectionOfDanglingRedirects(creator, temp.path());
+}
+
 TEST(ZimCreator, defaultHandlingOfDanglingRedirects)
 {
   unittests::TempFile temp("zimfile");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -363,6 +363,35 @@ TEST(ZimCreator, interruptedZimCreation)
   );
 }
 
+void testAutoEliminationOfDanglingRedirects(zim::writer::Creator& creator, const std::string& zimPath)
+{
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(zimPath);
+
+  creator.addItem(std::make_shared<TestItem>("1st", "1st entry in ZIM", ""));
+
+  EXPECT_NO_THROW(creator.addRedirection("good_redirect", "title", "1st"));
+
+  EXPECT_NO_THROW(
+      creator.addRedirection("bad_redirect", "title", "nonexistent/target/path")
+  );
+
+  EXPECT_NO_THROW(creator.finishZimCreation());
+
+  const zim::Archive archive(zimPath);
+
+  ASSERT_REDIRECT_ENTRY(archive, "good_redirect", "1st");
+  EXPECT_MISSING_ENTRY(archive, "bad_redirect");
+}
+
+TEST(ZimCreator, defaultHandlingOfDanglingRedirects)
+{
+  unittests::TempFile temp("zimfile");
+
+  writer::Creator creator;
+  testAutoEliminationOfDanglingRedirects(creator, temp.path());
+}
+
 TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
 {
   unittests::TempFile temp("zimfile");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -403,6 +403,33 @@ TEST(ZimCreator, autoEliminationOfDanglingRedirects)
   testAutoEliminationOfDanglingRedirects(creator, temp.path());
 }
 
+TEST(ZimCreator, immediateRejectionOfDanglingRedirects)
+{
+  unittests::TempFile temp("zimfile");
+  const auto tempPath = temp.path();
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+
+  creator.configDanglingRedirectHandling(zim::writer::PREVENT);
+
+  creator.startZimCreation(tempPath);
+
+  creator.addItem(std::make_shared<TestItem>("1st", "1st entry in ZIM", ""));
+
+  EXPECT_THROW(
+      creator.addRedirection("path", "title", "nonexistent/target/path"),
+      zim::InvalidEntry
+  );
+
+  EXPECT_NO_THROW(creator.addRedirection("path", "title", "1st"));
+
+  EXPECT_NO_THROW(creator.finishZimCreation());
+
+  const zim::Archive archive(tempPath);
+  ASSERT_REDIRECT_ENTRY(archive, "path", "1st");
+}
+
 TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
 {
   unittests::TempFile temp("zimfile");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -392,6 +392,17 @@ TEST(ZimCreator, defaultHandlingOfDanglingRedirects)
   testAutoEliminationOfDanglingRedirects(creator, temp.path());
 }
 
+TEST(ZimCreator, autoEliminationOfDanglingRedirects)
+{
+  unittests::TempFile temp("zimfile");
+
+  writer::Creator creator;
+
+  creator.configDanglingRedirectHandling(zim::writer::ELIMINATE);
+
+  testAutoEliminationOfDanglingRedirects(creator, temp.path());
+}
+
 TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
 {
   unittests::TempFile temp("zimfile");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -205,7 +205,6 @@ TEST(ZimCreator, createZim)
   creator.setMainPath("foo");
   creator.addRedirection("foo3", "FooRedirection", "foo"); // Not a front article.
   creator.addAlias("foo_ter", "The same redirection", "foo3", {{ zim::writer::FRONT_ARTICLE, true}}); // a clone of the previous redirect, but as a front article.
-  creator.addRedirection("foo4", "FooRedirection", "NoExistant", {{zim::writer::FRONT_ARTICLE, true}}); // Invalid redirection, must be removed by creator
   creator.finishZimCreation();
 
   // Do not use the high level Archive to test that zim file is correctly created but lower structure.
@@ -417,7 +416,7 @@ TEST(ZimCreator, defaultHandlingOfDanglingRedirects)
   unittests::TempFile temp("zimfile");
 
   writer::Creator creator;
-  testAutoEliminationOfDanglingRedirects(creator, temp.path());
+  testDelayedRejectionOfDanglingRedirects(creator, temp.path());
 }
 
 TEST(ZimCreator, autoEliminationOfDanglingRedirects)
@@ -464,6 +463,7 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
   const auto tempPath = temp.path();
 
   writer::Creator creator;
+  creator.configDanglingRedirectHandling(zim::writer::ELIMINATE);
   creator.setUuid(makeSafeUuid());
   creator.startZimCreation(tempPath);
 
@@ -493,6 +493,7 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
   const auto tempPath = temp.path();
 
   writer::Creator creator;
+  creator.configDanglingRedirectHandling(zim::writer::ELIMINATE);
   creator.setUuid(makeSafeUuid());
   creator.startZimCreation(tempPath);
 


### PR DESCRIPTION
Addresses #1056 without fixing the reported inconsistency in the outcome of attempting to remove a blind chain of redirects.