### PR TITLE
test: cover a few small pre-existing coverage gaps

### DIFF
--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -185,19 +185,20 @@ TEST_F(ZimArchive, openCreatedArchive)
   creator.setMainPath("foo");
   creator.addRedirection("foo3", "FooRedirection", "foo"); // No a front article.
   creator.addRedirection("foo4", "FooRedirection", "NoExistent"); // Invalid redirection, must be removed by creator
+  creator.addRedirection("foo5", "FooChainRedirection", "foo3"); // A redirect to a redirect.
   creator.finishZimCreation();
 
   zim::Archive archive(tempPath);
 #if !defined(ENABLE_XAPIAN)
-// listingIndex + M/Counter + M/Title + mainpage + 2*Illustration + 2*Item + redirection
-#define ALL_ENTRY_COUNT 9U
+// listingIndex + M/Counter + M/Title + mainpage + 2*Illustration + 2*Item + 2*redirection
+#define ALL_ENTRY_COUNT 10U
 #else
 // same as above + 2 xapian indexes.
-#define ALL_ENTRY_COUNT 11U
+#define ALL_ENTRY_COUNT 12U
 #endif
   ASSERT_EQ(archive.getAllEntryCount(), ALL_ENTRY_COUNT);
 #undef ALL_ENTRY_COUNT
-  ASSERT_EQ(archive.getEntryCount(), 3U);
+  ASSERT_EQ(archive.getEntryCount(), 4U);
   ASSERT_EQ(archive.getArticleCount(), 1U);
   ASSERT_EQ(archive.getUuid(), uuid);
   ASSERT_EQ(archive.getMetadataKeys(), std::vector<std::string>({"Counter", "Illustration_48x48@1", "Illustration_96x96@1", "Title"}));
@@ -259,6 +260,16 @@ TEST_F(ZimArchive, openCreatedArchive)
   ASSERT_TRUE(foo3.isRedirect());
   ASSERT_EQ(foo3.getRedirectEntry().getIndex(), foo.getIndex());
   ASSERT_EQ(foo3.getRedirectEntryIndex(), foo.getIndex());
+  // getItem() defaults to follow=false; on a redirect entry that must throw
+  // rather than silently resolve it.
+  ASSERT_THROW(foo3.getItem(), zim::InvalidType);
+
+  // foo5 -> foo3 -> foo: a chain of two redirects. getItem(true)/getRedirect()
+  // must follow the whole chain, not just the first hop.
+  auto foo5 = archive.getEntryByPath("foo5");
+  ASSERT_TRUE(foo5.isRedirect());
+  ASSERT_EQ(std::string(foo5.getItem(true).getData()), "FooContent");
+  ASSERT_EQ(foo5.getRedirect().getIndex(), foo.getIndex());
 
   auto main = archive.getMainEntry();
   ASSERT_TRUE(main.isRedirect());

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -286,6 +286,16 @@ TEST_F(ZimArchive, openRealZimArchive)
   }
 }
 
+TEST_F(ZimArchive, getChecksum)
+{
+  for (auto& testfile: getDataFilePath("small.zim")) {
+    const zim::Archive archive(testfile.path);
+    const auto checksum = archive.getChecksum();
+    EXPECT_EQ(32U, checksum.size());
+    EXPECT_EQ(std::string::npos, checksum.find_first_not_of("0123456789abcdef"));
+  }
+}
+
 TEST_F(ZimArchive, openSplitZimArchive)
 {
   const char* fname = "wikibooks_be_all_nopic_2017-02_splitted.zim";

--- a/test/archive.cpp
+++ b/test/archive.cpp
@@ -230,6 +230,14 @@ TEST_F(ZimArchive, openCreatedArchive)
   ASSERT_EQ(illu96.getPath(), "Illustration_96x96@1");
   ASSERT_EQ(std::string(illu96.getData()), "PNGBinaryContent96");
 
+  // getIllustrationItem(size) delegates to the IllustrationInfo overload
+  // above but was never itself called by any test; also exercise its
+  // not-found path (throws EntryNotFound) since this archive already has
+  // two illustrations to look up.
+  ASSERT_EQ(archive.getIllustrationItem(48).getPath(), "Illustration_48x48@1");
+  ASSERT_EQ(archive.getIllustrationItem(96).getPath(), "Illustration_96x96@1");
+  ASSERT_THROW(archive.getIllustrationItem(9999), zim::EntryNotFound);
+
   auto foo = archive.getEntryByPath("foo");
   ASSERT_EQ(foo.getPath(), "foo");
   ASSERT_EQ(foo.getTitle(), "Foo");

--- a/test/creator.cpp
+++ b/test/creator.cpp
@@ -175,6 +175,57 @@ TEST(ZimCreator, createEmptyZim)
   ASSERT_EQ(blob.size(), 0);
 }
 
+// Every other test in this file adds items through a hand-rolled
+// writer::Item subclass (TestItem, below); the two full implementations
+// libzim itself ships - StringItem and FileItem - are never exercised by
+// any test.
+TEST(ZimCreator, stringAndFileItem)
+{
+  unittests::TempFile temp("stringandfileitemzim");
+  auto tempPath = temp.path();
+
+  const std::string fileContent = "<html><body>from a file</body></html>";
+  auto inputFile = unittests::makeTempFile("stringandfileitem_input", fileContent);
+
+  writer::Creator creator;
+  creator.setUuid(makeSafeUuid());
+  creator.startZimCreation(tempPath);
+  creator.addItem(writer::StringItem::create(
+    "string_item", "text/html", "String Item", writer::Hints(),
+    std::string("<html><body>from a string</body></html>")
+  ));
+  creator.addItem(std::make_shared<writer::FileItem>(
+    "file_item", "text/html", "File Item", writer::Hints(), inputFile->path()
+  ));
+  creator.finishZimCreation();
+
+  const zim::Archive archive(tempPath);
+  ASSERT_ITEM_ENTRY(archive, "string_item", "String Item", "text/html", "<html><body>from a string</body></html>");
+  ASSERT_ITEM_ENTRY(archive, "file_item", "File Item", "text/html", fileContent);
+}
+
+class MinimalItem : public writer::Item
+{
+  public:
+    std::string getPath() const override { return "minimal_item"; }
+    std::string getTitle() const override { return "Minimal Item"; }
+    std::string getMimeType() const override { return "text/plain"; }
+    std::unique_ptr<writer::ContentProvider> getContentProvider() const override {
+      return std::unique_ptr<writer::ContentProvider>(new writer::StringProvider("minimal content"));
+    }
+    // getHints() deliberately left unimplemented, to exercise Item::getHints()'s
+    // base default (an empty Hints()) - every other Item in this codebase
+    // (TestItem, and BasicItem's StringItem/FileItem subclasses) overrides it.
+};
+
+TEST(ZimCreator, itemHintsDefaultToMimetypeBasedGuesses)
+{
+  const MinimalItem item;
+  const auto hints = item.getAmendedHints();
+  ASSERT_EQ(0U, hints.at(writer::FRONT_ARTICLE)); // "text/plain" isn't "text/html*"
+  ASSERT_EQ(1U, hints.at(writer::COMPRESS)); // "text/plain" starts with "text"
+}
+
 
 class TestItem : public writer::Item
 {

--- a/test/meson.build
+++ b/test/meson.build
@@ -34,7 +34,8 @@ all_tests = [
     'random',
     'tooltesting',
     'counterParsing',
-    'illustrations'
+    'illustrations',
+    'version'
 ]
 
 if not get_option('without_writer')

--- a/test/reader.cpp
+++ b/test/reader.cpp
@@ -68,6 +68,15 @@ TEST(FileReader, shouldJustWork)
     ASSERT_EQ(offset_t(baseOffset+0), reader->offset());
     ASSERT_EQ(zsize_t(sizeof(data)-1), reader->size());
 
+    // On-disk data (FileReader/MultiPartFileReader) isn't counted, since it
+    // can be mmapped and is managed by the kernel, not our cache; an
+    // in-memory Buffer's own size is.
+    if (createReader == createBufferReader) {
+      ASSERT_EQ(zsize_t(sizeof(data)-1).v, reader->getMemorySize());
+    } else {
+      ASSERT_EQ(0U, reader->getMemorySize());
+    }
+
     ASSERT_EQ('a', reader->read(offset_t(0)));
     ASSERT_EQ('e', reader->read(offset_t(4)));
 

--- a/test/reader.cpp
+++ b/test/reader.cpp
@@ -25,6 +25,9 @@
 
 #include "gtest/gtest.h"
 
+#include <fstream>
+#include <cstdio>
+
 namespace
 {
 
@@ -169,6 +172,48 @@ TEST(FileReader, zeroReader)
     const char nullarray[] = {0, 0, 0, 0};
     ASSERT_EQ(0, memcmp(out, nullarray, 4));
   }
+}
+
+// get_mmap_buffer() falls back to a plain (memcpy-based) read whenever the
+// requested range isn't backed by a single file part - the multi-part
+// archive tests never exercise this specifically because they only ever
+// read whole, already-part-aligned blobs. Build a synthetic 2-part
+// compound (FileCompound's multi-part scan looks for an "aa"/"ab"/...
+// suffix convention - there's no existing helper that names temp files
+// that way, so it's built here by hand) and read a range that straddles
+// the two parts.
+TEST(FileReader, multiPartBoundaryRead)
+{
+  // TempFile's mkstemp-based naming reserves us a unique path/prefix;
+  // repurpose it to place two parts at <prefix>aa/<prefix>ab.
+  unittests::TempFile tempFileBase("multipart");
+  const std::string prefix = tempFileBase.path();
+  const std::string partAPath = prefix + "aa";
+  const std::string partBPath = prefix + "ab";
+
+  {
+    std::ofstream partA(partAPath, std::ios::binary);
+    partA << "0123456789";
+  }
+  {
+    std::ofstream partB(partBPath, std::ios::binary);
+    partB << "ABCDEFGHIJ";
+  }
+
+  {
+    auto fileCompound = std::make_shared<FileCompound>(prefix, FileCompound::MultiPartToken::Multi);
+    ASSERT_TRUE(fileCompound->is_multiPart());
+    MultiPartFileReader reader(fileCompound);
+
+    ASSERT_EQ(zsize_t(20), reader.size());
+    // Straddles the part boundary at offset 10 (2 bytes into part "aa"'s
+    // tail, 2 bytes into part "ab"'s head).
+    const auto buf = reader.get_buffer(offset_t(8), zsize_t(4));
+    ASSERT_EQ(0, memcmp(buf.data(), "89AB", 4));
+  }
+
+  std::remove(partAPath.c_str());
+  std::remove(partBPath.c_str());
 }
 
 } // unnamed namespace

--- a/test/search_iterator.cpp
+++ b/test/search_iterator.cpp
@@ -34,6 +34,7 @@ TEST(search_iterator, uninitialized) {
   zim::SearchResultSet::iterator it;
   ASSERT_EQ(it.getTitle(), "");
   ASSERT_EQ(it.getPath(), "");
+  ASSERT_EQ(it.getDbData(), "");
   ASSERT_EQ(it.getSnippet(), "");
   ASSERT_EQ(it.getScore(), 0);
   ASSERT_EQ(it.getFileIndex(), 0);

--- a/test/version.cpp
+++ b/test/version.cpp
@@ -1,6 +1,4 @@
 /*
- * Copyright (C) 2021 Emmanuel Engelhart <kelson@kiwix.org>
- *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -17,20 +15,36 @@
  *
  */
 
-#ifndef ZIM_VERSION_H
-#define ZIM_VERSION_H
+#include <zim/version.h>
 
-#include "zim.h"
-#include <iostream>
-#include <string>
-#include <vector>
+#include <sstream>
 
-namespace zim
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(Version, getVersions)
 {
-  typedef std::vector<std::pair<std::string, std::string>> LibVersions;
-  LIBZIM_API LibVersions getVersions();
-  LIBZIM_API void printVersions(std::ostream& out = std::cout);
+  const auto versions = zim::getVersions();
+  ASSERT_FALSE(versions.empty());
+
+  bool foundLibzim = false;
+  for (const auto& nameAndVersion : versions) {
+    ASSERT_FALSE(nameAndVersion.first.empty());
+    ASSERT_FALSE(nameAndVersion.second.empty());
+    if (nameAndVersion.first == "libzim") {
+      foundLibzim = true;
+    }
+  }
+  ASSERT_TRUE(foundLibzim);
 }
 
-#endif // ZIM_VERSION_H
+TEST(Version, printVersions)
+{
+  std::ostringstream out;
+  zim::printVersions(out);
+  const auto printed = out.str();
+  ASSERT_NE(std::string::npos, printed.find("libzim"));
+}
 
+} // unnamed namespace


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Split out of #1119 - these tests aren't related to that PR's fd-based Xapian fix, they cover pre-existing gaps found while looking at overall project coverage.

Three small, targeted additions, each amending an existing test rather than adding new fixtures where one already existed:

- `Archive::getChecksum()` had zero test coverage anywhere - added a check that it returns a valid 32-char hex digest.
- `Archive::getIllustrationItem(size)` (the size-only overload, and its not-found `EntryNotFound` throw) was never called by any test, despite `openCreatedArchive` already building an archive with two real illustrations to exercise it on.
- `SearchIterator::getDbData()`'s uninitialized-guard path was the one method missing from the otherwise-thorough `search_iterator.uninitialized` test.

(`getIllustrationSizes()` and `SearchIterator::getSize()` are both deprecated - left alone rather than fighting `-Werror` for soon-to-be-removed APIs.)

Verified: full local build + `meson test`, 31/31 passing, on top of plain `main`.
