### PR TITLE
Tests are no longer slowed down in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
           meson test --verbose
         env:
           SKIP_BIG_MEMORY_TEST: 1
-          WAIT_TIME_FACTOR_TEST: 10
 
   Windows:
     strategy:
@@ -138,8 +137,6 @@ jobs:
           cd build
           ninja.exe download_test_data
           meson.exe test --verbose
-        env:
-          WAIT_TIME_FACTOR_TEST: 10
 
   Linux:
     strategy:
@@ -287,7 +284,6 @@ jobs:
         env:
           LD_LIBRARY_PATH: "${{env.HOME}}/BUILD_${{matrix.arch_name}}/INSTALL/lib:${{env.HOME}}/BUILD_${{matrix.arch_name}}/INSTALL/lib${{matrix.lib_postfix}}"
           SKIP_BIG_MEMORY_TEST: 1
-          WAIT_TIME_FACTOR_TEST: 10
         run: |
           cd build
           ninja download_test_data


### PR DESCRIPTION
Support for increasing wait times in some unit-tests (and thus making them slower to run) was introduced in #496 while working around a transient problem and was preserved just in case (according to https://github.com/openzim/libzim/pull/496#issuecomment-1253794527 which now belongs to the hidden items and only shows up after they are loaded by explicit user action).

Now 10 seconds per each of the 9 test points of the `CreatorError/FaultyDelayedItemErrorTest.faultyCompressedItem/*` unit-test results in high chances of failure (due to timeout) of the `error_in_creator` test-suite in the Windows CI job. Note that testing of `libzim` within the context of the `kiwix-build` CI isn't slowed down in such a manner and there are no complaints about the `error_in_creator` test suite there.

Hence, removing the artificial slow-down.

Related to #978