### PR TITLE
Conditionally exclude writer from build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,14 @@ jobs:
           meson.exe test --verbose
 
   Linux:
+    name: "Linux (${{matrix.target}}, with_xapian=${{matrix.with_xapian}}, without_writer=${{ matrix.without_writer != '' && format('{0}', matrix.without_writer) }} )"
     strategy:
       fail-fast: false
       matrix:
         target:
           - linux-x86_64-static
-          - jammy-x86_64-dyn
+          # The ci for jammy jobs is configured in the 'include' section below
+          # - jammy-x86_64-dyn  
           - noble-x86_64-dyn
           - resolute-x86_64-dyn
           - linux-aarch64-musl-dyn
@@ -169,7 +171,27 @@ jobs:
             lib_postfix: '/x86_64-linux-gnu'
             arch_name: linux-x86_64
             run_test: true
+            coverage: true
+            with_xapian: true
+            without_writer: true
+          - target: jammy-x86_64-dyn
+            image_variant: jammy
+            dl_deps_archive_target: linux-x86_64-dyn
+            lib_postfix: '/x86_64-linux-gnu'
+            arch_name: linux-x86_64
+            run_test: true
             coverage: false
+            with_xapian: true
+            without_writer: false
+          - target: jammy-x86_64-dyn
+            image_variant: jammy
+            dl_deps_archive_target: linux-x86_64-dyn
+            lib_postfix: '/x86_64-linux-gnu'
+            arch_name: linux-x86_64
+            run_test: true
+            coverage: false
+            with_xapian: false
+            without_writer: false
           - target: noble-x86_64-dyn
             image_variant: noble
             dl_deps_archive_target: linux-x86_64-dyn
@@ -272,6 +294,11 @@ jobs:
           if [[ "${{matrix.target}}" == wasm ]]
           then
             MESON_OPTION="$MESON_OPTION -Dexamples=false"
+          fi
+
+          if [[ "${{matrix.without_writer}}" != '' ]]
+          then
+            MESON_OPTION="$MESON_OPTION -Dwithout_writer=${{matrix.without_writer}}"
           fi
 
           meson setup . build ${MESON_OPTION} -Dwith_xapian=${{matrix.with_xapian}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,19 @@ jobs:
           - target: macos-aarch64-dyn
             arch_name: arm64-apple-macos
             run_test: true
+            without_writer: false
           - target: macos-x86_64-dyn
             arch_name: x86_64-apple-darwin
             run_test: true
+            without_writer: false
           - target: ios-arm64-dyn
             arch_name: aarch64-apple-ios
             run_test: false
+            without_writer: true
           - target: ios-x86_64-dyn
             arch_name: x86-apple-ios-simulator
             run_test: false
+            without_writer: true
     runs-on: macos-26
 
     steps:
@@ -61,12 +65,13 @@ jobs:
       - name: Compile
         shell: bash
         run: |
-          MESON_OPTION="--default-library=shared"
+          MESON_OPTION="--default-library=shared -Dwithout_writer=${{matrix.without_writer}}"
           MESON_CROSSFILE="$HOME/BUILD_${{matrix.arch_name}}/meson_cross_file.txt"
           if [ -e $MESON_CROSSFILE ]; then
             MESON_OPTION="$MESON_OPTION --cross-file $MESON_CROSSFILE -Dstatic-linkage=true"
             cat $MESON_CROSSFILE
           fi
+
           export PKG_CONFIG_PATH=$HOME/BUILD_${{matrix.arch_name}}/INSTALL/lib/pkgconfig
           meson . build ${MESON_OPTION}
           cd build
@@ -227,6 +232,7 @@ jobs:
             arch_name: arm-linux-androideabi
             run_test: false
             coverage: false
+            without_writer: true
           - target: android-arm64
             image_variant: jammy
             dl_deps_archive_target: android-arm64
@@ -234,6 +240,7 @@ jobs:
             arch_name: aarch64-linux-android
             run_test: false
             coverage: false
+            without_writer: true
           - target: wasm
             image_variant: jammy
             dl_deps_archive_target: wasm
@@ -241,6 +248,7 @@ jobs:
             arch_name: wasm64-emscripten
             run_test: false
             coverage: false
+            without_writer: true
         exclude:
           - target: noble-x86_64-dyn # Already tested wihout Xapian on jammy-x86_64-dyn
             with_xapian: false

--- a/include/zim/meson.build
+++ b/include/zim/meson.build
@@ -26,10 +26,11 @@ if xapian_dep.found()
   )
 endif
 
-install_headers(
-    'writer/item.h',
-    'writer/creator.h',
-    'writer/contentProvider.h',
-    subdir:'zim/writer'
-)
-
+if not get_option('without_writer')
+  install_headers(
+      'writer/item.h',
+      'writer/creator.h',
+      'writer/contentProvider.h',
+      subdir:'zim/writer'
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,12 @@ if get_option('default_library') == 'shared'
   add_project_arguments('-DLIBZIM_EXPORT_PRIVATE_DLL', language: 'cpp')
 endif
 
+without_writer = get_option('without_writer')
+if without_writer
+  private_conf.set('LIBZIM_WITHOUT_WRITER', without_writer)
+  public_conf.set('LIBZIM_WITHOUT_WRITER', without_writer)
+endif
+
 zstd_dep = dependency('libzstd', static:static_linkage, default_options:['werror=false'])
 
 if host_machine.system() == 'freebsd'
@@ -94,7 +100,9 @@ subdir('include')
 subdir('scripts')
 subdir('static')
 subdir('src')
-if get_option('examples')
+# The example project demonstrates writer usage
+# so only include it if the writer is also present
+if get_option('examples') and not get_option('without_writer')
   subdir('examples')
 endif
 if get_option('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,3 +24,5 @@ option('with_xapian', type : 'boolean', value: true,
   description: 'Build libzim with xapian support')
 option('test_data_dir', type : 'string', value: '',
   description: 'Where the test data are. If not set, meson will use a internal directory in  the build dir. If you want to download the data in the specified directory you can use `meson download_test_data`. As a special value, you can pass `none` to deactivate test using external test data.')
+option('without_writer', type : 'boolean', value : false, 
+  description: 'Compile only the libzim reader tools')

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -29,4 +29,6 @@
 
 #mesondefine ENV32BIT
 
+#mesondefine LIBZIM_WITHOUT_WRITER
+
 #endif // ZIM_CONFIG_H

--- a/src/fileheader.cpp
+++ b/src/fileheader.cpp
@@ -50,7 +50,7 @@ namespace zim
       layoutPage(std::numeric_limits<entry_index_type>::max()),
       checksumPos(std::numeric_limits<offset_type>::max())
   {}
-
+#ifndef LIBZIM_WITHOUT_WRITER
   void Fileheader::write(writer::BinaryFile& f) const
   {
     char header[Fileheader::size];
@@ -70,6 +70,7 @@ namespace zim
 
     f.write(header, Fileheader::size);
   }
+#endif
 
   void Fileheader::read(const Reader& reader)
   {

--- a/src/fileheader.h
+++ b/src/fileheader.h
@@ -24,7 +24,10 @@
 #include <zim/zim.h>
 #include <zim/uuid.h>
 #include "config.h"
-#include "./writer/binaryfile.h"
+
+#ifndef LIBZIM_WITHOUT_WRITER
+  #include "./writer/binaryfile.h"
+#endif
 
 #include <limits>
 
@@ -61,7 +64,9 @@ namespace zim
 
     public:
       Fileheader();
-      void write(writer::BinaryFile&) const;
+      #ifndef LIBZIM_WITHOUT_WRITER
+        void write(writer::BinaryFile&) const;
+      #endif
       void read(const Reader& reader);
 
       // Do some sanity check, raise a ZimFileFormateError is

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,24 @@ configure_file(output : 'config.h',
 
 src_directory = include_directories('.')
 
+writer_sources = [
+    'writer/binaryfile.cpp',
+    'writer/contentProvider.cpp',
+    'writer/creator.cpp',
+    'writer/item.cpp',
+    'writer/cluster.cpp',
+    'writer/dirent.cpp',
+    'writer/workers.cpp',
+    'writer/clusterWorker.cpp',
+    'writer/counterHandler.cpp'
+]
+
+xapian_writer_sources = [
+    'writer/xapianIndexer.cpp',
+    'writer/xapianWorker.cpp',
+    'writer/xapianHandler.cpp'
+]
+
 common_sources = [
 #    'config.h',
     'archive.cpp',
@@ -27,15 +45,6 @@ common_sources = [
     'istreamreader.cpp',
     'namedthread.cpp',
     'log.cpp',
-    'writer/binaryfile.cpp',
-    'writer/contentProvider.cpp',
-    'writer/creator.cpp',
-    'writer/item.cpp',
-    'writer/cluster.cpp',
-    'writer/dirent.cpp',
-    'writer/workers.cpp',
-    'writer/clusterWorker.cpp',
-    'writer/counterHandler.cpp',
     'suggestion.cpp',
     'suggestion_iterator.cpp',
     'version.cpp'
@@ -51,20 +60,25 @@ xapian_sources = [
     'search.cpp',
     'search_iterator.cpp',
     'xapian/htmlparse.cc',
-    'xapian/myhtmlparse.cc',
-    'writer/xapianIndexer.cpp',
-    'writer/xapianWorker.cpp',
-    'writer/xapianHandler.cpp'
+    'xapian/myhtmlparse.cc'
 ]
 
 sources = common_sources
 deps = [thread_dep, lzma_dep, zstd_dep, win_deps]
+
+without_writer = get_option('without_writer')
+if not without_writer
+    sources += writer_sources
+endif
 
 if target_machine.system() == 'freebsd'
     deps += [execinfo_dep]
 endif
 
 if xapian_dep.found()
+    if not without_writer 
+        xapian_sources += xapian_writer_sources
+    endif
     sources += xapian_sources
     sources += lib_resources
     deps += [xapian_dep, icu_dep]

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -23,7 +23,6 @@
 #include "zim/tools.h"
 #include "zim/illustration.h"
 #include "fs.h"
-#include "writer/_dirent.h"
 
 #include <sys/types.h>
 #include <string.h>

--- a/src/tools.h
+++ b/src/tools.h
@@ -29,7 +29,6 @@
 #include "config.h"
 
 #include <zim/item.h>
-#include "zim/writer/item.h"
 
 #if defined(ENABLE_XAPIAN)
 namespace Xapian {

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,17 +1,29 @@
-tests = [
+writer_dependant_tests = [
+    'cluster',
+    'dirent',
+    'creator',
+    'error_in_creator',
+    'indexing_criteria',
+    'tinyString',
+    'suggestion_iterator',
+    'archive',
+    'header',
+    'reader',
+    'iterator',
+    'find'
+]
+xapian_writer_dependant_tests = [
+    'search', 
+    'defaultIndexdata', 
+    'suggestion', 
+    'search_iterator'
+]
+
+all_tests = [
     'log',
     'lrucache',
     'concurrentcache',
-    'cluster',
-    'creator',
-    'dirent',
-    'error_in_creator',
-    'header',
     'uuid',
-    'archive',
-    'iterator',
-    'reader',
-    'find',
     'compression',
     'dirent_lookup',
     'istreamreader',
@@ -21,15 +33,15 @@ tests = [
     'parseLongPath',
     'random',
     'tooltesting',
-    'tinyString',
-    'suggestion_iterator',
-    'indexing_criteria',
     'counterParsing',
     'illustrations'
 ]
 
-if xapian_dep.found()
-    tests += ['search', 'defaultIndexdata', 'search_iterator', 'suggestion']
+if not get_option('without_writer')
+    if xapian_dep.found()
+        writer_dependant_tests += xapian_writer_dependant_tests
+    endif
+    all_tests += writer_dependant_tests
 endif
 
 datadir = get_option('test_data_dir')
@@ -52,7 +64,7 @@ if cpp.get_id() == 'gcc' and cpp.version().version_compare('>=12.0.0') and cpp.v
 endif
 
 if gtest_dep.found() and not meson.is_cross_build()
-    foreach test_name : tests
+    foreach test_name : all_tests
         test_exe = executable(test_name, [test_name+'.cpp', 'tools.cpp'],
                               implicit_include_directories: false,
                               include_directories: [include_directory, src_directory],

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -384,6 +384,7 @@ TEST(Suggestion, checkStopword) {
   );
 }
 
+#ifndef LIBZIM_WITHOUT_WRITER
 TEST(Suggestion, checkRedirectionCollapse) {
   TempZimArchive tza("testZim");
   zim::writer::Creator creator;
@@ -463,7 +464,7 @@ TEST(Suggestion, diffArticleSameTitle) {
                                             };
   ASSERT_EQ(resultSet, expectedResult);
 }
-
+#endif
 // Titles which begins with the search string should have higher relevance
 TEST(Suggestion, anchorQueryToBeginning) {
   std::vector<std::string> titles = {
@@ -647,6 +648,8 @@ TEST(Suggestion, reuseSearcher) {
   }
   ASSERT_EQ(count, 3);
 }
+
+#ifndef LIBZIM_WITHOUT_WRITER
 
 std::shared_ptr<TestItem> makeHtmlItem(std::string path, std::string title) {
   return std::make_shared<TestItem>(path, "text/html", title);
@@ -848,5 +851,6 @@ TEST(Suggestion, indexFullPath) {
   ASSERT_EQ(database.get_document(6).get_data(), "C/Volume2/Chapter3");
   ASSERT_EQ(database.get_document(7).get_data(), "C/Volume2/Chapter4");
 }
+#endif // LIBZIM_WITHOUT_WRITER
 
 } // unnamed namespace

--- a/test/tools.cpp
+++ b/test/tools.cpp
@@ -160,6 +160,7 @@ const std::vector<TestFile> getDataFilePath(const std::string& filename, const s
   return filePaths;
 }
 
+#ifndef LIBZIM_WITHOUT_WRITER
 zim::Archive TempZimArchive::createZimFromTitles(std::vector<std::string> titles) {
   zim::writer::Creator creator;
   creator.configIndexing(true, "en");
@@ -195,6 +196,7 @@ zim::Archive TempZimArchive::createZimFromContent(std::vector<std::vector<std::s
   creator.finishZimCreation();
   return zim::Archive(this->path());
 }
+#endif
 
 const std::string TempZimArchive::getPath() const {
   return this->path();

--- a/test/tools.h
+++ b/test/tools.h
@@ -41,9 +41,13 @@ typedef SSIZE_T ssize_t;
 
 #define ZIM_PRIVATE
 #include <zim/archive.h>
-#include <zim/writer/creator.h>
-#include <zim/writer/item.h>
-#include <zim/writer/contentProvider.h>
+
+#ifndef LIBZIM_WITHOUT_WRITER
+  #include <zim/writer/creator.h>
+  #include <zim/writer/item.h>
+  #include <zim/writer/contentProvider.h>
+#endif
+
 #include <zim/tools.h>
 
 namespace zim
@@ -194,7 +198,9 @@ enum class IsFrontArticle {
   DEFAULT
 };
 
-class TestItem : public zim::writer::Item {
+#ifndef LIBZIM_WITHOUT_WRITER
+class TestItem : public zim::writer::Item 
+{
   public:
     TestItem(
         const std::string& path,
@@ -213,6 +219,7 @@ class TestItem : public zim::writer::Item {
     virtual std::string getPath() const { return path; };
     virtual std::string getTitle() const { return title; };
     virtual std::string getMimeType() const { return mimetype; };
+
     virtual zim::writer::Hints getHints() const {
       switch (frontArticle) {
         case IsFrontArticle::YES:
@@ -234,6 +241,8 @@ class TestItem : public zim::writer::Item {
   std::string mimetype;
   IsFrontArticle frontArticle;
 };
+#endif // LIBZIM_WITHOUT_WRITER
+
 
 } // namespace unittests
 


### PR DESCRIPTION
Fixes #789

## Changes:
* Introduces a new build flag to `meson` for managing inclusion of libzim's writer tools
* When present; removes zim's writer source from the build at compile-time
* In addition to source removal, only the necessary tests are compiled into the final build output