### PR TITLE
Fix Typos in ICU dep part of meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,9 +80,9 @@ if xapian_dep.found()
         icu_dep = [icu_dep, dependency('icu-uc', static:static_linkage)]
     endif
 else
-    icu_dep = dependency('icu-i18n', 'required:false', static:static_linkage)
+    icu_dep = dependency('icu-i18n', required:false, static:static_linkage)
     if icu_dep.version().version_compare('>= 76')
-        icu_dep = [icu_dep, dependency('icu-uc', 'required:false', static:static_linkage)]
+        icu_dep = [icu_dep, dependency('icu-uc', required:false, static:static_linkage)]
     endif
 endif
 


### PR DESCRIPTION
Change 'required:false' to ONLY required:false.