### PR TITLE
Fix typos across the codebase

### DIFF
--- a/include/zim/archive.h
+++ b/include/zim/archive.h
@@ -85,7 +85,7 @@ namespace zim
    * When using new namespace scheme:
    * - User entries are always stored without namespace.
    *   (For information, they are stored in the same namespace `C`. Still consider there is no namespace as all API masks it)
-   *   As there is no namespace, paths don't contain it: `foo.hmtl`, `image.png`, ...
+   *   As there is no namespace, paths don't contain it: `foo.html`, `image.png`, ...
    * - All API taking or returning a path expect/will return a path without namespace.
    *
    * This difference may seem complex to handle, but not so much.
@@ -374,7 +374,7 @@ namespace zim
 
       /** Return a list of available sizes (width) for the illustrations in the archive.
        *
-       * Illustration is an icon for the archive that can be used in catalog and elsewehere to illustrate the archive.
+       * Illustration is an icon for the archive that can be used in catalog and elsewhere to illustrate the archive.
        * An Archive may contains several illustrations with different size.
        * This method allows to know which illustration are in the archive (by size: width)
        *
@@ -456,9 +456,9 @@ namespace zim
        *
        *  Use the index of the entry to get the idx'th entry
        *  The actual order of the entry is not really specified.
-       *  It is infered from the internal way the entry are stored.
+       *  It is inferred from the internal way the entry are stored.
        *
-       *  This method is probably not relevent and is provided for completeness.
+       *  This method is probably not relevant and is provided for completeness.
        *  You should probably use a iterator using the `efficientOrder`.
        *
        *  @param idx The index of the entry.
@@ -476,7 +476,7 @@ namespace zim
 
       /** Get a random entry.
        *
-       * The entry is picked randomly from the front artice list.
+       * The entry is picked randomly from the front article list.
        *
        * @return A random entry.
        * @exception EntryNotFound If no valid random entry can be found.

--- a/include/zim/blob.h
+++ b/include/zim/blob.h
@@ -42,12 +42,12 @@ namespace zim
 
     public: // functions
       /**
-       * Constuct a empty `Blob`
+       * Construct an empty `Blob`
        */
       Blob();
 
       /**
-       * Constuct `Blob` pointing to `data`.
+       * Construct `Blob` pointing to `data`.
        *
        * The created blob only point to the data and doesn't own it.
        * User must care that data is not freed before using the blob.
@@ -55,7 +55,7 @@ namespace zim
       Blob(const char* data, size_type size);
 
       /**
-       * Constuct `Blob` pointing to `data`.
+       * Construct `Blob` pointing to `data`.
        *
        * The created blob shares the ownership on data.
        */

--- a/include/zim/entry.h
+++ b/include/zim/entry.h
@@ -59,7 +59,7 @@ namespace zim
       /** Get the item associated to the target entry.
        *
        * If there is a chain of redirection, the whole chain is resolved
-       * and the item associted to the last entry is returned.
+       * and the item associated to the last entry is returned.
        *
        * @return the Item associated with the targeted entry.
        * @exception InvalidType if the entry is not a redirection.

--- a/include/zim/item.h
+++ b/include/zim/item.h
@@ -47,7 +47,7 @@ namespace zim
        *
        * Get the data of the item, starting at offset.
        *
-       * @param offset The number of byte to skip at begining of the data.
+       * @param offset The number of byte to skip at beginning of the data.
        * @return A blob corresponding to the data.
        */
       Blob getData(offset_type offset=0) const;
@@ -56,7 +56,7 @@ namespace zim
        *
        * Get the `size` bytes of data of the item, starting at offset.
        *
-       * @param offset The number of byte to skip at begining of the data.
+       * @param offset The number of byte to skip at beginning of the data.
        * @param size The number of byte to read.
        * @return A blob corresponding to the data.
        */
@@ -74,7 +74,7 @@ namespace zim
        * If possible, this function give information about which file
        * and at which to read to get the data.
        *
-       * It can be usefull as an optimisation when interacting with other system
+       * It can be useful as an optimisation when interacting with other system
        * by reopeing the file and reading the content bypassing the libzim.
        *
        * @return A pair of filename/offset specifying where read the content.

--- a/include/zim/search.h
+++ b/include/zim/search.h
@@ -45,7 +45,7 @@ class SearchResultSet;
  * A Searcher is a object fulltext searching a set of Archives
  *
  * A Searcher is mainly used to create new `Search`
- * Internaly, this is mainly a wrapper around a Xapian database.
+ * Internally, this is mainly a wrapper around a Xapian database.
  *
  * All search (at exception of SearchIterator) operation are thread safe.
  * You can freely create several Search from one Searcher and use them in different threads.
@@ -132,7 +132,7 @@ class LIBZIM_API Query
      * Some article may be geo positioned.
      * You can search for articles in a certain distance of a point.
      *
-     * @param latitude The latitute of the point.
+     * @param latitude The latitude of the point.
      * @param longitude The longitude of the point.
      * @param distance The maximal distance from the point.
      */
@@ -162,7 +162,7 @@ class LIBZIM_API Search
 
         /** Get a set of results for this search.
          *
-         * @param start The begining of the range to get
+         * @param start The beginning of the range to get
          *              (offset of the first result).
          * @param maxResults The maximum number of results to return
          *                   (offset of last result from the start of range).

--- a/include/zim/search_iterator.h
+++ b/include/zim/search_iterator.h
@@ -32,12 +32,12 @@ namespace zim
 class SearchResultSet;
 
 /**
- * A interator on search result (an Entry)
+ * An iterator on search result (an Entry)
  *
  * SearchIterator are mostly thread safe:
  * - Manipulating the iterator itself (increment it, ...) is not thread safe.
  *   You should not share an iterator between different thread (and you probably don't have use case for that)
- * - Reading from two iterators (getPath, ...) from two differents thread is ok.
+ * - Reading from two iterators (getPath, ...) from two different threads is ok.
  *   (ie: You can pass iterator from one thread to the other one)
  *
  * Be aware that the referenced/pointed Entry is generated and stored

--- a/include/zim/suggestion.h
+++ b/include/zim/suggestion.h
@@ -44,7 +44,7 @@ class SuggestionDataBase;
  * A SuggestionSearcher is a object suggesting over titles of an Archive
  *
  * A SuggestionSearcher is mainly used to create new `SuggestionSearch`
- * Internaly, this is a wrapper around a SuggestionDataBase with may or may not
+ * Internally, this is a wrapper around a SuggestionDataBase which may or may not
  * include a Xapian index.
  *
  * You should consider that all search operations are NOT threadsafe.
@@ -104,7 +104,7 @@ class LIBZIM_API SuggestionSearch
 
         /** Get a set of results for this search.
          *
-         * @param start The begining of the range to get
+         * @param start The beginning of the range to get
          *              (offset of the first result).
          * @param maxResults The maximum number of results to return
          *                   (offset of last result from the start of range).

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -466,7 +466,7 @@ namespace zim
     // So the end index will always be just after the prefix range. If there is no prefix range, both
     // begin and end will be just after where it would be.
     //
-    // Suposing a list of title :
+    // Supposing a list of titles:
     // 0. aaaaaa
     // 1. aaaaab
     // 2. aabbaa

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -210,7 +210,7 @@ getClusterReader(const Reader& zimReader, offset_t offset, Cluster::Compression*
   // Our approach is to return the average memory consumption by this cluster
   // under the assumption that half of its data is decompressed.
   // Note:
-  //  - No need to protect this method from concurent access (as well
+  //  - No need to protect this method from concurrent access (as well
   //    as memoize its result) as it is intended to be called by ConcurentCache
   //    which should invoke this method exactly once per cluster object
   size_t Cluster::getMemorySize() const {

--- a/src/compression.h
+++ b/src/compression.h
@@ -131,7 +131,7 @@ class Uncompressor
               // no more input.
               return RunnerStatus::NEED_MORE;
             } else {
-              // Not enought output size.
+              // Not enough output size.
               // Allocate more memory and continue the loop.
               DEB("need memory " << data_size << " " << stream.avail_out << " " << stream.total_out)
               data_size *= 2;
@@ -147,7 +147,7 @@ class Uncompressor
             // On first call where lzma cannot progress (no output size).
             // Lzma return OK. If we return NEED_MORE, then we will try to compress
             // with new input data, but we should not as current one is not processed.
-            // We must do a second step to have te BUF_ERROR and handle thing correctly.
+            // We must do a second step to have the BUF_ERROR and handle thing correctly.
             // If we have no more input, then we must ask for more.
             if (stream.avail_in == 0) {
               return RunnerStatus::NEED_MORE;

--- a/src/dirent.cpp
+++ b/src/dirent.cpp
@@ -123,7 +123,7 @@ namespace zim
     // the title, path and extra parameters.
     // This is a pity but we have no choice.
     // We cannot take a buffer of the size of the file, it would be really
-    // inefficient. Let's do try, catch and retry while chosing a smart value
+    // inefficient. Let's do try, catch and retry while choosing a smart value
     // for the buffer size. Most dirent will be "Article" entry (header's size
     // == 16) without extra parameters. Let's hope that path + title size will
     // be < 256 and if not try again with a bigger size.

--- a/src/fileimpl.cpp
+++ b/src/fileimpl.cpp
@@ -309,7 +309,7 @@ private: // data
     auto cluster = getCluster(dirent->getClusterNumber());
     if (cluster->isCompressed()) {
       // This is a ZimFileFormatError.
-      // Let's be tolerent and skip the entry
+      // Let's be tolerant and skip the entry
       return nullptr;
     }
     auto titleOffset = getClusterOffset(dirent->getClusterNumber()) + cluster->getBlobOffset(dirent->getBlobNumber());
@@ -523,15 +523,15 @@ private: // data
     auto cluster = getClusterCache().getOrPut(key, [=](){ return readCluster(idx); });
 #if ENV32BIT
     // There was a bug in the way we create the zim files using ZSTD compression.
-    // We were using a too hight compression level and so a window of 128Mb.
+    // We were using a too high compression level and so a window of 128Mb.
     // So at decompression, zstd reserve a 128Mb buffer.
     // While this memory is not really used (thanks to lazy allocation of OS),
     // we are still consumming address space. On 32bits this start to be a rare
-    // ressource when we reserved 128Mb at once.
+    // resource when we reserved 128Mb at once.
     // So we drop the cluster from the cache to avoid future memory allocation error.
     if (cluster->getCompression() == Cluster::Compression::Zstd) {
       // ZSTD compression starts to be used on version 5.0 of zim format.
-      // Recently after, we switch to 5.1 and itegrate the fix in zstd creation.
+      // Shortly after, we switched to 5.1 and integrated the fix in zstd creation.
       // 5.0 is not a perfect way to detect faulty zim file (it will generate false
       // positives) but it should be enough.
       if (header.getMajorVersion() == 5 && header.getMinorVersion() == 0) {

--- a/src/lrucache.h
+++ b/src/lrucache.h
@@ -1,5 +1,5 @@
 /*
- * Copyrigth (c) 2021, Matthieu Gautier <mgautier@kymeria.fr>
+ * Copyright (c) 2021, Matthieu Gautier <mgautier@kymeria.fr>
  * Copyright (c) 2020, Veloman Yunkan
  * Copyright (c) 2014, lamerman
  * All rights reserved.
@@ -73,7 +73,7 @@ struct UnitCostEstimation {
  *   consideration is used to select which item to drop.
  *
  * This lru cache is parametrized by a CostEstimation type. The type must have a
- * static method `cost` taking a reference to a `value_t` and returing its
+ * static method `cost` taking a reference to a `value_t` and returning its
  * "cost". As already said, this method must always return the same cost for
  * the same value.
  */

--- a/src/narrowdown.h
+++ b/src/narrowdown.h
@@ -36,7 +36,7 @@ namespace zim
 // narrow down the range in which the query key should belong.
 //
 // The target usage of this class is as a partial in-memory index for a sorted
-// list residing in external storage with high access cost to inidividual items.
+// list residing in external storage with high access cost to individual items.
 //
 // Illustration:
 //
@@ -109,8 +109,8 @@ public: // functions
   {
     // It would be better to have `key >= nextKey`, but pretty old zim file were not enforce to
     // have unique path, just that entries were sorted by path, but two entries could have the same path.
-    // It is somehow a bug and have been fixed then, but we still have to be tolerent here and accept that
-    // two concecutive keys can be equal.
+    // It is somehow a bug and have been fixed then, but we still have to be tolerant here and accept that
+    // two consecutive keys can be equal.
     if (key > nextKey) {
       Formatter fmt;
       fmt << "Dirent table is not properly sorted:\n";

--- a/src/reader.h
+++ b/src/reader.h
@@ -47,7 +47,7 @@ class LIBZIM_PRIVATE_API Reader {
     void read(char* dest, offset_t offset, zsize_t size) const {
       if (can_read(offset, size)) {
         if (size) {
-          // Do the actuall read only if we have a size to read
+          // Do the actual read only if we have a size to read
           readImpl(dest, offset, size);
         }
         return;

--- a/src/search_internal.h
+++ b/src/search_internal.h
@@ -105,7 +105,7 @@ class InternalDataBase {
     std::vector<Archive> m_archives;
 
     // If the database is open for suggestion.
-    // True even if the dabase has no newSuggestionformat.
+    // True even if the database has no newSuggestionformat.
     bool m_suggestionMode;
 
     // The query parser corresponding to the database.

--- a/src/suggestion.cpp
+++ b/src/suggestion.cpp
@@ -277,7 +277,7 @@ Xapian::Enquire& SuggestionSearch::getEnquire() const
    /*
     * In suggestion mode, we are searching over a separate title index. Default BM25 is not
     * adapted for this case. WDF factor(k1) controls the effect of within document frequency.
-    * k1 = 0.001 reduces the effect of word repitition in document. In BM25, smaller documents
+    * k1 = 0.001 reduces the effect of word repetition in document. In BM25, smaller documents
     * get larger weights, so normalising the length of documents is necessary using b = 1.
     * The document set is first sorted by their relevance score then by value so that suggestion
     * results are closer to search string.

--- a/src/writer/cluster.cpp
+++ b/src/writer/cluster.cpp
@@ -159,7 +159,7 @@ void Cluster::write(BinaryFile& f) const
   clusterInfo += static_cast<uint8_t>(getCompression());
   f.write(&clusterInfo, 1);
 
-  // Open a comprestion stream if needed
+  // Open a compression stream if needed
   switch(getCompression())
   {
     case Compression::None:

--- a/src/writer/defaultIndexData.h
+++ b/src/writer/defaultIndexData.h
@@ -60,7 +60,7 @@ namespace zim
           }
           std::lock_guard<std::mutex> lock(m_initLock);
           // We have to do a double check to be sure that two call on a un-initialized object
-          // will not be initiialized twice.
+          // will not be initialized twice.
           if (m_initialized) {
             return;
           }

--- a/src/writer/workers.cpp
+++ b/src/writer/workers.cpp
@@ -66,7 +66,7 @@ namespace zim
           wait += 100;
           if(creatorData->clusterToWrite.getHead(cluster)) {
             if (cluster == nullptr) {
-              // All cluster writen, we can quit
+              // All clusters written, we can quit
               return nullptr;
             }
             if (not cluster->isClosed()) {

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -184,7 +184,7 @@ TEST_F(ZimArchive, openCreatedArchive)
   creator.addIllustration(zim::IllustrationInfo{96, 96, 1, {}}, "PNGBinaryContent96");
   creator.setMainPath("foo");
   creator.addRedirection("foo3", "FooRedirection", "foo"); // No a front article.
-  creator.addRedirection("foo4", "FooRedirection", "NoExistant"); // Invalid redirection, must be removed by creator
+  creator.addRedirection("foo4", "FooRedirection", "NoExistent"); // Invalid redirection, must be removed by creator
   creator.finishZimCreation();
 
   zim::Archive archive(tempPath);
@@ -258,10 +258,10 @@ TEST_F(ZimArchive, openCreatedArchive)
   ASSERT_EQ(main.getRedirectEntryIndex(), foo.getIndex());
   ASSERT_EQ(archive.getMainEntryIndex(), main.getIndex());
 
-  // NO existant entries
-  ASSERT_THROW(archive.getEntryByPath("non/existant/path"), zim::EntryNotFound);
-  ASSERT_THROW(archive.getEntryByPath("C/non/existant/path"), zim::EntryNotFound);
-  ASSERT_THROW(archive.getEntryByPathWithNamespace('C', "non/existant/path"), zim::EntryNotFound);
+  // Nonexistent entries
+  ASSERT_THROW(archive.getEntryByPath("non/existent/path"), zim::EntryNotFound);
+  ASSERT_THROW(archive.getEntryByPath("C/non/existent/path"), zim::EntryNotFound);
+  ASSERT_THROW(archive.getEntryByPathWithNamespace('C', "non/existent/path"), zim::EntryNotFound);
 }
 
 #if WITH_TEST_DATA

--- a/test/cluster.cpp
+++ b/test/cluster.cpp
@@ -197,7 +197,7 @@ class FakeProvider : public zim::writer::ContentProvider
 
 TEST(ClusterTest, read_write_extended_cluster)
 {
-  //zim::writer doesn't suport 32 bits architectures.
+  //zim::writer doesn't support 32 bits architectures.
   if (SIZE_MAX == UINT32_MAX) {
     return;
   }

--- a/test/error_in_creator.cpp
+++ b/test/error_in_creator.cpp
@@ -303,9 +303,9 @@ TEST_P(FaultyDelayedItemErrorTest, faultyCompressedItem)
   // We force the closing of the cluster, so working thread will detect error
   CHECK_ASYNC_EXCEPT(creator.addMetadata("A metadata", "A compressed (default) metadata"));
   // give a chance to threads to detect the error.
-  // How many time to wait is a bit tricky.
-  // Too long and all tests will wait to much and developpers hate to wait,
-  // Not enough and error is not deteced and tests fail (and developpers hate failing tets)
+  // How much time to wait is a bit tricky.
+  // Too long and all tests will wait too much and developers hate to wait,
+  // Not enough and error is not detected and tests fail (and developers hate failing tests)
   // The exact value is specific to each computer, so we need to make this configurable.
   // We use a base and we multiply it by a factor taken from env variable.
   const long sleep_time = 1000000; // Default value is set to a factor 10 above what is needed to work on my (fast) computer
@@ -334,9 +334,9 @@ TEST_P(FaultyDelayedItemErrorTest, faultyUnCompressedItem)
   CHECK_ASYNC_EXCEPT(creator.addMetadata("A metadata", "A uncompressed metadata", "plain/content"));
   // give a chance to threads to detect the error
   // How many time to wait is a bit tricky.
-  // Too long and all tests will wait to much and developpers hate to wait
-  // Not enough and error is not deteced and tests fail (and developpers hate failing tets)
-  // The exacte value is specific to each computer, so we need to make this configurable.
+  // Too long and all tests will wait too much and developers hate to wait
+  // Not enough and error is not detected and tests fail (and developers hate failing tests)
+  // The exact value is specific to each computer, so we need to make this configurable.
   // We use a base and we multiply it by a factor taken from env variable.
   // Note here, that we have a base smaller than for compressed test as we don't compress the content
   // and the writer thread (the one using the contentProvider) detect the error sooner

--- a/test/find.cpp
+++ b/test/find.cpp
@@ -169,7 +169,7 @@ TEST(FindTests, ByTitleWithDuplicate)
   creator.finishZimCreation();
 
   zim::Archive archive(tza.getPath());
-  // First binary seach step will look for index 3 (0+6/2) which is a BBB,
+  // First binary search step will look for index 3 (0+6/2) which is a BBB,
   // but we want to be sure it returns article2 which is the start of the range "BBB*"
   CHECK_FIND_TITLE_COUNT("BBB", 3)
   CHECK_FIND_TITLE_COUNT("BB", 4)

--- a/test/search.cpp
+++ b/test/search.cpp
@@ -53,7 +53,7 @@ std::vector<std::string> getSnippet(const zim::Archive archive, std::string quer
     std::vector<std::string>({__VA_ARGS__})                     \
   )
 
-// To secure compatibity of new zim files with older kiwixes, we need to index
+// To secure compatibility of new zim files with older kiwixes, we need to index
 // full path of the entries as data of documents.
 TEST(Search, indexFullPath)
 {

--- a/test/suggestion.cpp
+++ b/test/suggestion.cpp
@@ -813,7 +813,7 @@ zim::Entry getTitleIndexEntry(const zim::Archive& a)
   return a.getEntryByPathWithNamespace('X', "title/xapian");
 }
 
-// To secure compatibity of new zim files with older kiwixes, we need to index
+// To secure compatibility of new zim files with older kiwixes, we need to index
 // full path of the entries as data of documents.
 TEST(Suggestion, indexFullPath) {
   TempZimArchiveMadeOfEmptyHtmlArticles tza("en", {

--- a/test/tooltesting.cpp
+++ b/test/tooltesting.cpp
@@ -98,7 +98,7 @@ namespace {
     ASSERT_EQ(zim::removeAccents("bépoàǹ"), "bepoan");
     std::ostringstream ss;
     // Create 2 and half batches (3 boundaries) of 4kb.
-    // Each bondary has its property:
+    // Each boundary has its property:
     // - A 4 bytes chars being cut by the boundary
     // - A "é" stored in NDF form when the "e" is before the boundary and the "´" is after
     // - Nothing special


### PR DESCRIPTION
Fix many typos in the code base (mostly documentation)

Superseeds #1076