### PR TITLE
Fixed Archive::getFilename() in case of a split ZIM file

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -106,16 +106,19 @@ namespace zim
 
       /** Archive constructor.
        *
-       *  Construct an archive from a filename.
-       *  The file is open readonly.
+       *  Construct an archive from a file path.
        *
-       *  The filename is the "logical" path.
-       *  So if you want to open a split zim file (foo.zimaa, foo.zimab, ...)
-       *  you must pass the `foo.zim` path.
+       *  The file is opened readonly.
        *
-       *  @param fname The filename to the file to open (utf8 encoded)
+       *  In case of a split ZIM file (foo.zimaa, foo.zimab, ...), either the
+       *  filename of the first part (foo.zimaa) or the "logical" filename
+       *  (foo.zim) can be used. Note, however, that opening a split ZIM file
+       *  via a logical path is subject to the risk of having the wrong file
+       *  opened (if that path is used by another file).
+       *
+       *  @param path The path of the file to open (utf8 encoded)
        */
-      explicit Archive(const std::string& fname);
+      explicit Archive(const std::string& path);
 
       /** Archive constructor.
        *
@@ -253,12 +256,12 @@ namespace zim
       Archive(const std::vector<FdInput>& fds, OpenConfig openConfig);
 #endif
 
-      /** Return the filename of the zim file.
+      /** Return the path used to open the ZIM file.
        *
-       *  Return the filename as passed to the constructor
-       *  (So foo.zim).
+       * If the ZIM file was opened using a file descriptor, an empty
+       * string is returned.
        *
-       *  @return The logical filename of the archive.
+       *  @return The path passed to the constructor.
        */
       const std::string& getFilename() const;
 

--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -256,12 +256,19 @@ namespace zim
       Archive(const std::vector<FdInput>& fds, OpenConfig openConfig);
 #endif
 
-      /** Return the path used to open the ZIM file.
+      /** Return the real path of the file(s) underlying this ZIM archive.
+       *
+       * In case of a regular (single-piece) ZIM file, returns the path of that
+       * file.
+       *
+       * In case of a split ZIM file, returns the path of its first (.zimaa)
+       * part.
        *
        * If the ZIM file was opened using a file descriptor, an empty
        * string is returned.
        *
-       *  @return The path passed to the constructor.
+       *  @return The path of the ZIM file or its first part (which can
+       *          be used directly to open the same file).
        */
       const std::string& getFilename() const;
 

--- a/src/file_compound.cpp
+++ b/src/file_compound.cpp
@@ -34,6 +34,17 @@
 
 namespace zim {
 
+namespace
+{
+
+bool endsWith(const std::string& str, const std::string& suffix)
+{
+  const size_t n = str.size();
+  return n > suffix.size() && str.substr(n-suffix.size()) == suffix;
+}
+
+} // unnamed namespace
+
 void FileCompound::addPart(FilePart* fpart)
 {
   const Range newRange(offset_t(_fsize.v), offset_t((_fsize+fpart->size()).v));
@@ -41,15 +52,11 @@ void FileCompound::addPart(FilePart* fpart)
   _fsize += fpart->size();
 }
 
-std::shared_ptr<FileCompound> FileCompound::openSinglePieceOrSplitZimFile(const std::string& original_filename) {
+std::shared_ptr<FileCompound> FileCompound::openSinglePieceOrSplitZimFile(const std::string& filename) {
   std::shared_ptr<FileCompound> fileCompound;
-  bool multi_parts_asked = false;
-  auto filename = original_filename;
-  if (filename.size() > 6 && filename.substr(filename.size()-6) == ".zimaa") {
-    filename.resize(filename.size()-2);
-    multi_parts_asked = true;
-  } else {
-  try {
+  const bool multi_parts_asked = endsWith(filename, ".zimaa");
+  if ( !multi_parts_asked ) {
+    try {
       fileCompound = std::make_shared<FileCompound>(filename);
     } catch(...) { }
   }
@@ -62,7 +69,7 @@ std::shared_ptr<FileCompound> FileCompound::openSinglePieceOrSplitZimFile(const 
     // We haven't found any part
     throw std::runtime_error(Formatter() << "Error opening "
                              << (multi_parts_asked ? "as a split " : "")
-                             << "ZIM file: " << original_filename);
+                             << "ZIM file: " << filename);
   }
   return fileCompound;
 }
@@ -74,10 +81,14 @@ FileCompound::FileCompound(const std::string& filename):
   addPart(new FilePart(filename));
 }
 
-FileCompound::FileCompound(const std::string& base_filename, MultiPartToken _token):
-  _filename(base_filename),
+FileCompound::FileCompound(const std::string& filename, MultiPartToken _token):
+  _filename(filename),
   _fsize(0)
 {
+  const std::string base_filename = endsWith(filename, ".zimaa")
+                                  ? filename.substr(0, filename.size()-2)
+                                  : filename;
+
   try {
     for (char ch0 = 'a'; ch0 <= 'z'; ++ch0)
     {

--- a/src/file_compound.cpp
+++ b/src/file_compound.cpp
@@ -82,12 +82,13 @@ FileCompound::FileCompound(const std::string& filename):
 }
 
 FileCompound::FileCompound(const std::string& filename, MultiPartToken _token):
-  _filename(filename),
   _fsize(0)
 {
   const std::string base_filename = endsWith(filename, ".zimaa")
                                   ? filename.substr(0, filename.size()-2)
                                   : filename;
+
+  _filename = base_filename + "aa";
 
   try {
     for (char ch0 = 'a'; ch0 <= 'z'; ++ch0)

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -298,7 +298,7 @@ TEST_F(ZimArchive, openSplitZimArchive)
       std::unique_ptr<zim::Archive> archive;
       EXPECT_NO_THROW( archive.reset(new zim::Archive(path)) ) << ctx;
       if ( archive ) {
-        EXPECT_EQ(archive->getFilename(), path);
+        EXPECT_EQ(archive->getFilename(), testfile.path + "aa");
         EXPECT_TRUE( archive->check() ) << ctx;
       }
     }

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -289,13 +289,18 @@ TEST_F(ZimArchive, openRealZimArchive)
 TEST_F(ZimArchive, openSplitZimArchive)
 {
   const char* fname = "wikibooks_be_all_nopic_2017-02_splitted.zim";
+  const std::string suffixes[] = { "", "aa" };
 
   for (auto& testfile: getDataFilePath(fname)) {
-    const TestContext ctx{ {"path", testfile.path+"aa" } };
-    std::unique_ptr<zim::Archive> archive;
-    EXPECT_NO_THROW( archive.reset(new zim::Archive(testfile.path+"aa")) ) << ctx;
-    if ( archive ) {
-      EXPECT_TRUE( archive->check() ) << ctx;
+    for ( const auto& suffix : suffixes ) {
+      const std::string path = testfile.path + suffix;
+      const TestContext ctx{ {"path", path } };
+      std::unique_ptr<zim::Archive> archive;
+      EXPECT_NO_THROW( archive.reset(new zim::Archive(path)) ) << ctx;
+      if ( archive ) {
+        EXPECT_EQ(archive->getFilename(), path);
+        EXPECT_TRUE( archive->check() ) << ctx;
+      }
     }
   }
 }


### PR DESCRIPTION
Should fix kiwix/kiwix-android#4510

Before this fix, `Archive::getFilename()` converted a .zimaa path used to open a split ZIM file into the "logical" (.zim) variant.
    
Now the path passed into the Archive constructor is returned unmodified.
    
But shouldn't the path of the first part (.zimaa) be always returned in case of a split ZIM file (even if it was opened via a .zim path)?
