### PR TITLE
The checksum adding step uses a temp file name too

### DIFF
--- a/src/writer/creator.cpp
+++ b/src/writer/creator.cpp
@@ -503,12 +503,20 @@ void Creator::finishZimCreation()
   writeLastParts();
   data->outFile.closeFile();
 
-  TINFO("rename tmpfile to final one.");
-  DEFAULTFS::rename(data->tmpFileName, data->zimName);
+  // Rename the tempfile so that it is not removed if checksum computation
+  // fails with an exception because of an IO error, as well as so that the
+  // file left behind by a process killed for whatever reason (timeout,
+  // power-outage, etc) can be recognized and converted into a valid ZIM file
+  // by a simple script
+  const auto checksumlessZimFileName = data->zimName + ".without_checksum";
+  TINFO("rename tmpfile");
+  DEFAULTFS::rename(data->tmpFileName, checksumlessZimFileName);
   data->tmpFileName.clear();
 
   INFO("Adding checksum...");
-  addChecksum(data->zimName);
+  addChecksum(checksumlessZimFileName);
+  TINFO("rename tmpfile to final one.");
+  DEFAULTFS::rename(checksumlessZimFileName, data->zimName);
   INFO("ZIM file is ready!");
 
   TINFO("finish");


### PR DESCRIPTION
Fixes #1106

Now ZIM creation uses a temporary file name during the checksum computation stage too.

Before checksum computation starts the name of the temporary file is  *REQURESTED_OUTPUT_FILE_NAME*__.tmp__  (this file is auto-deleted if an unrecoverable exception is thrown during ZIM writing). This is old behaviour and is mentioned merely for completeness.

During checksum computation the temporary file is renamed to  *REQURESTED_OUTPUT_FILE_NAME*__.without_checksum__, which is renamed to the final name *REQURESTED_OUTPUT_FILE_NAME* after the checksum is added (resulting in a valid ZIM file).
 
If checksum computation fails for whatever reason the \*__.without_checksum__ file is preserved and can be converted to a valid ZIM file by a simple script such as below (note that it doesn't rename the input file, which must be done separately):

```bash
#!/usr/bin/env bash

compute_zim_checksum()
{
    local zimfilepath=$1
    local n=$(cat "$zimfilepath"|wc -c)
    head -c $n "$zimfilepath"|md5sum|cut -d' ' -f 1
}

overwrite_bytes_in_file()
{
  local fname=$1
  local bytes=$2
  local offset=$3
  local nbytes=$(printf "$bytes"|wc -c)
  printf "$bytes" |
    dd of="$fname" bs=1 seek=$offset count=$nbytes conv=notrunc &> /dev/null
}

set_zimfile_checksum()
{
    local zimfilepath=$1
    local checksum_str=$2
    local n=$(cat "$zimfilepath"|wc -c)
    checksum_str=$(sed 's/\(..\)/\\x\1/g'<<<"$checksum_str")
    overwrite_bytes_in_file "$zimfilepath" "$checksum_str" $n
}

checksum_hexstr=$(compute_zim_checksum "$1")
echo "Setting checksum of file '$1' to $checksum_hexstr"
set_zimfile_checksum "$1" "$checksum_hexstr"
```