### PR TITLE
Drop single-letter suggestion test due to increased xapian min str len

### DIFF
--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -521,10 +521,6 @@ TEST(Suggestion, nonWordCharacters) {
       "Jack & Jill, on the hill"
     );
 
-    EXPECT_SUGGESTED_TITLES(archive, "4",
-      "Ali Baba & the 40 thieves"
-    );
-
     EXPECT_SUGGESTED_TITLES(archive, "40",
       "Ali Baba & the 40 thieves"
     );


### PR DESCRIPTION
Fixes #1073

The minimum string length for partial matching in [xapian v2 is now 2](https://github.com/xapian/xapian/blob/v2.0.0/xapian-core/include/xapian/queryparser.h#L955), causing the test to return no results. To avoid test failures against older xapian versions I've removed the test completely.