### PR TITLE
Fixed an old bug in zim::unix::FD::readAt()

### DIFF
--- a/src/fs_unix.cpp
+++ b/src/fs_unix.cpp
@@ -57,6 +57,7 @@ zsize_t FD::readAt(char* dest, zsize_t size, offset_t offset) const
     }
     size_to_read -= size_read;
     current_offset += size_read;
+    dest += size_read;
     full_size_read += size_read;
   }
   return zsize_t(full_size_read);


### PR DESCRIPTION
When the data could not be read in one chunk, the destination pointer was not being properly advanced for each consecutive chunk read to be appended to the results of the previous reads.

#1053 enabled this bug to manifest itself deterministically, though it is possible that the bug could (and did) fire under rare conditions that had gone unnoticed (when a large read is carried out in multiple shots because of decisions made by the OS kernel).

The `Dirent table is not properly sorted` error reported in #1058 is caused by this bug.