### PR TITLE
Compile with C++23 standard

### DIFF
--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -520,7 +520,7 @@ private: // data
 
     auto cluster_index_type = idx.v;
     auto key = std::make_tuple(this, cluster_index_type);
-    auto cluster = getClusterCache().getOrPut(key, [=](){ return readCluster(idx); });
+    auto cluster = getClusterCache().getOrPut(key, [this, idx](){ return readCluster(idx); });
 #if ENV32BIT
     // There was a bug in the way we create the zim files using ZSTD compression.
     // We were using a too high compression level and so a window of 128Mb.


### PR DESCRIPTION
Resolves: #1042 

* Removes deprecated lambda-capture-list syntax