### PR TITLE
More foolproof detection of MMAP_SUPPORT_64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() != 'windows'
 endif
 
 cpp = meson.get_compiler('cpp')
-sizeof_off_t = cpp.sizeof('off_t')
+sizeof_off_t = cpp.sizeof('off_t', prefix: '#include <sys/types.h>')
 sizeof_size_t = cpp.sizeof('size_t')
 
 private_conf = configuration_data()


### PR DESCRIPTION
In our CI/CD macOS builders the type `off_t` is not available via the default headers used by meson's `sizeof()` function. This resulted in MMAP_SUPPORT_64 not being enabled in our macOS builds.

Should fix #1058 (see https://github.com/openzim/libzim/issues/1058#issuecomment-4244834735).