### PR TITLE
Elimination of blind chains of redirections and redirection loops during ZIM creation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import os
 # -- Project information -----------------------------------------------------
 
 project = 'libzim'
-copyright = '2020, libzim-team'
+copyright = '2026, libzim-team'
 author = 'libzim-team'
 
 

--- a/include/zim/writer/creator.h
+++ b/include/zim/writer/creator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017-2021 Matthieu Gautier <mgautier@kymeria.fr>
- * Copyright (C) 2020 Veloman Yunkan
+ * Copyright (C) 2020, 2026 Veloman Yunkan
  * Copyright (C) 2009 Tommi Maekitalo
  *
  * This program is free software; you can redistribute it and/or
@@ -35,18 +35,17 @@ namespace zim
     class CreatorData;
 
     /**
-     * The `Creator` is responsible to create a zim file.
+     * A ZIM file should be created via `Creator` as follows:
      *
-     * Once the `Creator` is instantiated, it can be configured with the
-     * `config*` methods.
-     * Then the creation process must be started with `startZimCreation`.
-     * Elements of the zim file can be added using the `add*` methods.
-     * The final steps is to call `finishZimCreation`.
+     * 1. Instantiate the `Creator` object.
+     * 2. Configure it via the `config*()` methods as needed.
+     * 3. Start ZIM creation with `startZimCreation()`.
+     * 4. Add data to the ZIM file using the `add*()` methods.
+     * 5. Set special data records in the ZIM file with the `set*()` methods
+     *    (these are optional and may precede the data addition step).
+     * 6. Finish ZIM creation with `finishZimCreation()`.
      *
-     * During the creation of the zim file (and before the call to
-     * `finishZimCreation`), some values must be set using the `set*` methods.
-     *
-     * All `add*` methods and `finishZimCreation` can throw an exception.
+     * All `add*()` methods and `finishZimCreation()` can throw an exception
      * (most of the time - though not necessarily - a subclass of
      * zim::CreatorError). It is up to the user to catch this exception and
      * handle the error.
@@ -75,7 +74,7 @@ namespace zim
      *
      * - Any other exception thrown for unknown reason.
      *
-     * By default, creator status is not changed by thrown exception and
+     * By default, the creator status is not changed by the thrown exception and
      * creation should stop.
      */
     class LIBZIM_API Creator
@@ -83,9 +82,6 @@ namespace zim
       public:
         /**
          * Creator constructor.
-         *
-         * @param verbose If the creator print verbose information.
-         * @param comptype The compression algorithm to use.
          */
         Creator();
         virtual ~Creator();
@@ -93,7 +89,7 @@ namespace zim
         /**
          * Configure the verbosity of the creator
          *
-         * @param verbose if the creator print verbose information.
+         * @param verbose whether the creator should print verbose information.
          * @return a reference to itself.
          */
         Creator& configVerbose(bool verbose);
@@ -109,18 +105,21 @@ namespace zim
         /**
          * Set the size of the created clusters.
          *
-         * The creator will try to create cluster with (uncompressed) size
-         * as close as possible to targetSize without exceeding that limit.
-         * If not possible, the only such case being an item larger than targetSize,
-         * a separated cluster will be allocated for that oversized item.
+         * The creator will try to create clusters with (uncompressed) size as
+         * close as possible to `targetSize` without exceeding that limit.  If
+         * not possible (the only such case being an item larger than
+         * `targetSize`) a separate cluster will be allocated for that
+         * oversized item.
          *
-         * Be carefull with this value.
-         * Bigger value means more content put together, so a better compression ratio.
-         * But it means also that more decompression has to be made when reading a blob.
-         * If you don't know which value to put, don't use this method and let libzim
+         * Be careful with this value!
+         *
+         * Bigger value means more content put together, so a better
+         * compression ratio. But it means also that more decompression has to
+         * be done when reading a single item from a cluster. If you don't know
+         * what value to use, don't configure the cluster size and let libzim
          * use the default value.
          *
-         * @param targetSize The target size of a cluster (in byte).
+         * @param targetSize The target size of a cluster (in bytes).
          * @return a reference to itself.
          */
         Creator& configClusterSize(zim::size_type targetSize);
@@ -143,16 +142,16 @@ namespace zim
         Creator& configNbWorkers(unsigned nbWorkers);
 
         /**
-         * Start the zim creation.
+         * Start ZIM file creation.
          *
          * The creator must have been configured before calling this method.
          *
-         * @param filepath the path of the zim file to create.
+         * @param filepath the path of the ZIM file to create.
          */
         void startZimCreation(const std::string& filepath);
 
         /**
-         * Add a item to the archive.
+         * Add an item to the archive.
          *
          * @param item The item to add.
          */
@@ -163,20 +162,25 @@ namespace zim
          *
          * @param name the name of the metadata
          * @param content the content of the metadata
-         * @param mimetype the mimetype of the metadata.
-         *                 Only used to detect if the metadata must be compressed or not.
+         * @param mimetype the mimetype of the metadata. Only used to detect if
+         *        the metadata must be compressed or not.
          */
-        void addMetadata(const std::string& name, const std::string& content, const std::string& mimetype = "text/plain;charset=utf-8");
+        void addMetadata(const std::string& name,
+                         const std::string& content,
+                         const std::string& mimetype = "text/plain;charset=utf-8");
 
         /**
-         * Add a metadata to the archive using a contentProvider instead of plain string.
+         * Add a metadata to the archive using a contentProvider instead of a
+         * plain string.
          *
          * @param name the name of the metadata.
          * @param provider the provider of the content of the metadata.
-         * @param mimetype the mimetype of the metadata.
-         *                 Only used to detect if the metadata must be compressed.
+         * @param mimetype the mimetype of the metadata. Only used to detect if
+         *        the metadata must be compressed.
          */
-        void addMetadata(const std::string& name, std::unique_ptr<ContentProvider> provider, const std::string& mimetype = "text/plain;charset=utf-8");
+        void addMetadata(const std::string& name,
+                         std::unique_ptr<ContentProvider> provider,
+                         const std::string& mimetype = "text/plain;charset=utf-8");
 
         /**
          * Add illustration to the archive.
@@ -185,7 +189,8 @@ namespace zim
          * @param content the content of the illustration (must be a png
          *        content)
          */
-        void addIllustration(const IllustrationInfo& ii, const std::string& content);
+        void addIllustration(const IllustrationInfo& ii,
+                             const std::string& content);
 
         /**
          * Add illustration to the archive.
@@ -194,13 +199,15 @@ namespace zim
          * @param provider the provider of the content of the illustration
          *        (must be a png content)
          */
-        void addIllustration(const IllustrationInfo& ii, std::unique_ptr<ContentProvider> provider);
+        void addIllustration(const IllustrationInfo& ii,
+                             std::unique_ptr<ContentProvider> provider);
 
         /**
          * Add illustration to the archive.
          *
          * @param size the size (width and height) of the illustration.
-         * @param content the content of the illustration (must be a png content)
+         * @param content the content of the illustration (must be a png
+         *        content)
          */
         void addIllustration(unsigned int size, const std::string& content);
 
@@ -208,21 +215,32 @@ namespace zim
          * Add illustration to the archive.
          *
          * @param size the size (width and height) of the illustration.
-         * @param provider the provider of the content of the illustration (must be a png content)
+         * @param provider the provider of the content of the illustration
+         *        (must be a png content)
          */
-        void addIllustration(unsigned int size, std::unique_ptr<ContentProvider> provider);
+        void addIllustration(unsigned int size,
+                             std::unique_ptr<ContentProvider> provider);
 
         /**
-         * Add a redirection to the archive.
+         * Add a redirection entry to the archive.
+         *
+         * A redirection is an entry pointing to another entry (it is an analog
+         * of a symbolic link in a file system).
+         *
+         * `addRedirection()` allows creating a redirection to a
+         * not-yet-existent target entry, subject to the condition that the
+         * target entry is present when `finishZimCreation()` is called (see
+         * its documentation for additional information on the handling of
+         * invalid redirections).
          *
          * Hints (especially FRONT_ARTICLE) can be used to put the redirection
          * in the front articles list.
          * By default, redirections are not front article.
          *
-         * @param path the path of the redirection.
-         * @param title the title of the redirection.
+         * @param path the path of the redirection entry.
+         * @param title the title of the redirection entry.
          * @param targetpath the path of the target of the redirection.
-         * @param hints hints associated to the redirection.
+         * @param hints hints associated with the redirection.
          */
         void addRedirection(
             const std::string& path,
@@ -231,37 +249,46 @@ namespace zim
             const Hints& hints = Hints());
 
 
-        /**
-         * Add a alias of a existing entry.
+        /** Add an alias of an existing entry.
          *
-         * The existing entry pointed by `targetPath` is cloned and updated with
-         * `path` and `title`.
+         * An alias is an entry sharing data with another entry (it is an
+         * analog of a hard link in a file system).
          *
-         * The alias entry will shared the same type (redirection or item)
-         * and namespace than `targetPath`.
+         * `addAlias()` clones the existing entry found at `targetPath`, sets
+         * its title to `title` and stores the result under `path`.
          *
-         * If the `targetPath` is a item, the new entry will be item pointing
-         * to the same data than `targetPath` item. (Not a redirection to `targetPath`).
-         * However, the alias entry is not counted in the media type counter
-         * and it is not fulltext indexed (only title indexed).
+         * The alias entry will have the same type (redirection or item) as the
+         * source entry.
          *
-         * Hints can be given to influence creator handling (front article, ...)
-         * as it is done for redirection.
+         * If the source entry is an item, the new entry will be an item
+         * sharing the same MIME type and data with the existing item. (This is
+         * different from the creation of a [redirection](@ref addRedirection())
+         * to `targetPath`). However, the alias entry is not counted in the
+         * media type counter and it is not fulltext indexed (only title
+         * indexed).
          *
-         * @param path the path of the alias
-         * @param title the title of the alias
-         * @param targetPath the path of the aliased entry.
-         * @param hints hints associated to the alias.
+         * Hints can be given to influence creator handling (front article,
+         * ...) as it is done for redirections.
+         *
+         * @param path the path of the alias (new) entry.  @param title the
+         * title of the alias (new) entry.  @param targetPath the path of the
+         * aliased (existing) entry.  @param hints hints associated with the
+         * alias.
          */
         void addAlias(
             const std::string& path,
             const std::string& title,
             const std::string& targetPath,
-            const Hints& hints = Hints()
-        );
+            const Hints& hints = Hints());
 
         /**
-         * Finalize the zim creation.
+         * Finalize ZIM file creation.
+         *
+         * During this stage invalid redirections and/or redirection chains
+         * are detected and removed. A redirection is invalid if its target
+         * path is missing from the ZIM file. A redirection chain is invalid
+         * if it leads to an invalid redirection or ends with a loop. For
+         * each redirection removed a message is printed on standard output.
          */
         void finishZimCreation();
 

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -65,10 +65,10 @@ namespace zim
         } PACKED;
 
         struct Resolved {
-          Resolved(const Dirent* target) :
+          Resolved(Dirent* target) :
             targetDirent(target)
           {};
-          const Dirent* targetDirent;
+          Dirent* targetDirent;
         } PACKED;
 
       public: // functions
@@ -185,10 +185,13 @@ namespace zim
 
         NS getRedirectNs() const;
         std::string getRedirectPath() const;
-        void setRedirect(const Dirent* target) {
+        void setRedirect(Dirent* target) {
           ASSERT(info.tag, ==, DirentInfo::REDIRECT);
           info.~DirentInfo();
           new(&info) DirentInfo(DirentInfo::Resolved(target));
+        }
+        Dirent* getRedirectTargetDirent() const {
+          return info.getResolved().targetDirent;
         }
         entry_index_t getRedirectIndex() const;
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -108,6 +108,15 @@ namespace writer
 namespace
 {
 
+void reportInvalidRedirect(const Dirent& dirent)
+{
+  INFO("Invalid redirection "
+      << NsAsChar(dirent.getNamespace()) << '/' << dirent.getPath()
+      << " redirecting to (missing) "
+      << NsAsChar(dirent.getRedirectNs()) << '/' << dirent.getRedirectPath()
+  );
+}
+
 InvalidEntry direntConflictError(const Dirent& existingDirent, const Dirent& newDirent)
 {
   Formatter fmt;
@@ -280,6 +289,7 @@ void Creator::finishZimCreation()
   // before we ask data to the handlers
   TINFO("ResolveRedirectIndexes");
   data->resolveRedirectIndexes();
+  data->dropRemovedRedirects();
 
   TINFO("Set entry indexes");
   data->setEntryIndexes();
@@ -702,24 +712,28 @@ void CreatorData::resolveRedirectIndexes()
 {
   // translate redirect aid to index
   INFO("Resolve redirect");
+  for (Dirent* const dirent : dirents)
+  {
+    if ( dirent->isRedirect() ) {
+      Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
+      const auto targetDirentIt = dirents.find(&tmpDirent);
+      if ( targetDirentIt == dirents.end() || (*targetDirentIt)->isRemoved() ) {
+        reportInvalidRedirect(*dirent);
+        dirent->markRemoved();
+      } else  {
+        dirent->setRedirect(*targetDirentIt);
+      }
+    }
+  }
+}
+
+void CreatorData::dropRemovedRedirects()
+{
   for (auto it = dirents.begin(); it != dirents.end(); )
   {
-    Dirent* dirent = *it;
-    if ( !dirent->isRedirect() ) {
-      ++it;
-      continue;
-    }
-
-    Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
-    auto target_pos = dirents.find(&tmpDirent);
-    if(target_pos == dirents.end()) {
-      INFO("Invalid redirection "
-          << NsAsChar(dirent->getNamespace()) << '/' << dirent->getPath()
-          << " redirecting to (missing) "
-          << NsAsChar(dirent->getRedirectNs()) << '/' << dirent->getRedirectPath());
+    if ( (*it)->isRemoved() ) {
       it = removeDirent(it);
     } else  {
-      dirent->setRedirect(*target_pos);
       ++it;
     }
   }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -110,7 +110,7 @@ namespace
 
 void reportInvalidRedirect(const Dirent& dirent)
 {
-  INFO("Invalid redirection "
+  INFO("Removing invalid redirection "
       << NsAsChar(dirent.getNamespace()) << '/' << dirent.getPath()
       << " redirecting to (missing) "
       << NsAsChar(dirent.getRedirectNs()) << '/' << dirent.getRedirectPath()
@@ -124,6 +124,37 @@ InvalidEntry direntConflictError(const Dirent& existingDirent, const Dirent& new
       << "  dirent's title to add is : " << newDirent.getTitle() << "\n"
       << "  existing dirent's title is : " << existingDirent.getTitle() << "\n";
   return InvalidEntry(fmt);
+}
+
+entry_index_type markRedirectChain(Dirent* d, entry_index_type i)
+{
+  ASSERT(d->isRemoved(), ==, false);
+
+  const entry_index_type startingIndex = i;
+  while ( !d->isItem() ) {
+    d->setIdx(entry_index_t(i++));
+    d = d->getRedirectTargetDirent();
+    if ( d->isRemoved() || d->getIdx().v >= startingIndex ) {
+      // hit a dead end or detected being caught in a loop
+      return startingIndex;
+    }
+  }
+
+  return i;
+}
+
+void markBlindRedirectChainForRemoval(Dirent* d)
+{
+  for ( ; !d->isRemoved() ; d = d->getRedirectTargetDirent() ) {
+    const Dirent* const t = d->getRedirectTargetDirent();
+    INFO("Redirection "
+        << NsAsChar(d->getNamespace()) << '/' << d->getPath()
+        << " -> "
+        << NsAsChar(t->getNamespace()) << '/' << t->getPath()
+        << " belongs to a blind chain or loop. Removing..."
+    );
+    d->markRemoved();
+  }
 }
 
 } // unnamed namespace
@@ -289,6 +320,7 @@ void Creator::finishZimCreation()
   // before we ask data to the handlers
   TINFO("ResolveRedirectIndexes");
   data->resolveRedirectIndexes();
+  data->removeLoopsAndBlindChainsOfRedirects();
   data->dropRemovedRedirects();
 
   TINFO("Set entry indexes");
@@ -717,13 +749,38 @@ void CreatorData::resolveRedirectIndexes()
     if ( dirent->isRedirect() ) {
       Dirent tmpDirent(dirent->getRedirectNs(), dirent->getRedirectPath());
       const auto targetDirentIt = dirents.find(&tmpDirent);
-      if ( targetDirentIt == dirents.end() || (*targetDirentIt)->isRemoved() ) {
+      if ( targetDirentIt == dirents.end()) {
         reportInvalidRedirect(*dirent);
         dirent->markRemoved();
       } else  {
         dirent->setRedirect(*targetDirentIt);
       }
     }
+  }
+}
+
+// XXX: This procedure uses the 'idx' field of Dirent and is therefore
+// XXX: implemented under the assumption that Dirent::setIdx() has not yet been
+// XXX: called
+void CreatorData::removeLoopsAndBlindChainsOfRedirects()
+{
+  INFO("Detect loops and/or blind chains of redirects");
+  entry_index_type index = 1;
+  for (Dirent* const d : dirents)
+  {
+    if ( !d->isRemoved() && d->isRedirect() && d->getIdx().v == 0 ) {
+      const entry_index_type newIndex = markRedirectChain(d, index);
+      if ( newIndex == index ) {
+        markBlindRedirectChainForRemoval(d);
+      }
+      index = newIndex;
+    }
+  }
+
+  // Restore/reset Dirent::idx to 0
+  for (Dirent* const d : dirents)
+  {
+    d->setIdx(entry_index_t(0));
   }
 }
 

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -80,6 +80,7 @@ namespace zim
 
         void setEntryIndexes();
         void resolveRedirectIndexes();
+        void dropRemovedRedirects();
         void resolveMimeTypes();
 
         uint16_t getMimeTypeIdx(const std::string& mimeType);

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -80,6 +80,8 @@ namespace zim
 
         void setEntryIndexes();
         void resolveRedirectIndexes();
+        // XXX: This procedure uses the Dirent::idx field
+        void removeLoopsAndBlindChainsOfRedirects();
         void dropRemovedRedirects();
         void resolveMimeTypes();
 

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -38,6 +38,7 @@
 namespace
 {
 
+using zim::unittests::CapturedStderr;
 using zim::unittests::makeTempFile;
 using zim::unittests::getDataFilePath;
 using zim::unittests::TempFile;
@@ -676,27 +677,6 @@ TEST_F(ZimArchive, articleNumber)
   }
 }
 #endif
-
-class CapturedStderr
-{
-  std::ostringstream buffer;
-  std::streambuf* const sbuf;
-public:
-  CapturedStderr()
-    : sbuf(std::cerr.rdbuf())
-  {
-    std::cerr.rdbuf(buffer.rdbuf());
-  }
-
-  CapturedStderr(const CapturedStderr&) = delete;
-
-  ~CapturedStderr()
-  {
-    std::cerr.rdbuf(sbuf);
-  }
-
-  operator std::string() const { return buffer.str(); }
-};
 
 #define EXPECT_BROKEN_ZIMFILE(ZIMPATH, EXPECTED_STDERROR_TEXT) \
   CapturedStderr stderror;                                     \

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -446,8 +446,15 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
 
   creator.addRedirection("redirectA", "A -> B", "redirectB");
   creator.addRedirection("redirectB", "B -> C", "redirectC");
-  creator.addRedirection("redirectC", "C -> A", "redirectA");
+  creator.addRedirection("redirectC", "C -> D", "redirectD");
+  creator.addRedirection("redirectD", "D -> B", "redirectB");
 
+  creator.addRedirection("redirectS", "S -> S", "redirectS");
+
+  creator.addRedirection("redirectZ", "Z -> Y", "redirectY");
+  creator.addRedirection("redirectY", "Y -> X", "redirectX");
+  creator.addRedirection("redirectX", "X -> W", "redirectW");
+  creator.addRedirection("redirectW", "W -> Y", "redirectY");
   creator.finishZimCreation();
 
   const zim::Archive archive(tempPath);
@@ -455,6 +462,14 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
   EXPECT_MISSING_ENTRY(archive, "redirectA");
   EXPECT_MISSING_ENTRY(archive, "redirectB");
   EXPECT_MISSING_ENTRY(archive, "redirectC");
+  EXPECT_MISSING_ENTRY(archive, "redirectD");
+
+  EXPECT_MISSING_ENTRY(archive, "redirectS");
+
+  EXPECT_MISSING_ENTRY(archive, "redirectW");
+  EXPECT_MISSING_ENTRY(archive, "redirectX");
+  EXPECT_MISSING_ENTRY(archive, "redirectY");
+  EXPECT_MISSING_ENTRY(archive, "redirectZ");
 }
 
 } // unnamed namespace

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -472,4 +472,89 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
   EXPECT_MISSING_ENTRY(archive, "redirectZ");
 }
 
+TEST(ZimCreator, pruningOfARedirectionForest)
+{
+  unittests::TempFile temp("zimfile");
+  const auto tempPath = temp.path();
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(tempPath);
+
+  // Create redirections according to the following diagram (for convenience
+  // uppercase letters and digits participate only in invalid redirection
+  // components, while the valid redirection tree is built exclusively of
+  // lowercase letters):
+  //
+  //      T    P <- O
+  //      |    |    ^
+  //      v    v    |       // A tree leading into a redirection loop
+  // M -> N -> L -> 0
+  //
+  // A -> B
+  //        \                   //
+  // J -> K ---> Q -> (MISSING) // A tree ending with a dangling redirect
+  //        /                   //
+  // Z -> Y
+  //
+  // a -> b
+  //        \               // This one is the only healthy redirection tree
+  // j -> k ---> q -> root  // in this diagram. Only redirections from this
+  //        /               // component should survive.
+  // z -> y
+  //
+
+  creator.addItem(std::make_shared<TestItem>("root", "The only item", ""));
+
+  // A tree leading into a redirection loop
+  creator.addRedirection("T", "T -> N", "N");
+  creator.addRedirection("M", "M -> N", "N");
+  creator.addRedirection("N", "N -> L", "L");
+  creator.addRedirection("L", "L -> 0", "0");
+  creator.addRedirection("0", "0 -> O", "O");
+  creator.addRedirection("O", "O -> P", "P");
+  creator.addRedirection("P", "P -> L", "L");
+
+  // A redirection tree ending with a dangling redirect
+  creator.addRedirection("A", "A -> B", "B");
+  creator.addRedirection("B", "B -> Q", "Q");
+  creator.addRedirection("J", "J -> K", "K");
+  creator.addRedirection("K", "K -> Q", "Q");
+  creator.addRedirection("Z", "Z -> Y", "Y");
+  creator.addRedirection("Y", "Y -> Q", "Q");
+  creator.addRedirection("Q", "Q -> (MISSING)", "(MISSING)");
+
+  // A redirection tree rooted at an item entry
+  creator.addRedirection("a", "a -> b", "b");
+  creator.addRedirection("b", "b -> q", "q");
+  creator.addRedirection("j", "j -> k", "k");
+  creator.addRedirection("k", "k -> q", "q");
+  creator.addRedirection("z", "z -> y", "y");
+  creator.addRedirection("y", "y -> q", "q");
+  creator.addRedirection("q", "q -> root", "root");
+
+  creator.finishZimCreation();
+
+  const zim::Archive archive(tempPath);
+
+  EXPECT_MISSING_ENTRY(archive, "(MISSING)");
+  EXPECT_MISSING_ENTRY(archive, "0");
+  for ( char c = 'A'; c <= 'Z'; ++c ) {
+    // The constructor of std::string taking a character and a count
+    // is prone to the mistake of supplying the arguments in the wrong order
+    // (which doesn't lead to a compilation error).
+    // Hence using this more explicit way of converting a char to a string.
+    std::string path; path.push_back(c);
+    EXPECT_MISSING_ENTRY(archive, path);
+  }
+
+  ASSERT_REDIRECT_ENTRY(archive, "a", "b");
+  ASSERT_REDIRECT_ENTRY(archive, "b", "q");
+  ASSERT_REDIRECT_ENTRY(archive, "j", "k");
+  ASSERT_REDIRECT_ENTRY(archive, "k", "q");
+  ASSERT_REDIRECT_ENTRY(archive, "z", "y");
+  ASSERT_REDIRECT_ENTRY(archive, "y", "q");
+  ASSERT_REDIRECT_ENTRY(archive, "q", "root");
+}
+
 } // unnamed namespace

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -41,6 +41,7 @@ namespace
 {
 
 using namespace zim;
+using zim::unittests::CapturedStdout;
 
 #define ASSERT_REDIRECT_ENTRY(archive, path, targetPath) \
 {\
@@ -368,6 +369,8 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
   unittests::TempFile temp("zimfile");
   const auto tempPath = temp.path();
 
+  CapturedStdout stdOut;
+
   writer::Creator creator;
   creator.setUuid(makeSafeUuid());
   creator.startZimCreation(tempPath);
@@ -391,6 +394,15 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
 
   EXPECT_NO_THROW(creator.finishZimCreation());
 
+  EXPECT_EQ(stdOut.str(),
+    "Resolve redirect\n"
+    "Removing invalid redirection C/redirectC redirecting to (missing) C/missingTarget\n"
+    "Detect loops and/or blind chains of redirects\n"
+    "Redirection C/redirectA -> C/redirectB belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectB -> C/redirectC belongs to a blind chain or loop. Removing...\n"
+    "set index\n"
+  );
+
   const zim::Archive archive(tempPath);
 
   EXPECT_MISSING_ENTRY(archive, "missingTarget");
@@ -403,6 +415,8 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
 {
   unittests::TempFile temp("zimfile");
   const auto tempPath = temp.path();
+
+  CapturedStdout stdOut;
 
   writer::Creator creator;
   creator.setUuid(makeSafeUuid());
@@ -427,6 +441,15 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
 
   EXPECT_NO_THROW(creator.finishZimCreation());
 
+  EXPECT_EQ(stdOut.str(),
+    "Resolve redirect\n"
+    "Removing invalid redirection C/redirectA redirecting to (missing) C/missingTarget\n"
+    "Detect loops and/or blind chains of redirects\n"
+    "Redirection C/redirectB -> C/redirectA belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectC -> C/redirectB belongs to a blind chain or loop. Removing...\n"
+    "set index\n"
+  );
+
   const zim::Archive archive(tempPath);
 
   EXPECT_MISSING_ENTRY(archive, "missingTarget");
@@ -439,6 +462,8 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
 {
   unittests::TempFile temp("zimfile");
   const auto tempPath = temp.path();
+
+  CapturedStdout stdOut;
 
   writer::Creator creator;
   creator.setUuid(makeSafeUuid());
@@ -456,6 +481,21 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
   creator.addRedirection("redirectX", "X -> W", "redirectW");
   creator.addRedirection("redirectW", "W -> Y", "redirectY");
   creator.finishZimCreation();
+
+  EXPECT_EQ(stdOut.str(),
+    "Resolve redirect\n"
+    "Detect loops and/or blind chains of redirects\n"
+    "Redirection C/redirectA -> C/redirectB belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectB -> C/redirectC belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectC -> C/redirectD belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectD -> C/redirectB belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectS -> C/redirectS belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectW -> C/redirectY belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectY -> C/redirectX belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectX -> C/redirectW belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/redirectZ -> C/redirectY belongs to a blind chain or loop. Removing...\n"
+    "set index\n"
+  );
 
   const zim::Archive archive(tempPath);
 
@@ -476,6 +516,8 @@ TEST(ZimCreator, pruningOfARedirectionForest)
 {
   unittests::TempFile temp("zimfile");
   const auto tempPath = temp.path();
+
+  CapturedStdout stdOut;
 
   writer::Creator creator;
   creator.setUuid(makeSafeUuid());
@@ -534,6 +576,26 @@ TEST(ZimCreator, pruningOfARedirectionForest)
   creator.addRedirection("q", "q -> root", "root");
 
   creator.finishZimCreation();
+
+  EXPECT_EQ(stdOut.str(),
+    "Resolve redirect\n"
+    "Removing invalid redirection C/Q redirecting to (missing) C/(MISSING)\n"
+    "Detect loops and/or blind chains of redirects\n"
+    "Redirection C/0 -> C/O belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/O -> C/P belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/P -> C/L belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/L -> C/0 belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/A -> C/B belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/B -> C/Q belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/J -> C/K belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/K -> C/Q belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/M -> C/N belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/N -> C/L belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/T -> C/N belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/Y -> C/Q belongs to a blind chain or loop. Removing...\n"
+    "Redirection C/Z -> C/Y belongs to a blind chain or loop. Removing...\n"
+    "set index\n"
+  );
 
   const zim::Archive archive(tempPath);
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -389,7 +389,14 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
                          "Last redirect in an ascending blind chain",
                          "missingTarget");
 
-  EXPECT_THROW(creator.finishZimCreation(), zim::CreatorError);
+  EXPECT_NO_THROW(creator.finishZimCreation());
+
+  const zim::Archive archive(tempPath);
+
+  EXPECT_MISSING_ENTRY(archive, "missingTarget");
+  EXPECT_MISSING_ENTRY(archive, "redirectA");
+  EXPECT_MISSING_ENTRY(archive, "redirectB");
+  EXPECT_MISSING_ENTRY(archive, "redirectC");
 }
 
 TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
@@ -418,7 +425,7 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
                          "Last redirect in a descending blind chain",
                          "missingTarget");
 
-  creator.finishZimCreation();
+  EXPECT_NO_THROW(creator.finishZimCreation());
 
   const zim::Archive archive(tempPath);
 
@@ -445,9 +452,9 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
 
   const zim::Archive archive(tempPath);
 
-  ASSERT_REDIRECT_ENTRY(archive, "redirectA", "redirectB");
-  ASSERT_REDIRECT_ENTRY(archive, "redirectB", "redirectC");
-  ASSERT_REDIRECT_ENTRY(archive, "redirectC", "redirectA");
+  EXPECT_MISSING_ENTRY(archive, "redirectA");
+  EXPECT_MISSING_ENTRY(archive, "redirectB");
+  EXPECT_MISSING_ENTRY(archive, "redirectC");
 }
 
 } // unnamed namespace

--- a/test/tools.h
+++ b/test/tools.h
@@ -51,25 +51,39 @@ namespace zim
 namespace unittests
 {
 
-class CapturedStderr
+class CapturedStdOstream
 {
+  std::ostream* const ostream;
+  std::streambuf* const origbuf;
   std::ostringstream buffer;
-  std::streambuf* const sbuf;
+
 public:
-  CapturedStderr()
-    : sbuf(std::cerr.rdbuf())
+  explicit CapturedStdOstream(std::ostream* os)
+    : ostream(os)
+    , origbuf(os->rdbuf())
   {
-    std::cerr.rdbuf(buffer.rdbuf());
+    ostream->rdbuf(buffer.rdbuf());
   }
 
-  CapturedStderr(const CapturedStderr&) = delete;
+  CapturedStdOstream(const CapturedStdOstream&) = delete;
 
-  ~CapturedStderr()
+  ~CapturedStdOstream()
   {
-    std::cerr.rdbuf(sbuf);
+    ostream->rdbuf(origbuf);
   }
 
-  operator std::string() const { return buffer.str(); }
+  std::string str() const { return buffer.str(); }
+  operator std::string() const { return str(); }
+};
+
+struct CapturedStderr : CapturedStdOstream
+{
+  CapturedStderr() : CapturedStdOstream(&std::cerr) {}
+};
+
+struct CapturedStdout : CapturedStdOstream
+{
+  CapturedStdout() : CapturedStdOstream(&std::cout) {}
 };
 
 // TempFile is a utility class for working with temporary files in RAII fashion:

--- a/test/tools.h
+++ b/test/tools.h
@@ -51,6 +51,27 @@ namespace zim
 namespace unittests
 {
 
+class CapturedStderr
+{
+  std::ostringstream buffer;
+  std::streambuf* const sbuf;
+public:
+  CapturedStderr()
+    : sbuf(std::cerr.rdbuf())
+  {
+    std::cerr.rdbuf(buffer.rdbuf());
+  }
+
+  CapturedStderr(const CapturedStderr&) = delete;
+
+  ~CapturedStderr()
+  {
+    std::cerr.rdbuf(sbuf);
+  }
+
+  operator std::string() const { return buffer.str(); }
+};
+
 // TempFile is a utility class for working with temporary files in RAII fashion:
 //
 //   1. An empty temporary file is created (in the temporary file directory)


### PR DESCRIPTION
Fixes #1056

The implementation of loop detection didn't borrow/copy any code from zimcheck - a slightly different algorithm was used taking advantage of the availability of the `zim::writer::Dirent::idx` field (yet unused by this stage) for marking the visited dirents during traversal of redirection chains.

Redirections belonging to blind chains/loops are eliminated in two passes:

1. Redirections with a missing target are removed. The following message is printed on `stdout`:

    > Removing invalid redirection *ENTRY_PATH* redirecting to (missing) *TARGET_PATH*

   As a result of this pass other redirections may become invalid but they are reported with a different message during the second pass (because from the user's perspective they did have a valid target at the time of calling `finishZimCreation()`). 

2. Any redirections belonging to connectivity components ending with a dangling redirection or a loop are detected and removed with the following message reported on `stdout`:

    > Redirection *ENTRY_PATH* -> *TARGET_PATH* belongs to a blind chain or loop. Removing...