### PR TITLE
Exclusion of dropped redirects from the title index

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -398,7 +398,7 @@ void Creator::finishZimCreation()
 
   data->indexTitles();
 
-  TINFO("Set entry indexes");
+  TINFO("Set entry indices");
   data->setEntryIndexes();
 
   TINFO("Resolve mimetype");
@@ -819,8 +819,7 @@ Cluster* CreatorData::closeCluster(bool compressed)
 
 void CreatorData::setEntryIndexes()
 {
-  // set index
-  INFO("set index");
+  INFO("Set entry indices");
   entry_index_t idx(0);
   for (auto& dirent: dirents) {
     dirent->setIdx(idx);
@@ -961,6 +960,7 @@ void indexTitle(XapianIndexer& indexer, const Dirent& dirent)
 
 void CreatorData::indexTitles()
 {
+  INFO("Index titles");
 #if defined(ENABLE_XAPIAN)
   const std::string tmpFilePath = zimName + "_title.idx";
   XapianIndexer xi(tmpFilePath, indexingLanguage, IndexingMode::TITLE, true);

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -613,8 +613,9 @@ CreatorData::CreatorData(const std::string& fname,
   uncompCluster = new Cluster(Compression::None);
 
 #if defined(ENABLE_XAPIAN)
-  auto xapianIndexer = std::make_shared<XapianHandler>(this, withIndex);
-  m_direntHandlers.push_back(xapianIndexer);
+  if ( withIndex ) {
+    m_direntHandlers.push_back(std::make_shared<XapianHandler>(this));
+  }
 #endif
 
   m_direntHandlers.push_back(std::make_shared<CounterHandler>(this));

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -43,6 +43,7 @@
 
 #if defined(ENABLE_XAPIAN)
 # include "xapianHandler.h"
+# include "xapianIndexer.h"
 #endif
 
 #ifdef _WIN32
@@ -394,6 +395,8 @@ void Creator::finishZimCreation()
   data->detectDanglingRedirects();
   data->removeLoopsAndBlindChainsOfRedirects();
   data->dropRemovedRedirects();
+
+  data->indexTitles();
 
   TINFO("Set entry indexes");
   data->setEntryIndexes();
@@ -932,6 +935,49 @@ void CreatorData::addTitleListingData()
   Dirent* const d = *findDirent(NS::X, "listing/titleOrdered/v1");
   auto listingProvider = std::make_unique<TitleListingProvider>(this->dirents);
   addItemData(*d, std::move(listingProvider), false);
+}
+
+#if defined(ENABLE_XAPIAN)
+namespace
+{
+
+void indexTitle(XapianIndexer& indexer, const Dirent& dirent)
+{
+  const auto title = dirent.getTitle();
+  if ( !title.empty() ) {
+    const auto path = dirent.getPath();
+    if (dirent.isRedirect()) {
+      const auto redirectPath = dirent.getRedirectPath();
+      indexer.indexTitle(path, title, redirectPath);
+    } else {
+      indexer.indexTitle(path, title);
+    }
+  }
+}
+
+} // unnamed namespace
+#endif // defined(ENABLE_XAPIAN)
+
+void CreatorData::indexTitles()
+{
+#if defined(ENABLE_XAPIAN)
+  const std::string tmpFilePath = zimName + "_title.idx";
+  XapianIndexer xi(tmpFilePath, indexingLanguage, IndexingMode::TITLE, true);
+  xi.indexingPrelude();
+  for ( Dirent* const d : dirents ) {
+    if ( d->isFrontArticle() ) {
+      indexTitle(xi, *d);
+    }
+  }
+  xi.indexingPostlude();
+
+  if (!xi.is_empty()) {
+    Dirent* const d = createDirent(NS::X, "title/xapian",
+                                   "application/octet-stream+xapian", "");
+    auto fileDataProvider = std::make_unique<FileProvider>(tmpFilePath);
+    addItemData(*d, std::move(fileDataProvider), false);
+  }
+#endif // defined(ENABLE_XAPIAN)
 }
 
 } // namespace writer

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -95,6 +95,7 @@ namespace zim
         DirentIterator removeDirent(DirentIterator it);
         void removeDirent(Dirent* dirent);
 
+        void indexTitles();
         void addTitleListingData();
 
         DirentPool  pool;

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -30,7 +30,6 @@ using namespace zim::writer;
 
 XapianHandler::XapianHandler(CreatorData* data, bool withFulltextIndex)
   : mp_fulltextIndexer(withFulltextIndex ? new XapianIndexer(data->zimName+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true) : nullptr),
-    mp_titleIndexer(new XapianIndexer(data->zimName+"_title.idx", data->indexingLanguage, IndexingMode::TITLE, true)),
     mp_creatorData(data)
 {}
 
@@ -45,7 +44,6 @@ void XapianHandler::start() {
   if (mp_fulltextIndexer) {
     mp_fulltextIndexer->indexingPrelude();
   }
-  mp_titleIndexer->indexingPrelude();
 }
 
 void XapianHandler::stop() {
@@ -55,7 +53,6 @@ void XapianHandler::stop() {
     waitNoMoreTask();
     mp_fulltextIndexer->indexingPostlude();
   }
-  mp_titleIndexer->indexingPostlude();
 }
 
 DirentHandler::Dirents XapianHandler::createDirents() const {
@@ -67,9 +64,6 @@ DirentHandler::Dirents XapianHandler::createDirents() const {
       ret.push_back(mp_creatorData->createDirent(NS::X, "fulltext/xapian", "application/octet-stream+xapian", ""));
     }
   }
-  if (!mp_titleIndexer->is_empty()) {
-    ret.push_back(mp_creatorData->createDirent(NS::X, "title/xapian", "application/octet-stream+xapian", ""));
-  }
   return ret;
 }
 
@@ -78,31 +72,11 @@ DirentHandler::ContentProviders XapianHandler::getContentProviders() const {
   if (mp_fulltextIndexer && !mp_fulltextIndexer->is_empty()) {
     ret.push_back(std::unique_ptr<ContentProvider>(new FileProvider(mp_fulltextIndexer->getIndexPath())));
   }
-  if (!mp_titleIndexer->is_empty()) {
-    ret.push_back(std::unique_ptr<ContentProvider>(new FileProvider(mp_titleIndexer->getIndexPath())));
-  }
   return ret;
 }
 
-void XapianHandler::indexTitle(const Dirent& dirent) {
-  auto title = dirent.getTitle();
-  if (title.empty()) {
-    return;
-  }
-  auto path = dirent.getPath();
-  if (dirent.isRedirect()) {
-    auto redirectPath = dirent.getRedirectPath();
-    mp_titleIndexer->indexTitle(path, title, redirectPath);
-  } else {
-    mp_titleIndexer->indexTitle(path, title);
-  }
-}
-
-void XapianHandler::handle(const Dirent& dirent)
+void XapianHandler::handle(const Dirent&)
 {
-  if (dirent.isFrontArticle()) {
-      indexTitle(dirent);
-  }
 }
 
 void XapianHandler::handle(const Dirent& dirent, std::shared_ptr<Item> item)

--- a/src/writer/xapianHandler.cpp
+++ b/src/writer/xapianHandler.cpp
@@ -28,8 +28,8 @@
 
 using namespace zim::writer;
 
-XapianHandler::XapianHandler(CreatorData* data, bool withFulltextIndex)
-  : mp_fulltextIndexer(withFulltextIndex ? new XapianIndexer(data->zimName+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true) : nullptr),
+XapianHandler::XapianHandler(CreatorData* data)
+  : mp_fulltextIndexer(new XapianIndexer(data->zimName+"_fulltext.idx", data->indexingLanguage, IndexingMode::FULL, true)),
     mp_creatorData(data)
 {}
 
@@ -41,35 +41,29 @@ void XapianHandler::waitNoMoreTask() const {
 }
 
 void XapianHandler::start() {
-  if (mp_fulltextIndexer) {
-    mp_fulltextIndexer->indexingPrelude();
-  }
+  mp_fulltextIndexer->indexingPrelude();
 }
 
 void XapianHandler::stop() {
   // We need to wait that all indexation tasks have been done before closing the
   // xapian database.
-  if (mp_fulltextIndexer) {
-    waitNoMoreTask();
-    mp_fulltextIndexer->indexingPostlude();
-  }
+  waitNoMoreTask();
+  mp_fulltextIndexer->indexingPostlude();
 }
 
 DirentHandler::Dirents XapianHandler::createDirents() const {
   // Wait for all task to be done before checking if we are empty.
   Dirents ret;
-  if (mp_fulltextIndexer) {
-    waitNoMoreTask();
-    if (!mp_fulltextIndexer->is_empty()) {
-      ret.push_back(mp_creatorData->createDirent(NS::X, "fulltext/xapian", "application/octet-stream+xapian", ""));
-    }
+  waitNoMoreTask();
+  if (!mp_fulltextIndexer->is_empty()) {
+    ret.push_back(mp_creatorData->createDirent(NS::X, "fulltext/xapian", "application/octet-stream+xapian", ""));
   }
   return ret;
 }
 
 DirentHandler::ContentProviders XapianHandler::getContentProviders() const {
   ContentProviders ret;
-  if (mp_fulltextIndexer && !mp_fulltextIndexer->is_empty()) {
+  if (!mp_fulltextIndexer->is_empty()) {
     ret.push_back(std::unique_ptr<ContentProvider>(new FileProvider(mp_fulltextIndexer->getIndexPath())));
   }
   return ret;
@@ -89,13 +83,11 @@ void XapianHandler::handle(const Dirent& dirent, std::shared_ptr<Item> item)
   handle(dirent);
 
   // FullText index
-  if (mp_fulltextIndexer) {
-    auto indexData = item->getIndexData();
-    if (!indexData) {
-      return;
-    }
-    auto path = dirent.getPath();
-    mp_creatorData->taskList.pushToQueue(std::make_shared<IndexTask>(indexData, path, mp_fulltextIndexer.get()));
+  auto indexData = item->getIndexData();
+  if (!indexData) {
+    return;
   }
+  auto path = dirent.getPath();
+  mp_creatorData->taskList.pushToQueue(std::make_shared<IndexTask>(indexData, path, mp_fulltextIndexer.get()));
 }
 

--- a/src/writer/xapianHandler.h
+++ b/src/writer/xapianHandler.h
@@ -29,7 +29,7 @@ class XapianIndexer;
 
 class XapianHandler : public DirentHandler {
   public:
-    XapianHandler(CreatorData* data, bool withFullTextIndex);
+    explicit XapianHandler(CreatorData* data);
     virtual ~XapianHandler();
 
     void start() override;

--- a/src/writer/xapianHandler.h
+++ b/src/writer/xapianHandler.h
@@ -43,12 +43,10 @@ class XapianHandler : public DirentHandler {
     Dirents createDirents() const override;
 
   private: // methods
-    void indexTitle(const Dirent& dirent);
     void waitNoMoreTask() const;
 
   private: // data
     std::unique_ptr<XapianIndexer> mp_fulltextIndexer;
-    std::unique_ptr<XapianIndexer> mp_titleIndexer;
     CreatorData* mp_creatorData;
 };
 

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -388,7 +388,8 @@ TEST(ZimCreator, interruptedZimCreation)
 const std::string OUTPUT_FROM_TIDY_ZIM_CREATION =
     "Detect dangling redirects\n"
     "Detect loops and/or blind chains of redirects\n"
-    "set index\n";
+    "Index titles\n"
+    "Set entry indices\n";
 
 TEST(ZimCreator, redirectAddedAfterItsTargetIsCreated)
 {
@@ -688,7 +689,8 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
     "Detect loops and/or blind chains of redirects\n"
     "Redirection C/redirectA -> C/redirectB belongs to a blind chain or loop. Removing...\n"
     "Redirection C/redirectB -> C/redirectC belongs to a blind chain or loop. Removing...\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -735,7 +737,8 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
     "Detect loops and/or blind chains of redirects\n"
     "Redirection C/redirectB -> C/redirectA belongs to a blind chain or loop. Removing...\n"
     "Redirection C/redirectC -> C/redirectB belongs to a blind chain or loop. Removing...\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -782,7 +785,8 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
     "Redirection C/redirectY -> C/redirectX belongs to a blind chain or loop. Removing...\n"
     "Redirection C/redirectX -> C/redirectW belongs to a blind chain or loop. Removing...\n"
     "Redirection C/redirectZ -> C/redirectY belongs to a blind chain or loop. Removing...\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -882,7 +886,8 @@ TEST(ZimCreator, pruningOfARedirectionForest)
     "Redirection C/T -> C/N belongs to a blind chain or loop. Removing...\n"
     "Redirection C/Y -> C/Q belongs to a blind chain or loop. Removing...\n"
     "Redirection C/Z -> C/Y belongs to a blind chain or loop. Removing...\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -956,7 +961,8 @@ TEST(ZimCreator, addingATargetForAnAlreadyAddedRedirectFails)
     "Detect dangling redirects\n"
     "Removing invalid redirection C/R1 redirecting to (missing) C/Discardable\n"
     "Detect loops and/or blind chains of redirects\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive a(tempPath);
@@ -1025,7 +1031,8 @@ TEST(ZimCreator, titleIndexingOfDroppedEntries)
     "Removing invalid redirection C/farewell redirecting to (missing) C/goodbye\n"
     "Detect loops and/or blind chains of redirects\n"
     "Redirection C/adios -> C/farewell belongs to a blind chain or loop. Removing...\n"
-    "set index\n"
+    "Index titles\n"
+    "Set entry indices\n"
   );
 
   const zim::Archive a(tempPath);

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -25,6 +25,7 @@
 #include <zim/error.h>
 #include <zim/item.h>
 #include <zim/tools.h>
+#include <zim/suggestion.h>
 
 #include "tools.h"
 #include "../src/file_compound.h"
@@ -911,18 +912,22 @@ struct SimulatedError : std::exception
 {
 };
 
-std::shared_ptr<zim::writer::Item> makeUnaddableItem(const std::string& path)
+std::shared_ptr<zim::writer::Item> makeUnaddableItem(const std::string& path,
+                                                     const std::string& title)
 {
   struct UnaddableItem : TestItem
   {
-    UnaddableItem(const std::string& path) : TestItem(path, "", "") {}
+    UnaddableItem(const std::string& path, const std::string& title)
+      : TestItem(path, title, "")
+    {}
+
     virtual std::unique_ptr<writer::ContentProvider> getContentProvider() const
     {
       throw SimulatedError();
     }
   };
 
-  return std::make_shared<UnaddableItem>(path);
+  return std::make_shared<UnaddableItem>(path, title);
 }
 
 TEST(ZimCreator, addingATargetForAnAlreadyAddedRedirectFails)
@@ -939,10 +944,10 @@ TEST(ZimCreator, addingATargetForAnAlreadyAddedRedirectFails)
   c.addRedirection("R2", "Redirect to an important item", "Important");
 
   // Adding this item fails and is not retried
-  EXPECT_THROW(c.addItem(makeUnaddableItem("Discardable")), SimulatedError);
+  EXPECT_THROW(c.addItem(makeUnaddableItem("Discardable", "")), SimulatedError);
 
   // Adding this item fails but is retried with a success
-  EXPECT_THROW(c.addItem(makeUnaddableItem("Important")), SimulatedError);
+  EXPECT_THROW(c.addItem(makeUnaddableItem("Important", "")), SimulatedError);
   EXPECT_NO_THROW(c.addItem(makeTestItem("Important", "", "")));
 
   EXPECT_NO_THROW(c.finishZimCreation());
@@ -960,5 +965,92 @@ TEST(ZimCreator, addingATargetForAnAlreadyAddedRedirectFails)
   EXPECT_MISSING_ENTRY(a, "Discardable");
   ASSERT_REDIRECT_ENTRY(a, "R2", "Redirect to an important item", "Important");
 }
+
+#if defined(ENABLE_XAPIAN)
+typedef std::vector<std::pair<std::string, std::string>> PathAndTitles;
+
+PathAndTitles getAllSuggestions(const zim::Archive archive, std::string query)
+{
+  zim::SuggestionSearcher suggestionSearcher(archive);
+  suggestionSearcher.setVerbose(true);
+  auto suggestionSearch = suggestionSearcher.suggest(query);
+  const auto entryCount = archive.getEntryCount();
+  auto suggestionResult = suggestionSearch.getResults(0, entryCount);
+
+  PathAndTitles result;
+  for (auto entry : suggestionResult) {
+    result.push_back({entry.getPath(), entry.getTitle()});
+  }
+  return result;
+}
+
+#define EXPECT_SUGGESTIONS(archive, query, ...)     \
+  ASSERT_EQ(                                        \
+      getAllSuggestions(archive, query),            \
+      PathAndTitles({__VA_ARGS__})                  \
+  )
+
+TEST(ZimCreator, titleIndexingOfDroppedEntries)
+{
+  unittests::TempFile temp("zimfile");
+  auto tempPath = temp.path();
+
+  CapturedStdout stdOut;
+  writer::Creator c;
+  c.setUuid(makeSafeUuid());
+  c.startZimCreation(tempPath);
+  c.configIndexing(false, "eng");
+
+  const zim::writer::Hints FRONT_ARTICLE{{zim::writer::FRONT_ARTICLE, 1}};
+
+  c.addItem(makeTestItem("home", "Home, Sweet Home", ""));
+
+  EXPECT_THROW(
+    c.addItem(makeUnaddableItem("street", "Street, Sour Street")),
+    SimulatedError
+  );
+
+  c.addRedirection("welcome", "Welcome Page", "home", FRONT_ARTICLE);
+
+  // A dangling redirection
+  c.addRedirection("farewell", "Farewell Page", "goodbye", FRONT_ARTICLE);
+
+  // A redirection on a blind chain
+  c.addRedirection("adios", "Advertizing iOS", "farewell", FRONT_ARTICLE);
+
+  EXPECT_NO_THROW(c.finishZimCreation());
+
+  ASSERT_EQ(stdOut.str(),
+    "Detect dangling redirects\n"
+    "Removing invalid redirection C/farewell redirecting to (missing) C/goodbye\n"
+    "Detect loops and/or blind chains of redirects\n"
+    "Redirection C/adios -> C/farewell belongs to a blind chain or loop. Removing...\n"
+    "set index\n"
+  );
+
+  const zim::Archive a(tempPath);
+
+  EXPECT_SUGGESTIONS(a, "home",
+      {"home", "Home, Sweet Home"}
+  );
+
+  EXPECT_SUGGESTIONS(a, "street",
+      // Adding the "street" entry failed, so it was not indexed. Good!
+  );
+
+  EXPECT_SUGGESTIONS(a, "fare",
+      {"farewell", ""             }  // Oops! An eliminated entry shows up
+  );
+
+  EXPECT_SUGGESTIONS(a, "adver",
+      {"adios",    ""             }  // Oops! An eliminated entry shows up
+  );
+
+  EXPECT_SUGGESTIONS(a, "page",
+      {"farewell", ""             }, // Oops! An eliminated entry shows up
+      {"welcome",  "Welcome Page" }
+  );
+}
+#endif // defined(ENABLE_XAPIAN)
 
 } // unnamed namespace

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -1039,16 +1039,16 @@ TEST(ZimCreator, titleIndexingOfDroppedEntries)
   );
 
   EXPECT_SUGGESTIONS(a, "fare",
-      {"farewell", ""             }  // Oops! An eliminated entry shows up
+      // The "farewell" redirect was removed, so it was not indexed. Good!
   );
 
   EXPECT_SUGGESTIONS(a, "adver",
-      {"adios",    ""             }  // Oops! An eliminated entry shows up
+      // The "adios" redirect was removed, so it was not indexed. Good!
   );
 
   EXPECT_SUGGESTIONS(a, "page",
-      {"farewell", ""             }, // Oops! An eliminated entry shows up
       {"welcome",  "Welcome Page" }
+      // The "farewell" redirect was removed, so it was not indexed. Good!
   );
 }
 #endif // defined(ENABLE_XAPIAN)

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -841,12 +841,12 @@ TEST(Suggestion, indexFullPath) {
   // Make sure that the namespace is included in the path recorded
   // with each indexed document
   ASSERT_EQ(database.get_document(1).get_data(), "C/MainPage");
-  ASSERT_EQ(database.get_document(2).get_data(), "C/Preface");
-  ASSERT_EQ(database.get_document(3).get_data(), "C/Volume1/Chapter1");
-  ASSERT_EQ(database.get_document(4).get_data(), "C/Volume1/Chapter2");
-  ASSERT_EQ(database.get_document(5).get_data(), "C/Volume2/Chapter3");
-  ASSERT_EQ(database.get_document(6).get_data(), "C/Volume2/Chapter4");
-  ASSERT_EQ(database.get_document(7).get_data(), "C/Postbutt");
+  ASSERT_EQ(database.get_document(2).get_data(), "C/Postbutt");
+  ASSERT_EQ(database.get_document(3).get_data(), "C/Preface");
+  ASSERT_EQ(database.get_document(4).get_data(), "C/Volume1/Chapter1");
+  ASSERT_EQ(database.get_document(5).get_data(), "C/Volume1/Chapter2");
+  ASSERT_EQ(database.get_document(6).get_data(), "C/Volume2/Chapter3");
+  ASSERT_EQ(database.get_document(7).get_data(), "C/Volume2/Chapter4");
 }
 
 } // unnamed namespace


### PR DESCRIPTION
Fixes #1075 

As a result of this change title indexing runs after invalid redirects have been removed. Though I was a little wary about the performance impact of fixing the bug in this manner, it turned out that - at least on the flow used to benchmark #1068 - even a slight speed-up was observed. This pleasant surprise can be explained by the reduced pressure on the CPU cache - in the previous implementation where additional work had to be done for each new dirent the code running in the main thread had to jump across unrelated functions (and load/unload unrelated data into the CPU cache). Now the main thread isn't distracted by Xapian activities when executing the `zim::writer::Creator::add*()` methods, but instead fully focuses on them in (a respective step of) `zim::writer::Creator::finishZimCreation()`.