### PR TITLE
ZIM file writing via buffered IO

### DIFF
--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -57,6 +57,11 @@ namespace zim
       checksumPos(std::numeric_limits<offset_type>::max())
   {}
 
+  void Fileheader::write(writer::BinaryFile& f) const
+  {
+    write(f.out_fd);
+  }
+
   void Fileheader::write(int out_fd) const
   {
     char header[Fileheader::size];

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -27,12 +27,6 @@
 #include "reader.h"
 #include "bufferstreamer.h"
 #include "buffer.h"
-#ifdef _WIN32
-# include "io.h"
-#else
-# include "unistd.h"
-# define _write(fd, addr, size) ::write((fd), (addr), (size))
-#endif
 
 log_define("zim.file.header")
 
@@ -74,13 +68,7 @@ namespace zim
     toLittleEndian(getLayoutPage(), header + 68);
     toLittleEndian(getChecksumPos(), header + 72);
 
-    auto ret = _write(f.out_fd, header, Fileheader::size);
-    if (ret != Fileheader::size) {
-      std::cerr << "Error Writing" << std::endl;
-      std::cerr << "Ret is " << ret << std::endl;
-      perror("Error writing");
-      throw std::runtime_error("Error writing");
-    }
+    f.write(header, Fileheader::size);
   }
 
   void Fileheader::read(const Reader& reader)

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -59,11 +59,6 @@ namespace zim
 
   void Fileheader::write(writer::BinaryFile& f) const
   {
-    write(f.out_fd);
-  }
-
-  void Fileheader::write(int out_fd) const
-  {
     char header[Fileheader::size];
     toLittleEndian(Fileheader::zimMagic, header);
     toLittleEndian(getMajorVersion(), header + 4);
@@ -79,7 +74,7 @@ namespace zim
     toLittleEndian(getLayoutPage(), header + 68);
     toLittleEndian(getChecksumPos(), header + 72);
 
-    auto ret = _write(out_fd, header, Fileheader::size);
+    auto ret = _write(f.out_fd, header, Fileheader::size);
     if (ret != Fileheader::size) {
       std::cerr << "Error Writing" << std::endl;
       std::cerr << "Ret is " << ret << std::endl;

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -24,6 +24,7 @@
 #include <zim/zim.h>
 #include <zim/uuid.h>
 #include "config.h"
+#include "./writer/binaryfile.h"
 
 #include <limits>
 
@@ -60,6 +61,7 @@ namespace zim
 
     public:
       Fileheader();
+      void write(writer::BinaryFile&) const;
       void write(int out_fd) const;
       void read(const Reader& reader);
 

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -62,7 +62,6 @@ namespace zim
     public:
       Fileheader();
       void write(writer::BinaryFile&) const;
-      void write(int out_fd) const;
       void read(const Reader& reader);
 
       // Do some sanity check, raise a ZimFileFormateError is

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ common_sources = [
     'istreamreader.cpp',
     'namedthread.cpp',
     'log.cpp',
+    'writer/binaryfile.cpp',
     'writer/contentProvider.cpp',
     'writer/creator.cpp',
     'writer/item.cpp',

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -23,6 +23,7 @@
 
 #include "cluster.h"
 #include "tinyString.h"
+#include "binaryfile.h"
 
 #include "debug.h"
 
@@ -170,6 +171,7 @@ namespace zim
               && getRedirectTargetDirent()->isPlaceholder();
         }
 
+        void write(BinaryFile&) const;
         void write(int out_fd) const;
 
         bool comparePath(const Dirent& other) const {

--- a/src/writer/_dirent.h
+++ b/src/writer/_dirent.h
@@ -172,7 +172,6 @@ namespace zim
         }
 
         void write(BinaryFile&) const;
-        void write(int out_fd) const;
 
         bool comparePath(const Dirent& other) const {
           return pathTitle.comparePath(other.pathTitle);

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -7,6 +7,8 @@
 
 #ifdef _WIN32
 #include <io.h>
+#else
+#include <unistd.h>
 #endif
 
 namespace zim
@@ -17,6 +19,8 @@ namespace writer
 
 void BinaryFile::openFile(const std::string& filePath)
 {
+  closeFile();
+
 #ifdef _WIN32
   int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
   int mode =  _S_IREAD | _S_IWRITE;
@@ -27,6 +31,14 @@ void BinaryFile::openFile(const std::string& filePath)
   out_fd = ::open(filePath.c_str(), flag, mode);
   if (out_fd == -1){
     throw std::runtime_error(std::strerror(errno));
+  }
+}
+
+void BinaryFile::closeFile()
+{
+  if ( out_fd != -1 ) {
+    ::close(out_fd);
+    out_fd = -1;
   }
 }
 

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -17,6 +17,15 @@ namespace zim
 namespace writer
 {
 
+BinaryFile::BinaryFile()
+{
+}
+
+BinaryFile::~BinaryFile()
+{
+  closeFile();
+}
+
 void BinaryFile::openFile(const std::string& filePath)
 {
   closeFile();

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -51,6 +51,11 @@ void BinaryFile::closeFile()
   }
 }
 
+offset_type BinaryFile::tellFilePos() const
+{
+  return lseek(out_fd, 0, SEEK_CUR);
+}
+
 } // namespace writer
 
 } // namespace zim

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -19,7 +19,8 @@ namespace zim
 namespace writer
 {
 
-BinaryFile::BinaryFile()
+BinaryFile::BinaryFile(int fd)
+  : out_fd(fd)
 {
 }
 

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -56,6 +56,13 @@ offset_type BinaryFile::tellFilePos() const
   return lseek(out_fd, 0, SEEK_CUR);
 }
 
+void BinaryFile::seek(offset_type pos)
+{
+  if ( offset_type(lseek(out_fd, pos, SEEK_SET)) != pos ) {
+    throw std::runtime_error(std::strerror(errno));
+  }
+}
+
 offset_type BinaryFile::seekEnd()
 {
   return lseek(out_fd, 0, SEEK_END);

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -9,6 +9,8 @@
 #include <io.h>
 #else
 #include <unistd.h>
+#define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
+{throw std::runtime_error("Error writing");}
 #endif
 
 namespace zim
@@ -66,6 +68,11 @@ void BinaryFile::seek(offset_type pos)
 offset_type BinaryFile::seekEnd()
 {
   return lseek(out_fd, 0, SEEK_END);
+}
+
+void BinaryFile::write(const char* buf, size_t size)
+{
+  _write(out_fd, buf, size);
 }
 
 } // namespace writer

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -56,6 +56,11 @@ offset_type BinaryFile::tellFilePos() const
   return lseek(out_fd, 0, SEEK_CUR);
 }
 
+offset_type BinaryFile::seekEnd()
+{
+  return lseek(out_fd, 0, SEEK_END);
+}
+
 } // namespace writer
 
 } // namespace zim

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -1,0 +1,35 @@
+#include "binaryfile.h"
+
+#include <fcntl.h>
+#include <cstring>
+
+#include <stdexcept>
+
+#ifdef _WIN32
+#include <io.h>
+#endif
+
+namespace zim
+{
+
+namespace writer
+{
+
+void BinaryFile::openFile(const std::string& filePath)
+{
+#ifdef _WIN32
+  int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
+  int mode =  _S_IREAD | _S_IWRITE;
+#else
+  int flag = O_RDWR | O_CREAT | O_TRUNC;
+  mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+#endif
+  out_fd = ::open(filePath.c_str(), flag, mode);
+  if (out_fd == -1){
+    throw std::runtime_error(std::strerror(errno));
+  }
+}
+
+} // namespace writer
+
+} // namespace zim

--- a/src/writer/binaryfile.cpp
+++ b/src/writer/binaryfile.cpp
@@ -9,8 +9,7 @@
 #include <io.h>
 #else
 #include <unistd.h>
-#define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
-{throw std::runtime_error("Error writing");}
+#define _dup(fd) dup(fd)
 #endif
 
 namespace zim
@@ -20,7 +19,7 @@ namespace writer
 {
 
 BinaryFile::BinaryFile(int fd)
-  : out_fd(fd)
+  : file(fd >= 0 ? fdopen(_dup(fd), "wb") : nullptr)
 {
 }
 
@@ -33,47 +32,54 @@ void BinaryFile::openFile(const std::string& filePath)
 {
   closeFile();
 
-#ifdef _WIN32
-  int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
-  int mode =  _S_IREAD | _S_IWRITE;
-#else
-  int flag = O_RDWR | O_CREAT | O_TRUNC;
-  mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-#endif
-  out_fd = ::open(filePath.c_str(), flag, mode);
-  if (out_fd == -1){
+  file = fopen(filePath.c_str(), "wb");
+  if ( !file ){
     throw std::runtime_error(std::strerror(errno));
+  }
+}
+
+void BinaryFile::flush()
+{
+  if ( file ) {
+    fflush(file);
   }
 }
 
 void BinaryFile::closeFile()
 {
-  if ( out_fd != -1 ) {
-    ::close(out_fd);
-    out_fd = -1;
+  if ( file ) {
+    flush();
+    fclose(file);
+    file = nullptr;
   }
 }
 
 offset_type BinaryFile::tellFilePos() const
 {
-  return lseek(out_fd, 0, SEEK_CUR);
+  return ftell(file);
 }
 
 void BinaryFile::seek(offset_type pos)
 {
-  if ( offset_type(lseek(out_fd, pos, SEEK_SET)) != pos ) {
+  if ( fseek(file, pos, SEEK_SET) == -1 ) {
     throw std::runtime_error(std::strerror(errno));
   }
 }
 
 offset_type BinaryFile::seekEnd()
 {
-  return lseek(out_fd, 0, SEEK_END);
+  if ( fseek(file, 0, SEEK_END) == -1 ) {
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  return tellFilePos();
 }
 
 void BinaryFile::write(const char* buf, size_t size)
 {
-  _write(out_fd, buf, size);
+  if ( fwrite(buf, 1, size, file) != size ) {
+    throw std::runtime_error(std::strerror(errno));
+  }
 }
 
 } // namespace writer

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -33,6 +33,12 @@ namespace writer
 class LIBZIM_PRIVATE_API BinaryFile
 {
 public: // functions
+  BinaryFile(const BinaryFile& ) = delete;
+  void operator=(const BinaryFile& ) = delete;
+
+  BinaryFile();
+  ~BinaryFile();
+
   void openFile(const std::string& filePath);
   void closeFile();
 

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -22,6 +22,8 @@
 
 #include "config.h"
 
+#include <string>
+
 namespace zim
 {
 
@@ -30,8 +32,11 @@ namespace writer
 
 class LIBZIM_PRIVATE_API BinaryFile
 {
-public:
-    int out_fd;
+public: // functions
+  void openFile(const std::string& filePath);
+
+public: // data
+  int out_fd = -1;
 };
 
 } // namespace writer

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -44,6 +44,7 @@ public: // functions
   void closeFile();
 
   offset_type tellFilePos() const;
+  void seek(offset_type pos);
   offset_type seekEnd();
 
 public: // data

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -21,6 +21,7 @@
 #define ZIM_WRITER_BINARY_FILE_H
 
 #include "config.h"
+#include "zim/zim.h"
 
 #include <string>
 
@@ -41,6 +42,8 @@ public: // functions
 
   void openFile(const std::string& filePath);
   void closeFile();
+
+  offset_type tellFilePos() const;
 
 public: // data
   int out_fd = -1;

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -24,6 +24,7 @@
 #include "zim/zim.h"
 
 #include <string>
+#include <stdio.h>
 
 namespace zim
 {
@@ -49,8 +50,12 @@ public: // functions
 
   void write(const char* buf, size_t size);
 
+  void flush();
+
 private: // data
-  int out_fd = -1;
+  // For our use cases C stdio proves to be significantly more efficient than
+  // std::ofstream or (untuned) custom buffering over raw syscalls to write()
+  FILE* file = nullptr;
 };
 
 } // namespace writer

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -37,7 +37,7 @@ public: // functions
   BinaryFile(const BinaryFile& ) = delete;
   void operator=(const BinaryFile& ) = delete;
 
-  BinaryFile();
+  explicit BinaryFile(int fd = -1);
   ~BinaryFile();
 
   void openFile(const std::string& filePath);
@@ -49,7 +49,7 @@ public: // functions
 
   void write(const char* buf, size_t size);
 
-public: // data
+private: // data
   int out_fd = -1;
 };
 

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -34,6 +34,7 @@ class LIBZIM_PRIVATE_API BinaryFile
 {
 public: // functions
   void openFile(const std::string& filePath);
+  void closeFile();
 
 public: // data
   int out_fd = -1;

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef ZIM_WRITER_BINARY_FILE_H
+#define ZIM_WRITER_BINARY_FILE_H
+
+#include "config.h"
+
+namespace zim
+{
+
+namespace writer
+{
+
+class LIBZIM_PRIVATE_API BinaryFile
+{
+public:
+    int out_fd;
+};
+
+} // namespace writer
+
+} // namespace zim
+
+#endif // ZIM_WRITER_BINARY_FILE_H

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -47,6 +47,8 @@ public: // functions
   void seek(offset_type pos);
   offset_type seekEnd();
 
+  void write(const char* buf, size_t size);
+
 public: // data
   int out_fd = -1;
 };

--- a/src/writer/binaryfile.h
+++ b/src/writer/binaryfile.h
@@ -44,6 +44,7 @@ public: // functions
   void closeFile();
 
   offset_type tellFilePos() const;
+  offset_type seekEnd();
 
 public: // data
   int out_fd = -1;

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -158,18 +158,13 @@ void Cluster::_compress()
 
 void Cluster::write(BinaryFile& f) const
 {
-  write(f.out_fd);
-}
-
-void Cluster::write(int out_fd) const
-{
   // write clusterInfo
   char clusterInfo = 0;
   if (isExtended) {
     clusterInfo = 0x10;
   }
   clusterInfo += static_cast<uint8_t>(getCompression());
-  if (_write(out_fd, &clusterInfo, 1) == -1) {
+  if (_write(f.out_fd, &clusterInfo, 1) == -1) {
     throw std::runtime_error("Error writing");
   }
 
@@ -178,7 +173,7 @@ void Cluster::write(int out_fd) const
   {
     case Compression::None:
     {
-      auto writer = [=](const Blob& data) -> void {
+      auto writer = [&f](const Blob& data) -> void {
         // Ideally we would simply have to do :
         // ::write(tmp_fd, data.c_str(), data.size());
         // However, the data can be pretty big (> 4Gb), especially with test,
@@ -187,7 +182,7 @@ void Cluster::write(int out_fd) const
         const char* src = data.data();
         while (to_write) {
          size_type chunk_size = std::min(MAX_WRITE_SIZE, to_write);
-         auto ret = _write(out_fd, src, chunk_size);
+         auto ret = _write(f.out_fd, src, chunk_size);
          src += ret;
          to_write -= ret;
         }
@@ -199,7 +194,7 @@ void Cluster::write(int out_fd) const
     case Compression::Zstd:
       {
         log_debug("compress data");
-        if (_write(out_fd, compressed_data.data(), compressed_data.size()) == -1) {
+        if (_write(f.out_fd, compressed_data.data(), compressed_data.size()) == -1) {
           throw std::runtime_error("Error writing");
         }
         break;

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -156,6 +156,11 @@ void Cluster::_compress()
   compressed_data = Blob(comp.release(), size.v);
 }
 
+void Cluster::write(BinaryFile& f) const
+{
+  write(f.out_fd);
+}
+
 void Cluster::write(int out_fd) const
 {
   // write clusterInfo

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -32,14 +32,7 @@
 #include <fcntl.h>
 #include <stdexcept>
 
-#ifdef _WIN32
-# include <io.h>
-#else
-# include <unistd.h>
-# define _write(fd, addr, size) ::write((fd), (addr), (size))
-#endif
-
-const zim::size_type MAX_WRITE_SIZE(4UL*1024*1024*1024-1);
+const zim::size_type MAX_WRITE_SIZE(16UL*1024*1024);
 
 namespace zim {
 namespace writer {
@@ -164,9 +157,7 @@ void Cluster::write(BinaryFile& f) const
     clusterInfo = 0x10;
   }
   clusterInfo += static_cast<uint8_t>(getCompression());
-  if (_write(f.out_fd, &clusterInfo, 1) == -1) {
-    throw std::runtime_error("Error writing");
-  }
+  f.write(&clusterInfo, 1);
 
   // Open a comprestion stream if needed
   switch(getCompression())
@@ -177,14 +168,14 @@ void Cluster::write(BinaryFile& f) const
         // Ideally we would simply have to do :
         // ::write(tmp_fd, data.c_str(), data.size());
         // However, the data can be pretty big (> 4Gb), especially with test,
-        // And ::write fails to write data > 4Gb. So we have to chunck the write.
+        // And ::write fails to write data > 4Gb. So we have to chunk the write.
         size_type to_write = data.size();
         const char* src = data.data();
         while (to_write) {
-         size_type chunk_size = std::min(MAX_WRITE_SIZE, to_write);
-         auto ret = _write(f.out_fd, src, chunk_size);
-         src += ret;
-         to_write -= ret;
+         const size_type chunk_size = std::min(MAX_WRITE_SIZE, to_write);
+         f.write(src, chunk_size);
+         src += chunk_size;
+         to_write -= chunk_size;
         }
       };
       write_content(writer);
@@ -194,9 +185,7 @@ void Cluster::write(BinaryFile& f) const
     case Compression::Zstd:
       {
         log_debug("compress data");
-        if (_write(f.out_fd, compressed_data.data(), compressed_data.size()) == -1) {
-          throw std::runtime_error("Error writing");
-        }
+        f.write(compressed_data.data(), compressed_data.size());
         break;
       }
 

--- a/src/writer/cluster.h
+++ b/src/writer/cluster.h
@@ -31,6 +31,7 @@
 #include "../zim_types.h"
 #include "../debug.h"
 #include "config.h"
+#include "binaryfile.h"
 
 namespace zim {
 
@@ -75,6 +76,7 @@ class LIBZIM_PRIVATE_API Cluster {
       return offset_t(1) + offset_t((count().v + 1) * (isExtended?sizeof(uint64_t):sizeof(uint32_t)));
     }
 
+    void write(BinaryFile&) const;
     void write(int out_fd) const;
 
   protected:

--- a/src/writer/cluster.h
+++ b/src/writer/cluster.h
@@ -77,7 +77,6 @@ class LIBZIM_PRIVATE_API Cluster {
     }
 
     void write(BinaryFile&) const;
-    void write(int out_fd) const;
 
   protected:
     Compression compression;

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -503,8 +503,7 @@ void Creator::finishZimCreation()
 
   TINFO("write zimfile :");
   writeLastParts();
-  ::close(data->out_fd);
-  data->out_fd = -1;
+  data->closeFile();
 
   TINFO("rename tmpfile to final one.");
   DEFAULTFS::rename(data->tmpFileName, data->zimName);
@@ -621,7 +620,7 @@ CreatorData::CreatorData(const std::string& fname,
 {
   openFile(tmpFileName);
   if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
-    close(out_fd);
+    closeFile();
     throw std::runtime_error(std::strerror(errno));
   }
 
@@ -655,9 +654,7 @@ CreatorData::~CreatorData()
   for(auto& cluster: clustersList) {
     delete cluster;
   }
-  if ( out_fd != - 1 ) {
-    ::close(out_fd);
-  }
+  closeFile();
   if ( ! tmpFileName.empty() ) {
     DEFAULTFS::removeFile(tmpFileName);
   }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -254,6 +254,18 @@ void writeChecksum(int fd)
   _write(fd, reinterpret_cast<const char*>(digest), 16);
 }
 
+void addChecksum(const std::string& filePath)
+{
+#ifdef _WIN32
+  const int flag = _O_RDWR | _O_BINARY;
+#else
+  const int flag = O_RDWR;
+#endif
+  const int fd = ::open(filePath.c_str(), flag);
+  writeChecksum(fd);
+  ::close(fd);
+}
+
 } // unnamed namespace
 
 Creator::Creator()
@@ -498,6 +510,10 @@ void Creator::finishZimCreation()
   DEFAULTFS::rename(data->tmpFileName, data->zimName);
   data->tmpFileName.clear();
 
+  INFO("Adding checksum...");
+  addChecksum(data->zimName);
+  INFO("ZIM file is ready!");
+
   TINFO("finish");
 }
 
@@ -565,9 +581,6 @@ void Creator::writeLastParts() const
   TINFO(" write header");
   lseek(out_fd, 0, SEEK_SET);
   header.write(out_fd);
-
-  TINFO(" write checksum");
-  writeChecksum(out_fd);
 }
 
 void Creator::checkError()

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -209,6 +209,20 @@ class TitleListingProvider : public ContentProvider {
     DirentPtrs::const_iterator m_it;
 };
 
+typedef std::deque<offset_t> DirentOffsets;
+
+DirentOffsets writeDirents(int fd, const CreatorData::UrlSortedDirents& dirents)
+{
+  DirentOffsets direntOffsets;
+  lseek(fd, 0, SEEK_END);
+  for (Dirent* dirent: dirents)
+  {
+    direntOffsets.push_back(offset_t(lseek(fd, 0, SEEK_CUR)));
+    dirent->write(fd);
+  }
+  return direntOffsets;
+}
+
 } // unnamed namespace
 
 Creator::Creator()
@@ -497,15 +511,8 @@ void Creator::writeLastParts() const
   // TODO: the offset values with dirent size values and reconstructing
   // TODO: the offsets as a running sum starting from the offset of the
   // TODO: first dirent
-  std::deque<offset_t> direntOffsets;
-
   TINFO(" write directory entries");
-  lseek(out_fd, 0, SEEK_END);
-  for (Dirent* dirent: data->dirents)
-  {
-    direntOffsets.push_back(offset_t(lseek(out_fd, 0, SEEK_CUR)));
-    dirent->write(out_fd);
-  }
+  const DirentOffsets direntOffsets = writeDirents(out_fd, data->dirents);
 
   TINFO(" write path ptr list");
   header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -229,7 +229,7 @@ void writeDirentOffsets(BinaryFile& f, const DirentOffsets& direntOffsets)
   {
     char tmp_buff[sizeof(offset_type)];
     toLittleEndian(offset, tmp_buff);
-    _write(f.out_fd, tmp_buff, sizeof(offset_type));
+    f.write(tmp_buff, sizeof(offset_type));
   }
 }
 
@@ -539,16 +539,15 @@ void Creator::writeLastParts() const
   fillHeader(&header);
 
   BinaryFile& outFile = *data;
-  const int out_fd = outFile.out_fd;
 
   outFile.seek(header.getMimeListPos());
   TINFO(" write mimetype list");
   for(auto& mimeType: data->mimeTypesList)
   {
-    _write(out_fd, mimeType.c_str(), mimeType.size()+1);
+    outFile.write(mimeType.c_str(), mimeType.size()+1);
   }
 
-  _write(out_fd, "", 1);
+  outFile.write("", 1);
 
   ASSERT(outFile.tellFilePos(), <, offset_type(CLUSTER_BASE_OFFSET));
 
@@ -573,7 +572,7 @@ void Creator::writeLastParts() const
   {
     char tmp_buff[sizeof(offset_type)];
     toLittleEndian(cluster->getOffset(), tmp_buff);
-    _write(out_fd, tmp_buff, sizeof(offset_type));
+    outFile.write(tmp_buff, sizeof(offset_type));
   }
 
   header.setChecksumPos(outFile.tellFilePos());

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -233,6 +233,27 @@ void writeDirentOffsets(int fd, const DirentOffsets& direntOffsets)
   }
 }
 
+void writeChecksum(int fd)
+{
+  struct zim_MD5_CTX md5ctx;
+  unsigned char batch_read[1024+1];
+  lseek(fd, 0, SEEK_SET);
+  zim_MD5Init(&md5ctx);
+  while (true) {
+     auto r = read(fd, batch_read, 1024);
+     if (r == -1) {
+       throw std::runtime_error(std::strerror(errno));
+     }
+     if (r == 0)
+       break;
+     batch_read[r] = 0;
+     zim_MD5Update(&md5ctx, batch_read, r);
+  }
+  unsigned char digest[16];
+  zim_MD5Final(digest, &md5ctx);
+  _write(fd, reinterpret_cast<const char*>(digest), 16);
+}
+
 } // unnamed namespace
 
 Creator::Creator()
@@ -546,23 +567,7 @@ void Creator::writeLastParts() const
   header.write(out_fd);
 
   TINFO(" write checksum");
-  struct zim_MD5_CTX md5ctx;
-  unsigned char batch_read[1024+1];
-  lseek(out_fd, 0, SEEK_SET);
-  zim_MD5Init(&md5ctx);
-  while (true) {
-     auto r = read(out_fd, batch_read, 1024);
-     if (r == -1) {
-       throw std::runtime_error(std::strerror(errno));
-     }
-     if (r == 0)
-       break;
-     batch_read[r] = 0;
-     zim_MD5Update(&md5ctx, batch_read, r);
-  }
-  unsigned char digest[16];
-  zim_MD5Final(digest, &md5ctx);
-  _write(out_fd, reinterpret_cast<const char*>(digest), 16);
+  writeChecksum(out_fd);
 }
 
 void Creator::checkError()

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -580,7 +580,7 @@ void Creator::writeLastParts() const
 
   TINFO(" write header");
   lseek(out_fd, 0, SEEK_SET);
-  header.write(out_fd);
+  header.write(outFile);
 }
 
 void Creator::checkError()

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -620,7 +620,6 @@ CreatorData::CreatorData(const std::string& fname,
 {
   openFile(tmpFileName);
   if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
-    closeFile();
     throw std::runtime_error(std::strerror(errno));
   }
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -223,6 +223,16 @@ DirentOffsets writeDirents(int fd, const CreatorData::UrlSortedDirents& dirents)
   return direntOffsets;
 }
 
+void writeDirentOffsets(int fd, const DirentOffsets& direntOffsets)
+{
+  for (auto offset : direntOffsets)
+  {
+    char tmp_buff[sizeof(offset_type)];
+    toLittleEndian(offset, tmp_buff);
+    _write(fd, tmp_buff, sizeof(offset_type));
+  }
+}
+
 } // unnamed namespace
 
 Creator::Creator()
@@ -516,12 +526,7 @@ void Creator::writeLastParts() const
 
   TINFO(" write path ptr list");
   header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
-  for (auto offset : direntOffsets)
-  {
-    char tmp_buff[sizeof(offset_type)];
-    toLittleEndian(offset, tmp_buff);
-    _write(out_fd, tmp_buff, sizeof(offset_type));
-  }
+  writeDirentOffsets(out_fd, direntOffsets);
 
   } // writing dirents
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -223,13 +223,13 @@ DirentOffsets writeDirents(BinaryFile& f, const CreatorData::UrlSortedDirents& d
   return direntOffsets;
 }
 
-void writeDirentOffsets(int fd, const DirentOffsets& direntOffsets)
+void writeDirentOffsets(BinaryFile& f, const DirentOffsets& direntOffsets)
 {
   for (auto offset : direntOffsets)
   {
     char tmp_buff[sizeof(offset_type)];
     toLittleEndian(offset, tmp_buff);
-    _write(fd, tmp_buff, sizeof(offset_type));
+    _write(f.out_fd, tmp_buff, sizeof(offset_type));
   }
 }
 
@@ -563,7 +563,7 @@ void Creator::writeLastParts() const
 
   TINFO(" write path ptr list");
   header.setPathPtrPos(outFile.tellFilePos());
-  writeDirentOffsets(out_fd, direntOffsets);
+  writeDirentOffsets(outFile, direntOffsets);
 
   } // writing dirents
 

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -218,7 +218,7 @@ DirentOffsets writeDirents(BinaryFile& f, const CreatorData::UrlSortedDirents& d
   for (Dirent* dirent: dirents)
   {
     direntOffsets.push_back(offset_t(f.tellFilePos()));
-    dirent->write(f.out_fd);
+    dirent->write(f);
   }
   return direntOffsets;
 }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -214,7 +214,7 @@ typedef std::deque<offset_t> DirentOffsets;
 DirentOffsets writeDirents(BinaryFile& f, const CreatorData::UrlSortedDirents& dirents)
 {
   DirentOffsets direntOffsets;
-  lseek(f.out_fd, 0, SEEK_END);
+  f.seekEnd();
   for (Dirent* dirent: dirents)
   {
     direntOffsets.push_back(offset_t(f.tellFilePos()));

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -538,7 +538,8 @@ void Creator::writeLastParts() const
   Fileheader header;
   fillHeader(&header);
 
-  int out_fd = data->out_fd;
+  BinaryFile& outFile = *data;
+  const int out_fd = outFile.out_fd;
 
   lseek(out_fd, header.getMimeListPos(), SEEK_SET);
   TINFO(" write mimetype list");
@@ -549,7 +550,7 @@ void Creator::writeLastParts() const
 
   _write(out_fd, "", 1);
 
-  ASSERT(lseek(out_fd, 0, SEEK_CUR), <, CLUSTER_BASE_OFFSET);
+  ASSERT(outFile.tellFilePos(), <, offset_type(CLUSTER_BASE_OFFSET));
 
   { // writing dirents
 
@@ -561,13 +562,13 @@ void Creator::writeLastParts() const
   const DirentOffsets direntOffsets = writeDirents(out_fd, data->dirents);
 
   TINFO(" write path ptr list");
-  header.setPathPtrPos(lseek(out_fd, 0, SEEK_CUR));
+  header.setPathPtrPos(outFile.tellFilePos());
   writeDirentOffsets(out_fd, direntOffsets);
 
   } // writing dirents
 
   TINFO(" write cluster offset list");
-  header.setClusterPtrPos(lseek(out_fd, 0, SEEK_CUR));
+  header.setClusterPtrPos(outFile.tellFilePos());
   for (auto cluster : data->clustersList)
   {
     char tmp_buff[sizeof(offset_type)];
@@ -575,7 +576,7 @@ void Creator::writeLastParts() const
     _write(out_fd, tmp_buff, sizeof(offset_type));
   }
 
-  header.setChecksumPos(lseek(out_fd, 0, SEEK_CUR));
+  header.setChecksumPos(outFile.tellFilePos());
 
   TINFO(" write header");
   lseek(out_fd, 0, SEEK_SET);

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -48,9 +48,7 @@
 
 #ifdef _WIN32
 # include <io.h>
-# include <fcntl.h>
 #else
-# include <unistd.h>
 # define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
 {throw std::runtime_error("Error writing");}
 #endif

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -541,7 +541,7 @@ void Creator::writeLastParts() const
   BinaryFile& outFile = *data;
   const int out_fd = outFile.out_fd;
 
-  lseek(out_fd, header.getMimeListPos(), SEEK_SET);
+  outFile.seek(header.getMimeListPos());
   TINFO(" write mimetype list");
   for(auto& mimeType: data->mimeTypesList)
   {
@@ -579,7 +579,7 @@ void Creator::writeLastParts() const
   header.setChecksumPos(outFile.tellFilePos());
 
   TINFO(" write header");
-  lseek(out_fd, 0, SEEK_SET);
+  outFile.seek(0);
   header.write(outFile);
 }
 
@@ -620,9 +620,7 @@ CreatorData::CreatorData(const std::string& fname,
     start_time(time(NULL))
 {
   openFile(tmpFileName);
-  if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
-    throw std::runtime_error(std::strerror(errno));
-  }
+  seek(CLUSTER_BASE_OFFSET);
 
   // We keep both a "compressed cluster" and an "uncompressed cluster"
   // because we don't know which one will fill up first.  We also need

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -619,17 +619,7 @@ CreatorData::CreatorData(const std::string& fname,
     nbUnCompClusters(0),
     start_time(time(NULL))
 {
-#ifdef _WIN32
-  int flag = _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY;
-  int mode =  _S_IREAD | _S_IWRITE;
-#else
-  int flag = O_RDWR | O_CREAT | O_TRUNC;
-  mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-#endif
-  out_fd = open(tmpFileName.c_str(), flag, mode);
-  if (out_fd == -1){
-    throw std::runtime_error(std::strerror(errno));
-  }
+  openFile(tmpFileName);
   if(lseek(out_fd, CLUSTER_BASE_OFFSET, SEEK_SET) != CLUSTER_BASE_OFFSET) {
     close(out_fd);
     throw std::runtime_error(std::strerror(errno));

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -503,7 +503,7 @@ void Creator::finishZimCreation()
 
   TINFO("write zimfile :");
   writeLastParts();
-  data->closeFile();
+  data->outFile.closeFile();
 
   TINFO("rename tmpfile to final one.");
   DEFAULTFS::rename(data->tmpFileName, data->zimName);
@@ -538,7 +538,7 @@ void Creator::writeLastParts() const
   Fileheader header;
   fillHeader(&header);
 
-  BinaryFile& outFile = *data;
+  BinaryFile& outFile = data->outFile;
 
   outFile.seek(header.getMimeListPos());
   TINFO(" write mimetype list");
@@ -618,8 +618,8 @@ CreatorData::CreatorData(const std::string& fname,
     nbUnCompClusters(0),
     start_time(time(NULL))
 {
-  openFile(tmpFileName);
-  seek(CLUSTER_BASE_OFFSET);
+  outFile.openFile(tmpFileName);
+  outFile.seek(CLUSTER_BASE_OFFSET);
 
   // We keep both a "compressed cluster" and an "uncompressed cluster"
   // because we don't know which one will fill up first.  We also need
@@ -651,7 +651,7 @@ CreatorData::~CreatorData()
   for(auto& cluster: clustersList) {
     delete cluster;
   }
-  closeFile();
+  outFile.closeFile();
   if ( ! tmpFileName.empty() ) {
     DEFAULTFS::removeFile(tmpFileName);
   }

--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -211,14 +211,14 @@ class TitleListingProvider : public ContentProvider {
 
 typedef std::deque<offset_t> DirentOffsets;
 
-DirentOffsets writeDirents(int fd, const CreatorData::UrlSortedDirents& dirents)
+DirentOffsets writeDirents(BinaryFile& f, const CreatorData::UrlSortedDirents& dirents)
 {
   DirentOffsets direntOffsets;
-  lseek(fd, 0, SEEK_END);
+  lseek(f.out_fd, 0, SEEK_END);
   for (Dirent* dirent: dirents)
   {
-    direntOffsets.push_back(offset_t(lseek(fd, 0, SEEK_CUR)));
-    dirent->write(fd);
+    direntOffsets.push_back(offset_t(f.tellFilePos()));
+    dirent->write(f.out_fd);
   }
   return direntOffsets;
 }
@@ -559,7 +559,7 @@ void Creator::writeLastParts() const
   // TODO: the offsets as a running sum starting from the offset of the
   // TODO: first dirent
   TINFO(" write directory entries");
-  const DirentOffsets direntOffsets = writeDirents(out_fd, data->dirents);
+  const DirentOffsets direntOffsets = writeDirents(outFile, data->dirents);
 
   TINFO(" write path ptr list");
   header.setPathPtrPos(outFile.tellFilePos());

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -51,7 +51,7 @@ namespace zim
     class Cluster;
     class Task;
 
-    class CreatorData : public BinaryFile
+    class CreatorData
     {
       public:
         typedef std::set<Dirent*, UrlCompare> UrlSortedDirents;
@@ -121,6 +121,7 @@ namespace zim
         const Compression compression;
         std::string zimName;
         std::string tmpFileName;
+        BinaryFile  outFile;
         bool isEmpty = true;
         size_t clusterSize;
         Cluster *compCluster = nullptr;

--- a/src/writer/creatordata.h
+++ b/src/writer/creatordata.h
@@ -36,6 +36,7 @@
 
 #include "../fileheader.h"
 #include "direntPool.h"
+#include "binaryfile.h"
 
 namespace zim
 {
@@ -49,7 +50,8 @@ namespace zim
 
     class Cluster;
     class Task;
-    class CreatorData
+
+    class CreatorData : public BinaryFile
     {
       public:
         typedef std::set<Dirent*, UrlCompare> UrlSortedDirents;
@@ -123,7 +125,6 @@ namespace zim
         size_t clusterSize;
         Cluster *compCluster = nullptr;
         Cluster *uncompCluster = nullptr;
-        int out_fd;
 
         bool withIndex;
         std::string indexingLanguage;

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -108,6 +108,11 @@ entry_index_t Dirent::getRedirectIndex() const      {
   return targetDirent->getIdx();
 }
 
+void Dirent::write(BinaryFile& f) const
+{
+  write(f.out_fd);
+}
+
 void Dirent::write(int out_fd) const
 {
   const static char zero = 0;

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -110,11 +110,6 @@ entry_index_t Dirent::getRedirectIndex() const      {
 
 void Dirent::write(BinaryFile& f) const
 {
-  write(f.out_fd);
-}
-
-void Dirent::write(int out_fd) const
-{
   const static char zero = 0;
   union
   {
@@ -132,17 +127,17 @@ void Dirent::write(int out_fd) const
   if (isRedirect())
   {
     zim::toLittleEndian(getRedirectIndex().v, header.d + 8);
-    _write(out_fd, header.d, 12);
+    _write(f.out_fd, header.d, 12);
   }
   else
   {
     zim::toLittleEndian(zim::cluster_index_type(getClusterNumber()), header.d + 8);
     zim::toLittleEndian(zim::blob_index_type(getBlobNumber()), header.d + 12);
-    _write(out_fd, header.d, 16);
+    _write(f.out_fd, header.d, 16);
   }
 
-  _write(out_fd, pathTitle.data(), pathTitle.size());
-  _write(out_fd, &zero, 1);
+  _write(f.out_fd, pathTitle.data(), pathTitle.size());
+  _write(f.out_fd, &zero, 1);
 }
 
 } // namespace writer

--- a/src/writer/dirent.cpp
+++ b/src/writer/dirent.cpp
@@ -26,13 +26,6 @@
 #include "log.h"
 #include <algorithm>
 #include <cstring>
-#ifdef _WIN32
-# include <io.h>
-#else
-# include <unistd.h>
-# define _write(fd, addr, size) if(::write((fd), (addr), (size)) != (ssize_t)(size)) \
-{throw std::runtime_error("Error writing");}
-#endif
 
 log_define("zim.dirent")
 
@@ -127,17 +120,17 @@ void Dirent::write(BinaryFile& f) const
   if (isRedirect())
   {
     zim::toLittleEndian(getRedirectIndex().v, header.d + 8);
-    _write(f.out_fd, header.d, 12);
+    f.write(header.d, 12);
   }
   else
   {
     zim::toLittleEndian(zim::cluster_index_type(getClusterNumber()), header.d + 8);
     zim::toLittleEndian(zim::blob_index_type(getBlobNumber()), header.d + 12);
-    _write(f.out_fd, header.d, 16);
+    f.write(header.d, 16);
   }
 
-  _write(f.out_fd, pathTitle.data(), pathTitle.size());
-  _write(f.out_fd, &zero, 1);
+  f.write(pathTitle.data(), pathTitle.size());
+  f.write(&zero, 1);
 }
 
 } // namespace writer

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -74,7 +74,7 @@ namespace zim
             }
             creatorData->clusterToWrite.popFromQueue(cluster);
             cluster->setOffset(offset_t(creatorData->tellFilePos()));
-            cluster->write(creatorData->out_fd);
+            cluster->write(static_cast<BinaryFile&>(*creatorData));
             cluster->clear_data();
             wait = 0;
           }

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -73,7 +73,7 @@ namespace zim
               continue;
             }
             creatorData->clusterToWrite.popFromQueue(cluster);
-            cluster->setOffset(offset_t(lseek(creatorData->out_fd, 0, SEEK_CUR)));
+            cluster->setOffset(offset_t(creatorData->tellFilePos()));
             cluster->write(creatorData->out_fd);
             cluster->clear_data();
             wait = 0;

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -73,8 +73,8 @@ namespace zim
               continue;
             }
             creatorData->clusterToWrite.popFromQueue(cluster);
-            cluster->setOffset(offset_t(creatorData->tellFilePos()));
-            cluster->write(static_cast<BinaryFile&>(*creatorData));
+            cluster->setOffset(offset_t(creatorData->outFile.tellFilePos()));
+            cluster->write(creatorData->outFile);
             cluster->clear_data();
             wait = 0;
           }

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -389,7 +389,9 @@ const std::string OUTPUT_FROM_TIDY_ZIM_CREATION =
     "Detect dangling redirects\n"
     "Detect loops and/or blind chains of redirects\n"
     "Index titles\n"
-    "Set entry indices\n";
+    "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n";
 
 TEST(ZimCreator, redirectAddedAfterItsTargetIsCreated)
 {
@@ -691,6 +693,8 @@ TEST(ZimCreator, handlingOfAnAscendingBlindChainOfRedirections)
     "Redirection C/redirectB -> C/redirectC belongs to a blind chain or loop. Removing...\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -739,6 +743,8 @@ TEST(ZimCreator, handlingOfADescendingBlindChainOfRedirections)
     "Redirection C/redirectC -> C/redirectB belongs to a blind chain or loop. Removing...\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -787,6 +793,8 @@ TEST(ZimCreator, handlingOfRedirectionLoops)
     "Redirection C/redirectZ -> C/redirectY belongs to a blind chain or loop. Removing...\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -888,6 +896,8 @@ TEST(ZimCreator, pruningOfARedirectionForest)
     "Redirection C/Z -> C/Y belongs to a blind chain or loop. Removing...\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive archive(tempPath);
@@ -963,6 +973,8 @@ TEST(ZimCreator, addingATargetForAnAlreadyAddedRedirectFails)
     "Detect loops and/or blind chains of redirects\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive a(tempPath);
@@ -1033,6 +1045,8 @@ TEST(ZimCreator, titleIndexingOfDroppedEntries)
     "Redirection C/adios -> C/farewell belongs to a blind chain or loop. Removing...\n"
     "Index titles\n"
     "Set entry indices\n"
+    "Adding checksum...\n"
+    "ZIM file is ready!\n"
   );
 
   const zim::Archive a(tempPath);

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -58,8 +58,7 @@ zim::Dirent read_from_buffer(const zim::Buffer& buf)
 size_t writtenDirentSize(const zim::writer::Dirent& dirent)
 {
   TempFile tmpFile("test_dirent");
-  zim::writer::BinaryFile bf;
-  bf.out_fd = dup(tmpFile.fd());
+  zim::writer::BinaryFile bf(dup(tmpFile.fd()));
   dirent.write(bf);
   return bf.seekEnd();
 }

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -58,9 +58,10 @@ zim::Dirent read_from_buffer(const zim::Buffer& buf)
 size_t writtenDirentSize(const zim::writer::Dirent& dirent)
 {
   TempFile tmpFile("test_dirent");
-  const auto tmp_fd = tmpFile.fd();
-  dirent.write(tmp_fd);
-  auto size = lseek(tmp_fd, 0, SEEK_END);
+  zim::writer::BinaryFile bf;
+  bf.out_fd = dup(tmpFile.fd());
+  dirent.write(bf);
+  auto size = lseek(bf.out_fd, 0, SEEK_END);
   return size;
 }
 

--- a/test/dirent.cpp
+++ b/test/dirent.cpp
@@ -61,8 +61,7 @@ size_t writtenDirentSize(const zim::writer::Dirent& dirent)
   zim::writer::BinaryFile bf;
   bf.out_fd = dup(tmpFile.fd());
   dirent.write(bf);
-  auto size = lseek(bf.out_fd, 0, SEEK_END);
-  return size;
+  return bf.seekEnd();
 }
 
 TEST(DirentTest, size)

--- a/test/tools.h
+++ b/test/tools.h
@@ -36,6 +36,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #include "../src/buffer.h"
+#include "../src/writer/binaryfile.h"
 #include <limits.h>
 
 #define ZIM_PRIVATE
@@ -146,8 +147,10 @@ template<typename T>
 zim::Buffer write_to_buffer(const T& object, const std::string& tail="")
 {
   TempFile tmpFile("test_temp_file");
-  const auto tmp_fd = tmpFile.fd();
-  object.write(tmp_fd);
+  const auto tmp_fd = dup(tmpFile.fd());
+  zim::writer::BinaryFile bf;
+  bf.out_fd = tmp_fd;
+  object.write(bf);
   if (write(tmp_fd, tail.data(), tail.size()) != (ssize_t)tail.size()) {
     throw std::runtime_error("Cannot write to " + tmpFile.path());
   }

--- a/test/tools.h
+++ b/test/tools.h
@@ -148,8 +148,7 @@ zim::Buffer write_to_buffer(const T& object, const std::string& tail="")
 {
   TempFile tmpFile("test_temp_file");
   const auto tmp_fd = dup(tmpFile.fd());
-  zim::writer::BinaryFile bf;
-  bf.out_fd = tmp_fd;
+  zim::writer::BinaryFile bf(tmp_fd);
   object.write(bf);
   if (write(tmp_fd, tail.data(), tail.size()) != (ssize_t)tail.size()) {
     throw std::runtime_error("Cannot write to " + tmpFile.path());

--- a/test/tools.h
+++ b/test/tools.h
@@ -150,6 +150,7 @@ zim::Buffer write_to_buffer(const T& object, const std::string& tail="")
   const auto tmp_fd = dup(tmpFile.fd());
   zim::writer::BinaryFile bf(tmp_fd);
   object.write(bf);
+  bf.flush();
   if (write(tmp_fd, tail.data(), tail.size()) != (ssize_t)tail.size()) {
     throw std::runtime_error("Cannot write to " + tmpFile.path());
   }


### PR DESCRIPTION
Fixes #1086

This PR speeds-up ZIM writing by taking advantage of buffered IO. It has the greatest effect when writing dirents and their offsets. In a test flow with 20M redirects the duration of that step dropped from 66 seconds to the lovely less-than-3 (<3) seconds (the decrease in total time of ZIM creation is less impressive - from 140s down to 76s).

The PR mostly consists of refactoring changes in preparation for the clean and safe implementation of the optimization.

An important side change is how the checksum is added to the ZIM file. During ZIM file creation everything is written to a temporary file which is renamed to the user requested filename only upon successful completion (this is not new, it used to be that way for a long time). Any C++ exception thrown during the execution of `zim::writer::Creator::finishZimCreation()` leads to the said temporary file being automatically deleted. Before, that applied also to exceptions caused by IO errors during the checksum computation step. Now, the checksum is not included in the temporary file; the checksum is added to the final file (after the renaming). This opens up the possibility of ending up with a pseudo-invalid ZIM file being delivered by the `zim::Creator`, however such ZIM files can be easily fixed by a simple external script that adds the missing checksum.