### PR TITLE
A little stabler unit-test Log.concurrencyOrchestration

### DIFF
--- a/test/log.cpp
+++ b/test/log.cpp
@@ -88,15 +88,15 @@ void millisleep(unsigned milliseconds) {
 
 TEST(Log, concurrencyOrchestration) {
   const auto oddFlow = [](){
-    millisleep(10);
+    millisleep(40);
     log_debug("Humpty Dumpty sat on a wall.");
-    millisleep(10);
+    millisleep(40);
     log_debug("All the king's horses and all the king's men");
   };
 
   const auto evenFlow = [](){
     log_debug("Humpty Dumpty had a great fall.");
-    millisleep(15);
+    millisleep(60);
     log_debug("Couldn't put Humpty together again.");
   };
 


### PR DESCRIPTION
The non-orchestrated flow in the Log.concurrencyOrchestration unit-test is unstable by its nature due to the absence of any guarantees on the order of unsynchronized concurrent operations performed in different threads. Suspensions of threads by a given duration only increase the probability of achieving the desired scenario, with longer wait times having higher chances of working as intended even on slow hardware or under high load.

Addresses https://github.com/openzim/libzim/issues/978#issuecomment-4704164772