### PR TITLE
Fixed the test utility millisleep()

### DIFF
--- a/test/log.cpp
+++ b/test/log.cpp
@@ -82,8 +82,11 @@ void millisleep(unsigned milliseconds) {
   // of waking up the concurrent thread at the right time under high load.
   using namespace std::chrono_literals;
 
-  for ( unsigned i = 0; i < milliseconds; ++i )
+  const std::chrono::milliseconds d(milliseconds);
+  const auto endTime = std::chrono::high_resolution_clock::now() + d;
+  do {
     std::this_thread::sleep_for(1ms);
+  } while ( std::chrono::high_resolution_clock::now() < endTime );
 }
 
 TEST(Log, concurrencyOrchestration) {


### PR DESCRIPTION
Previous implementation of millisleep() could overshoot significantly when the thread was not given enough CPU time. Suppose that the code is running in a high contention environment, competing for CPU time with a lot of other processes/tasks, so that the thread only wakes up once every N milliseconds. Then a call to the old implementation of millisleep(T) could take N*T milliseconds!

With the new implementation the same call will take at most T+N+O(1) milliseconds (where O(1) stands for the fixed duration that it takes to enter and exit the function; it applies to the old implementation too, but there it was not worth mentioning).

Addresses https://github.com/openzim/libzim/issues/978#issuecomment-4704164772 and https://github.com/openzim/libzim/issues/978#issuecomment-4727654041